### PR TITLE
Add Maven plugin to autoformat Java code

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -150,6 +150,7 @@
     <dependency-check-plugin.version>7.1.2</dependency-check-plugin.version>
     <jxr-plugin.version>3.3.0</jxr-plugin.version>
     <errorprone.version>2.15.0</errorprone.version>
+    <spotless-plugin.version>2.27.2</spotless-plugin.version>
     <project-info-reports-plugin.version>3.4.1</project-info-reports-plugin.version>
     <versions-plugin.version>2.11.0</versions-plugin.version>
     <lock-plugin.version>0.25</lock-plugin.version>
@@ -551,6 +552,27 @@
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>versions-maven-plugin</artifactId>
         <version>${versions-plugin.version}</version>
+      </plugin>
+      <plugin>
+        <groupId>com.diffplug.spotless</groupId>
+        <artifactId>spotless-maven-plugin</artifactId>
+        <version>${spotless-plugin.version}</version>
+        <executions>
+          <execution>
+            <phase>process-sources</phase>
+            <goals>
+              <goal>apply</goal>
+            </goals>
+          </execution>
+        </executions>
+        <configuration>
+          <java>
+            <googleJavaFormat>
+              <version>1.15.0</version>
+              <style>GOOGLE</style>
+            </googleJavaFormat>
+          </java>
+        </configuration>
       </plugin>
     </plugins>
   </build>


### PR DESCRIPTION
Using the following tools (latest versions as of committing):
- [maven-spotless-plugin v2.27.2](https://github.com/diffplug/spotless/releases/tag/maven%2F2.27.2) 
- [google-java-format v1.15.0](https://github.com/google/google-java-format/releases/tag/v1.15.0)