### PR TITLE
Add rule to check order of struct member declarations

### DIFF
--- a/src/main/java/org/sonar/plugins/delphi/pmd/rules/MemberDeclarationOrderRule.java
+++ b/src/main/java/org/sonar/plugins/delphi/pmd/rules/MemberDeclarationOrderRule.java
@@ -1,0 +1,78 @@
+/*
+ * Sonar Delphi Plugin
+ * Copyright (C) 2019-2022 Integrated Application Development
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02
+ */
+package org.sonar.plugins.delphi.pmd.rules;
+
+import java.util.ArrayList;
+import java.util.List;
+import net.sourceforge.pmd.RuleContext;
+import net.sourceforge.pmd.lang.ast.Node;
+import org.sonar.plugins.delphi.antlr.ast.node.FieldDeclarationNode;
+import org.sonar.plugins.delphi.antlr.ast.node.FieldSectionNode;
+import org.sonar.plugins.delphi.antlr.ast.node.MethodDeclarationNode;
+import org.sonar.plugins.delphi.antlr.ast.node.PropertyNode;
+import org.sonar.plugins.delphi.antlr.ast.node.VisibilitySectionNode;
+
+public class MemberDeclarationOrderRule extends AbstractDelphiRule {
+  private enum BodySegment {
+    FIELDS,
+    METHODS,
+    PROPERTIES
+  }
+
+  private List<Node> getOutOfOrderDeclarations(VisibilitySectionNode sectionNode) {
+    var currentSegment = BodySegment.FIELDS;
+    List<Node> outOfOrderDeclarations = new ArrayList<>();
+
+    for (int i = 0; i < sectionNode.jjtGetNumChildren(); i++) {
+      Node itemNode = sectionNode.jjtGetChild(i);
+
+      if (itemNode instanceof FieldSectionNode && currentSegment != BodySegment.FIELDS) {
+        outOfOrderDeclarations.addAll(itemNode.findChildrenOfType(FieldDeclarationNode.class));
+      } else if (itemNode instanceof MethodDeclarationNode
+          && currentSegment != BodySegment.METHODS) {
+        if (currentSegment == BodySegment.FIELDS) {
+          currentSegment = BodySegment.METHODS;
+        } else {
+          outOfOrderDeclarations.add(itemNode);
+        }
+      } else if (itemNode instanceof PropertyNode) {
+        // A property declaration has no restrictions on it, but it invalidates any later fields
+        // or methods.
+        currentSegment = BodySegment.PROPERTIES;
+      }
+    }
+
+    return outOfOrderDeclarations;
+  }
+
+  @Override
+  public RuleContext visit(VisibilitySectionNode sectionNode, RuleContext data) {
+    List<Node> outOfOrderDeclarations = getOutOfOrderDeclarations(sectionNode);
+
+    if (!outOfOrderDeclarations.isEmpty()) {
+      addViolationWithMessage(
+          data,
+          outOfOrderDeclarations.get(0),
+          "Reorder this visibility section ({0} declarations are out of order, starting here)",
+          new Object[] {outOfOrderDeclarations.size()});
+    }
+
+    return super.visit(sectionNode, data);
+  }
+}

--- a/src/main/resources/org/sonar/plugins/delphi/pmd/rules.xml
+++ b/src/main/resources/org/sonar/plugins/delphi/pmd/rules.xml
@@ -669,6 +669,29 @@ Foo := Foo; // Noncompliant
     </properties>
   </rule>
 
+  <rule class="org.sonar.plugins.delphi.pmd.rules.MemberDeclarationOrderRule"
+    message="Declarations in visibility sections should follow an expected order"
+    name="MemberDeclarationOrderRule">
+    <priority>4</priority>
+    <description>
+      Visibility sections within the body of a class, interface, or record declaration should be
+      organized in the following order:
+      &lt;br&gt;
+      1. Field declarations
+      2. Method declarations
+      3. Property declarations
+      &lt;br&gt;
+      &lt;br&gt;
+      For more information, see the Class Body Organization section of the Embarcadero style guide page on
+      &lt;a href='https://docwiki.embarcadero.com/RADStudio/en/Type_Declarations#Class_Body_Organization'&gt;
+      Type Declarations
+      &lt;/a&gt;
+    </description>
+    <properties>
+      <property name="baseEffort" value="3min"/>
+    </properties>
+  </rule>
+
   <rule class="org.sonar.plugins.delphi.pmd.rules.VariableInitializationRule"
     message="Variables must be initialized before being used"
     name="VariableInitializationRule">

--- a/src/test/java/org/sonar/plugins/delphi/pmd/rules/MemberDeclarationOrderRuleTest.java
+++ b/src/test/java/org/sonar/plugins/delphi/pmd/rules/MemberDeclarationOrderRuleTest.java
@@ -1,0 +1,203 @@
+/*
+ * Sonar Delphi Plugin
+ * Copyright (C) 2019-2022 Integrated Application Development
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02
+ */
+package org.sonar.plugins.delphi.pmd.rules;
+
+import static org.sonar.plugins.delphi.utils.conditions.RuleKey.ruleKey;
+import static org.sonar.plugins.delphi.utils.conditions.RuleKeyAtLine.ruleKeyAtLine;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.sonar.plugins.delphi.utils.builders.DelphiTestUnitBuilder;
+
+class MemberDeclarationOrderRuleTest extends BasePmdRuleTest {
+  @Test
+  void testOrderedClassBodyShouldNotAddIssue() {
+    DelphiTestUnitBuilder builder = new DelphiTestUnitBuilder();
+    builder
+        .appendDecl("type")
+        .appendDecl("  TFoo = class(TObject)")
+        .appendDecl("  private")
+        .appendDecl("    FMyField: Integer;")
+        .appendDecl("    FMyOtherField: Integer;")
+        .appendDecl("    procedure MyProc;")
+        .appendDecl("    procedure MyOtherProc;")
+        .appendDecl("    property MyProp: Integer read FMyField write FMyField;")
+        .appendDecl("  end;");
+
+    execute(builder);
+
+    assertIssues().areNot(ruleKey("MemberDeclarationOrderRule"));
+  }
+
+  @ParameterizedTest(name = "[{index}] {0} before {1}")
+  @CsvSource({"function,field", "property,field", "property,function"})
+  void testForbiddenItemsBeforeFieldsShouldAddIssue(String firstItem, String secondItem) {
+    firstItem = firstItem.replace("field", "");
+    secondItem = secondItem.replace("field", "");
+
+    DelphiTestUnitBuilder builder = new DelphiTestUnitBuilder();
+    builder
+        .appendDecl("type")
+        .appendDecl("  TFoo = class(TObject)")
+        .appendDecl("  private")
+        .appendDecl("    " + firstItem + " Bar: Integer;")
+        .appendDecl("    " + secondItem + " Baz: Integer;")
+        .appendDecl("  end;");
+
+    execute(builder);
+
+    assertIssues()
+        .areExactly(1, ruleKeyAtLine("MemberDeclarationOrderRule", builder.getOffsetDecl() + 5));
+  }
+
+  @Test
+  void testPropertiesBeforeMultipleFieldsShouldAddIssue() {
+    DelphiTestUnitBuilder builder = new DelphiTestUnitBuilder();
+    builder
+        .appendDecl("type")
+        .appendDecl("  TFoo = class(TObject)")
+        .appendDecl("  private")
+        .appendDecl("    property MyProp: Integer read FMyField write FMyField;")
+        .appendDecl("    FMyField: Integer;")
+        .appendDecl("    FMyOtherField: Integer;")
+        .appendDecl("  end;");
+
+    execute(builder);
+
+    assertIssues()
+        .areExactly(1, ruleKeyAtLine("MemberDeclarationOrderRule", builder.getOffsetDecl() + 5))
+        .areNot(ruleKeyAtLine("MemberDeclarationOrderRule", builder.getOffsetDecl() + 6));
+  }
+
+  @Test
+  void testMultipleOrderedVisibilitySectionsShouldNotAddIssue() {
+    DelphiTestUnitBuilder builder = new DelphiTestUnitBuilder();
+    builder
+        .appendDecl("type")
+        .appendDecl("  TFoo = class(TObject)")
+        .appendDecl("  private")
+        .appendDecl("    FMyField: Integer;")
+        .appendDecl("    procedure MyProc;")
+        .appendDecl("    property MyProp: Integer read FMyField write FMyField;")
+        .appendDecl("  protected")
+        .appendDecl("    FMyOtherField: Integer;")
+        .appendDecl("    procedure MyOtherProc;")
+        .appendDecl("    property MySecondProp: Integer read FMyField write FMyField;")
+        .appendDecl("  end;");
+
+    execute(builder);
+
+    assertIssues().areNot(ruleKey("MemberDeclarationOrderRule"));
+  }
+
+  @Test
+  void testMultipleBlocksShouldAddIssue() {
+    DelphiTestUnitBuilder builder = new DelphiTestUnitBuilder();
+    builder
+        .appendDecl("type")
+        .appendDecl("  TFoo = class(TObject)")
+        .appendDecl("  private")
+        .appendDecl("    FMyField: Integer;")
+        .appendDecl("    procedure MyProc;")
+        .appendDecl("    property MyProp: Integer read FMyField write FMyField;")
+        .appendDecl("    FMyOtherField: Integer;")
+        .appendDecl("    procedure MyOtherProc;")
+        .appendDecl("    property MyOtherProp: Integer read FMyField write FMyField;")
+        .appendDecl("  end;");
+
+    execute(builder);
+
+    assertIssues()
+        .areExactly(1, ruleKeyAtLine("MemberDeclarationOrderRule", builder.getOffsetDecl() + 7))
+        .areNot(ruleKeyAtLine("MemberDeclarationOrderRule", builder.getOffsetDecl() + 8));
+  }
+
+  @Test
+  void testMultiplePropertySectionsShouldNotAddIssue() {
+    DelphiTestUnitBuilder builder = new DelphiTestUnitBuilder();
+    builder
+        .appendDecl("type")
+        .appendDecl("  TFoo = class(TObject)")
+        .appendDecl("  private")
+        .appendDecl("    FMyField: Integer;")
+        .appendDecl("    procedure MyProc;")
+        .appendDecl("    property MyProp: Integer read FMyField write FMyField;")
+        .appendDecl("    FMyOtherField: Integer;")
+        .appendDecl("    procedure MyOtherProc;")
+        .appendDecl("    property MyOtherProp: Integer read FMyField write FMyField;")
+        .appendDecl("  end;");
+
+    execute(builder);
+
+    assertIssues().areNot(ruleKeyAtLine("MemberDeclarationOrderRule", builder.getOffsetDecl() + 9));
+  }
+
+  @ParameterizedTest
+  @CsvSource({"field", "function", "property"})
+  void testSingleItemShouldNotAddIssue(String item) {
+    item = item.replace("field", "");
+
+    DelphiTestUnitBuilder builder = new DelphiTestUnitBuilder();
+    builder
+        .appendDecl("type")
+        .appendDecl("  TFoo = class(TObject)")
+        .appendDecl("  private")
+        .appendDecl("    " + item + " Bar: Integer;")
+        .appendDecl("  end;");
+
+    execute(builder);
+
+    assertIssues().areNot(ruleKey("MemberDeclarationOrderRule"));
+  }
+
+  @Test
+  void testImplicitVisibilitySectionShouldAddIssue() {
+    DelphiTestUnitBuilder builder = new DelphiTestUnitBuilder();
+    builder
+        .appendDecl("type")
+        .appendDecl("  TFoo = class(TObject)")
+        .appendDecl("    property MyProp: Integer;")
+        .appendDecl("    procedure MyProc;")
+        .appendDecl("  end;");
+
+    execute(builder);
+
+    assertIssues()
+        .areExactly(1, ruleKeyAtLine("MemberDeclarationOrderRule", builder.getOffsetDecl() + 4));
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {"class", "record", "interface", "object"})
+  void testAnyOutOfOrderStructureShouldAddIssue(String structType) {
+    DelphiTestUnitBuilder builder = new DelphiTestUnitBuilder();
+    builder
+        .appendDecl("type")
+        .appendDecl("  TFoo = " + structType)
+        .appendDecl("    property MyProp: Integer;")
+        .appendDecl("    procedure MyProc;")
+        .appendDecl("  end;");
+
+    execute(builder);
+
+    assertIssues()
+        .areExactly(1, ruleKeyAtLine("MemberDeclarationOrderRule", builder.getOffsetDecl() + 4));
+  }
+}


### PR DESCRIPTION
Adds a rule checking that the order of member declarations within a class, interface, or record declaration is correct as specified in [the Embarcadero style guide](https://docwiki.embarcadero.com/RADStudio/en/Type_Declarations#Class_Body_Organization):

> The body of a class declaration should be organized in the following order, for each of the access specifier blocks:
> * Field declarations
> * Method declarations
> * Property declarations