### PR TITLE
Add rule to check order of visibility sections

### DIFF
--- a/src/main/java/org/sonar/plugins/delphi/pmd/rules/VisibilitySectionOrderRule.java
+++ b/src/main/java/org/sonar/plugins/delphi/pmd/rules/VisibilitySectionOrderRule.java
@@ -1,0 +1,75 @@
+/*
+ * Sonar Delphi Plugin
+ * Copyright (C) 2019-2022 Integrated Application Development
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02
+ */
+package org.sonar.plugins.delphi.pmd.rules;
+
+import com.google.common.collect.Maps;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import net.sourceforge.pmd.RuleContext;
+import net.sourceforge.pmd.lang.ast.Node;
+import org.sonar.plugins.delphi.antlr.ast.node.StructTypeNode;
+import org.sonar.plugins.delphi.antlr.ast.node.Visibility.VisibilityType;
+import org.sonar.plugins.delphi.antlr.ast.node.VisibilityNode;
+import org.sonar.plugins.delphi.antlr.ast.node.VisibilitySectionNode;
+
+public class VisibilitySectionOrderRule extends AbstractDelphiRule {
+  private static final Map<VisibilityType, Integer> VISIBILITY_ORDER =
+      Maps.immutableEnumMap(
+          Map.of(
+              VisibilityType.IMPLICIT_PUBLISHED, 0,
+              VisibilityType.STRICT_PRIVATE, 1,
+              VisibilityType.PRIVATE, 2,
+              VisibilityType.STRICT_PROTECTED, 3,
+              VisibilityType.PROTECTED, 4,
+              VisibilityType.PUBLIC, 5,
+              VisibilityType.PUBLISHED, 6));
+
+  private VisibilityNode getVisibilityNode(VisibilitySectionNode visibilitySectionNode) {
+    if (visibilitySectionNode.jjtGetNumChildren() > 0) {
+      Node firstChild = visibilitySectionNode.jjtGetChild(0);
+      if (firstChild instanceof VisibilityNode) {
+        return (VisibilityNode) firstChild;
+      }
+    }
+
+    return null;
+  }
+
+  private void checkOrder(List<VisibilitySectionNode> visibilitySections, RuleContext data) {
+    int currentVisibilityOrder = VISIBILITY_ORDER.get(VisibilityType.IMPLICIT_PUBLISHED);
+
+    for (var visibilitySection : visibilitySections) {
+      int sectionVisibilityOrder = VISIBILITY_ORDER.get(visibilitySection.getVisibility());
+
+      if (sectionVisibilityOrder >= currentVisibilityOrder) {
+        currentVisibilityOrder = sectionVisibilityOrder;
+      } else {
+        var visibilityNode = getVisibilityNode(visibilitySection);
+        addViolation(data, Objects.requireNonNullElse(visibilityNode, visibilitySection));
+      }
+    }
+  }
+
+  @Override
+  public RuleContext visit(StructTypeNode structTypeNode, RuleContext data) {
+    checkOrder(structTypeNode.getVisibilitySections(), data);
+    return super.visit(structTypeNode, data);
+  }
+}

--- a/src/main/resources/org/sonar/plugins/delphi/pmd/rules.xml
+++ b/src/main/resources/org/sonar/plugins/delphi/pmd/rules.xml
@@ -709,6 +709,36 @@ Foo := Foo; // Noncompliant
     </properties>
   </rule>
 
+  <rule class="org.sonar.plugins.delphi.pmd.rules.VisibilitySectionOrderRule"
+    message="Access specifiers should be in ascending order of accessibility"
+    name="VisibilitySectionOrderRule">
+    <priority>3</priority>
+    <description>
+      Access specifiers should be declared in ascending order of accessibility:
+      &lt;br&gt;
+      1. strict private
+      &lt;br&gt;
+      2. private
+      &lt;br&gt;
+      3. strict protected
+      &lt;br&gt;
+      4. protected
+      &lt;br&gt;
+      5. public
+      &lt;br&gt;
+      6. published
+      &lt;br&gt;
+      &lt;br&gt;
+      For more information, see the Embarcadero style guide page on
+      &lt;a href='https://docwiki.embarcadero.com/RADStudio/en/Type_Declarations#Class_.28and_Record.29_Declarations'&gt;
+      Type Declarations
+      &lt;/a&gt;
+    </description>
+    <properties>
+      <property name="baseEffort" value="3min"/>
+    </properties>
+  </rule>
+
   <rule class="org.sonar.plugins.delphi.pmd.rules.VariableInitializationRule"
     message="Variables must be initialized before being used"
     name="VariableInitializationRule">

--- a/src/test/java/org/sonar/plugins/delphi/pmd/rules/VisibilitySectionOrderRuleTest.java
+++ b/src/test/java/org/sonar/plugins/delphi/pmd/rules/VisibilitySectionOrderRuleTest.java
@@ -1,0 +1,169 @@
+/*
+ * Sonar Delphi Plugin
+ * Copyright (C) 2019-2022 Integrated Application Development
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02
+ */
+package org.sonar.plugins.delphi.pmd.rules;
+
+import static org.sonar.plugins.delphi.utils.conditions.RuleKey.ruleKey;
+import static org.sonar.plugins.delphi.utils.conditions.RuleKeyAtLine.ruleKeyAtLine;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.sonar.plugins.delphi.utils.builders.DelphiTestUnitBuilder;
+
+class VisibilitySectionOrderRuleTest extends BasePmdRuleTest {
+  @ParameterizedTest(name = "[{index}] {0} before {1}")
+  @CsvSource({
+    "private,strict private",
+    "protected,private",
+    "protected,strict protected",
+    "published,public",
+    "published,private",
+  })
+  void testOutOfOrderSectionsShouldAddIssue(String firstVisibility, String secondVisibility) {
+    DelphiTestUnitBuilder builder = new DelphiTestUnitBuilder();
+    builder
+        .appendDecl("type")
+        .appendDecl("  TFoo = class(TObject)")
+        .appendDecl("  " + firstVisibility)
+        .appendDecl("    procedure Bar;")
+        .appendDecl("    property Baz: Integer;")
+        .appendDecl("  " + secondVisibility)
+        .appendDecl("    procedure Bar2;")
+        .appendDecl("    property Baz2: Integer;")
+        .appendDecl(" end;");
+
+    execute(builder);
+
+    assertIssues()
+        .areExactly(1, ruleKeyAtLine("VisibilitySectionOrderRule", builder.getOffsetDecl() + 6))
+        .areExactly(1, ruleKey("VisibilitySectionOrderRule"));
+  }
+
+  @ParameterizedTest(name = "[{index}] {0} before {1}")
+  @CsvSource({
+    "strict private,private",
+    "private,protected",
+    "strict protected,protected",
+    "public,published",
+    "private,published",
+  })
+  void testOrderedSectionsShouldNotAddIssue(String firstVisibility, String secondVisibility) {
+    DelphiTestUnitBuilder builder = new DelphiTestUnitBuilder();
+    builder
+        .appendDecl("type")
+        .appendDecl("  TFoo = class(TObject)")
+        .appendDecl("  " + firstVisibility)
+        .appendDecl("    procedure Bar;")
+        .appendDecl("    property Baz: Integer;")
+        .appendDecl("  " + secondVisibility)
+        .appendDecl("    procedure Bar2;")
+        .appendDecl("    property Baz2: Integer;")
+        .appendDecl(" end;");
+
+    execute(builder);
+
+    assertIssues().areNot(ruleKey("VisibilitySectionOrderRule"));
+  }
+
+  @Test
+  void testMultipleOfTheSameSectionShouldNotAddIssue() {
+    DelphiTestUnitBuilder builder = new DelphiTestUnitBuilder();
+    builder
+        .appendDecl("type")
+        .appendDecl("  TFoo = class(TObject)")
+        .appendDecl("  public")
+        .appendDecl("    procedure Bar;")
+        .appendDecl("    property Baz: Integer;")
+        .appendDecl("  public")
+        .appendDecl("    procedure Bar2;")
+        .appendDecl("    property Baz2: Integer;")
+        .appendDecl(" end;");
+
+    execute(builder);
+
+    assertIssues().areNot(ruleKey("VisibilitySectionOrderRule"));
+  }
+
+  @Test
+  void testMultipleOutOfOrderSectionsShouldAddMultipleIssues() {
+    DelphiTestUnitBuilder builder = new DelphiTestUnitBuilder();
+    builder
+        .appendDecl("type")
+        .appendDecl("  TFoo = class(TObject)")
+        .appendDecl("  public")
+        .appendDecl("    procedure Baz;")
+        .appendDecl("  private")
+        .appendDecl("    procedure Bee;")
+        .appendDecl("  protected")
+        .appendDecl("    procedure Bee;")
+        .appendDecl("  published")
+        .appendDecl("    procedure Bee;")
+        .appendDecl(" end;");
+
+    execute(builder);
+
+    assertIssues()
+        .areExactly(1, ruleKeyAtLine("VisibilitySectionOrderRule", builder.getOffsetDecl() + 5))
+        .areExactly(1, ruleKeyAtLine("VisibilitySectionOrderRule", builder.getOffsetDecl() + 7))
+        .areExactly(2, ruleKey("VisibilitySectionOrderRule"));
+  }
+
+  @Test
+  void testImplicitPublishedFollowedByPrivateShouldNotAddIssue() {
+    DelphiTestUnitBuilder builder = new DelphiTestUnitBuilder();
+    builder
+        .appendDecl("type")
+        .appendDecl("  TFoo = class(TObject)")
+        .appendDecl("    procedure Bar;")
+        .appendDecl("  private")
+        .appendDecl("    procedure Baz;")
+        .appendDecl(" end;");
+
+    execute(builder);
+
+    assertIssues().areNot(ruleKey("VisibilitySectionOrderRule"));
+  }
+
+  @ParameterizedTest
+  @ValueSource(
+      strings = {
+        "class",
+        "record",
+        "object",
+        "class helper for TObject",
+        "record helper for string"
+      })
+  void testAllStructTypesWithOrderedVisibilitySectionsShouldAddIssue(String structType) {
+    DelphiTestUnitBuilder builder = new DelphiTestUnitBuilder();
+    builder
+        .appendDecl("type")
+        .appendDecl("  TFoo = " + structType)
+        .appendDecl("  public")
+        .appendDecl("    procedure Bar;")
+        .appendDecl("  protected")
+        .appendDecl("    procedure Baz;")
+        .appendDecl(" end;");
+
+    execute(builder);
+
+    assertIssues()
+        .areExactly(1, ruleKeyAtLine("VisibilitySectionOrderRule", builder.getOffsetDecl() + 5));
+  }
+}


### PR DESCRIPTION
Adds a rule checking that visibility sections within a class, record, object, or helper are ordered in ascending order of visibility, as specified in [the Embarcadero style guide](https://docwiki.embarcadero.com/RADStudio/en/Type_Declarations#Class_.28and_Record.29_Declarations):

> Access specifier (or scoping) directives should use the same indentation of the class name they belong to), and declared in the order shown in this example: 
> ```
> type
> TMyClass = class(TObject)
>  strict private
>  private
>  strict protected
>  protected
>  public
>  published
>  end;
> ```