### PR TITLE
Provide NCLOC_DATA metric to record which lines contain code

### DIFF
--- a/src/main/java/org/sonar/plugins/delphi/antlr/ast/visitors/MetricsVisitor.java
+++ b/src/main/java/org/sonar/plugins/delphi/antlr/ast/visitors/MetricsVisitor.java
@@ -63,8 +63,8 @@ public class MetricsVisitor implements DelphiParserVisitor<Data> {
       return statements;
     }
 
-    public int getCodeLines() {
-      return codeLines.size();
+    public Set<Integer> getCodeLines() {
+      return codeLines;
     }
   }
 

--- a/src/main/java/org/sonar/plugins/delphi/executor/DelphiMetricsExecutor.java
+++ b/src/main/java/org/sonar/plugins/delphi/executor/DelphiMetricsExecutor.java
@@ -19,8 +19,11 @@
 package org.sonar.plugins.delphi.executor;
 
 import java.io.Serializable;
+import java.util.Set;
 import org.sonar.api.batch.sensor.SensorContext;
 import org.sonar.api.measures.CoreMetrics;
+import org.sonar.api.measures.FileLinesContext;
+import org.sonar.api.measures.FileLinesContextFactory;
 import org.sonar.api.measures.Metric;
 import org.sonar.plugins.delphi.antlr.ast.visitors.MetricsVisitor;
 import org.sonar.plugins.delphi.antlr.ast.visitors.MetricsVisitor.Data;
@@ -29,7 +32,12 @@ import org.sonar.plugins.delphi.file.DelphiFile.DelphiInputFile;
 public class DelphiMetricsExecutor implements Executor {
   private static final MetricsVisitor VISITOR = new MetricsVisitor();
   private SensorContext context;
+  private final FileLinesContextFactory fileLinesContextFactory;
   private DelphiInputFile file;
+
+  public DelphiMetricsExecutor(FileLinesContextFactory fileLinesContextFactory) {
+    this.fileLinesContextFactory = fileLinesContextFactory;
+  }
 
   @Override
   public void execute(Context context, DelphiInputFile file) {
@@ -43,11 +51,23 @@ public class DelphiMetricsExecutor implements Executor {
     saveMetricOnFile(CoreMetrics.COMPLEXITY, metrics.getComplexity());
     saveMetricOnFile(CoreMetrics.COMMENT_LINES, metrics.getCommentLines());
     saveMetricOnFile(CoreMetrics.STATEMENTS, metrics.getStatements());
-    saveMetricOnFile(CoreMetrics.NCLOC, metrics.getCodeLines());
     saveMetricOnFile(CoreMetrics.COGNITIVE_COMPLEXITY, metrics.getCognitiveComplexity());
+
+    Set<Integer> codeLines = metrics.getCodeLines();
+    saveMetricOnFile(CoreMetrics.NCLOC, codeLines.size());
+    saveCodeLinesOnFile(codeLines);
   }
 
   private <T extends Serializable> void saveMetricOnFile(Metric<T> metric, T value) {
     context.<T>newMeasure().forMetric(metric).on(file.getInputFile()).withValue(value).save();
+  }
+
+  private void saveCodeLinesOnFile(Set<Integer> codeLines) {
+    FileLinesContext fileLinesContext = fileLinesContextFactory.createFor(file.getInputFile());
+    for (int line = 1; line <= file.getInputFile().lines(); line++) {
+      fileLinesContext.setIntValue(
+          CoreMetrics.NCLOC_DATA_KEY, line, codeLines.contains(line) ? 1 : 0);
+    }
+    fileLinesContext.save();
   }
 }

--- a/src/test/java/org/sonar/plugins/delphi/executor/DelphiMetricsExecutorTest.java
+++ b/src/test/java/org/sonar/plugins/delphi/executor/DelphiMetricsExecutorTest.java
@@ -19,14 +19,21 @@
 package org.sonar.plugins.delphi.executor;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import java.io.File;
 import java.io.Serializable;
+import java.util.Set;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.sonar.api.batch.fs.InputFile;
 import org.sonar.api.batch.sensor.internal.SensorContextTester;
 import org.sonar.api.measures.CoreMetrics;
+import org.sonar.api.measures.FileLinesContext;
+import org.sonar.api.measures.FileLinesContextFactory;
 import org.sonar.api.measures.Metric;
 import org.sonar.plugins.delphi.file.DelphiFile.DelphiInputFile;
 import org.sonar.plugins.delphi.symbol.SymbolTable;
@@ -44,12 +51,17 @@ class DelphiMetricsExecutorTest {
 
   private DelphiMetricsExecutor executor;
   private SensorContextTester sensorContext;
+  private FileLinesContext fileLinesContext;
   private ExecutorContext context;
   private String componentKey;
 
   @BeforeEach
   void setup() {
-    executor = new DelphiMetricsExecutor();
+    FileLinesContextFactory fileLinesContextFactory = mock(FileLinesContextFactory.class);
+    fileLinesContext = mock(FileLinesContext.class);
+    when(fileLinesContextFactory.createFor(any(InputFile.class))).thenReturn(fileLinesContext);
+
+    executor = new DelphiMetricsExecutor(fileLinesContextFactory);
     sensorContext = SensorContextTester.create(ROOT_DIR);
     context = new ExecutorContext(sensorContext, mock(SymbolTable.class));
   }
@@ -64,6 +76,11 @@ class DelphiMetricsExecutorTest {
     checkMetric(CoreMetrics.STATEMENTS, 1);
     checkMetric(CoreMetrics.NCLOC, 28);
     checkMetric(CoreMetrics.COGNITIVE_COMPLEXITY, 0);
+    checkCodeLines(
+        Set.of(
+            1, 3, 5, 6, 7, 8, 9, 10, 11, 12, 13, 15, 16, 18, 20, 21, 22, 23, 25, 26, 27, 29, 30, 31,
+            33, 34, 35, 37),
+        37);
   }
 
   @Test
@@ -76,6 +93,7 @@ class DelphiMetricsExecutorTest {
     checkMetric(CoreMetrics.STATEMENTS, 0);
     checkMetric(CoreMetrics.NCLOC, 15);
     checkMetric(CoreMetrics.COGNITIVE_COMPLEXITY, 0);
+    checkCodeLines(Set.of(1, 3, 6, 7, 8, 11, 14, 15, 16, 17, 21, 23, 24, 38, 42), 42);
   }
 
   @Test
@@ -88,6 +106,12 @@ class DelphiMetricsExecutorTest {
     checkMetric(CoreMetrics.STATEMENTS, 12);
     checkMetric(CoreMetrics.NCLOC, 54);
     checkMetric(CoreMetrics.COGNITIVE_COMPLEXITY, 3);
+    checkCodeLines(
+        Set.of(
+            1, 3, 5, 6, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 19, 20, 22, 24, 26, 27, 28, 29, 30,
+            31, 32, 33, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 48, 49, 50, 51, 52, 53, 55,
+            56, 57, 58, 59, 60, 62, 63, 65, 67),
+        67);
   }
 
   @Test
@@ -100,6 +124,7 @@ class DelphiMetricsExecutorTest {
     checkMetric(CoreMetrics.STATEMENTS, 3);
     checkMetric(CoreMetrics.NCLOC, 18);
     checkMetric(CoreMetrics.COGNITIVE_COMPLEXITY, 0);
+    checkCodeLines(Set.of(1, 3, 5, 6, 7, 8, 9, 10, 12, 14, 15, 20, 21, 22, 23, 24, 25, 27), 27);
   }
 
   private void execute(String filename) {
@@ -112,5 +137,12 @@ class DelphiMetricsExecutorTest {
     assertThat(sensorContext.measure(componentKey, metric).value())
         .as(metric.getDescription())
         .isEqualTo(value);
+  }
+
+  void checkCodeLines(Set<Integer> codeLines, int totalLines) {
+    for (int i = 1; i <= totalLines; i++) {
+      verify(fileLinesContext)
+          .setIntValue(CoreMetrics.NCLOC_DATA_KEY, i, codeLines.contains(i) ? 1 : 0);
+    }
   }
 }

--- a/src/test/java/org/sonar/plugins/delphi/pmd/rules/BasePmdRuleTest.java
+++ b/src/test/java/org/sonar/plugins/delphi/pmd/rules/BasePmdRuleTest.java
@@ -50,6 +50,7 @@ import org.sonar.api.batch.sensor.internal.SensorContextTester;
 import org.sonar.api.batch.sensor.issue.Issue;
 import org.sonar.api.batch.sensor.issue.IssueLocation;
 import org.sonar.api.config.Configuration;
+import org.sonar.api.measures.FileLinesContextFactory;
 import org.sonar.api.rule.RuleKey;
 import org.sonar.plugins.delphi.DelphiPlugin;
 import org.sonar.plugins.delphi.DelphiSensor;
@@ -149,7 +150,7 @@ public abstract class BasePmdRuleTest {
         new DelphiMasterExecutor(
             new DelphiHighlightExecutor(),
             new DelphiCpdExecutor(),
-            new DelphiMetricsExecutor(),
+            new DelphiMetricsExecutor(mock(FileLinesContextFactory.class)),
             new DelphiSymbolTableExecutor(),
             executor);
 


### PR DESCRIPTION
Improves `MetricVisitor` to calculate the `NCLOC_DATA` SonarQube metric, which records whether individual lines contain code or not. 

Providing this metric is a requirement for custom language plugins on the SonarQube Marketplace, see [here](https://community.sonarsource.com/t/deploying-to-the-marketplace/35236):

> If your plugin adds analysis of a language that is not analyzed by SonarQube you must provide the `NCLOC` and `NCLOC_DATA`  metrics, which are both required for a consistent user experience.