### PR TITLE
Remove build GitHub action on PRs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - 'master'
-  pull_request:
 
 jobs:
   verify:


### PR DESCRIPTION
We currently have the build action, which takes about 5 minutes, enabled on pull request. As there is considerable churn in PR branches and we only have a limited number of free minutes while the repository is private, this PR modifies the build action to no longer trigger on pull request.