### PR TITLE
Refactor PMD executor to get rule classnames from rules.xml

### DIFF
--- a/src/main/java/org/sonar/plugins/delphi/pmd/xml/DelphiRuleSetHelper.java
+++ b/src/main/java/org/sonar/plugins/delphi/pmd/xml/DelphiRuleSetHelper.java
@@ -23,11 +23,13 @@ package org.sonar.plugins.delphi.pmd.xml;
 import java.io.IOException;
 import java.io.Reader;
 import org.jetbrains.annotations.NotNull;
+import org.sonar.api.SonarProduct;
 import org.sonar.api.batch.rule.ActiveRules;
 import org.sonar.api.profiles.RulesProfile;
 import org.sonar.api.utils.ValidationMessages;
 import org.sonar.api.utils.log.Logger;
 import org.sonar.api.utils.log.Loggers;
+import org.sonar.plugins.delphi.pmd.profile.DelphiPmdRuleSetDefinitionProvider;
 import org.sonar.plugins.delphi.pmd.xml.factory.ActiveRulesRuleSetFactory;
 import org.sonar.plugins.delphi.pmd.xml.factory.RuleSetFactory;
 import org.sonar.plugins.delphi.pmd.xml.factory.RulesProfileRuleSetFactory;
@@ -70,11 +72,19 @@ public class DelphiRuleSetHelper {
    *
    * @param activeRules The currently active rules.
    * @param repositoryKey The key identifier of the rule repository.
+   * @param sonarProduct The sonar product that analysis is running on.
+   * @param pmdRuleSetDefinitionProvider Provider for the pmd ruleset definition.
    * @return instance of DelphiRuleSet. Empty if an error occurs.
    */
   @NotNull
-  public static DelphiRuleSet createFrom(ActiveRules activeRules, String repositoryKey) {
-    return create(new ActiveRulesRuleSetFactory(activeRules, repositoryKey));
+  public static DelphiRuleSet createFrom(
+      ActiveRules activeRules,
+      String repositoryKey,
+      SonarProduct sonarProduct,
+      DelphiPmdRuleSetDefinitionProvider pmdRuleSetDefinitionProvider) {
+    return create(
+        new ActiveRulesRuleSetFactory(
+            activeRules, repositoryKey, sonarProduct, pmdRuleSetDefinitionProvider));
   }
 
   /**

--- a/src/test/java/org/sonar/plugins/delphi/executor/DelphiPmdExecutorTest.java
+++ b/src/test/java/org/sonar/plugins/delphi/executor/DelphiPmdExecutorTest.java
@@ -29,7 +29,6 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 import static org.sonar.plugins.delphi.pmd.DelphiPmdConstants.BASE_EFFORT;
 import static org.sonar.plugins.delphi.pmd.DelphiPmdConstants.SCOPE;
@@ -75,7 +74,8 @@ class DelphiPmdExecutorTest {
     pmdConfiguration = spy(new DelphiPmdConfiguration(fileSystem, configuration, provider));
     violationRecorder = mock(DelphiPmdViolationRecorder.class);
 
-    executor = spy(new DelphiPmdExecutor(context, rules, pmdConfiguration, violationRecorder));
+    executor =
+        spy(new DelphiPmdExecutor(context, rules, pmdConfiguration, violationRecorder, provider));
     executor.setup();
   }
 
@@ -154,7 +154,6 @@ class DelphiPmdExecutorTest {
     executor.complete();
 
     verify(violationRecorder, never()).saveViolation(any(DelphiRuleViolation.class), eq(context));
-    verifyNoMoreInteractions(context);
   }
 
   @Test

--- a/src/test/java/org/sonar/plugins/delphi/pmd/rules/BasePmdRuleTest.java
+++ b/src/test/java/org/sonar/plugins/delphi/pmd/rules/BasePmdRuleTest.java
@@ -143,7 +143,9 @@ public abstract class BasePmdRuleTest {
     DelphiPmdConfiguration pmdConfig = new DelphiPmdConfiguration(fs, config, ruleProvider);
 
     var violationRecorder = new DelphiPmdViolationRecorder(delphiProjectHelper, rulesProfile);
-    var executor = new DelphiPmdExecutor(sensorContext, rulesProfile, pmdConfig, violationRecorder);
+    var executor =
+        new DelphiPmdExecutor(
+            sensorContext, rulesProfile, pmdConfig, violationRecorder, ruleProvider);
 
     DelphiMasterExecutor masterExecutor =
         new DelphiMasterExecutor(


### PR DESCRIPTION
Currently, SonarDelphi stores the fully qualified class names corresponding to PMD rules in the `rules.xml` file and duplicates the information in the `internalKey` / `configKey` property of the Sonar rule, which it uses at runtime. This information duplication is unnecessary as SonarDelphi has access to the contents of `rules.xml`, and is an issue in a lint context as the `internalKey` / `configKey` of active rules is not passed down to the plugin.

This PR:

- Modifies the PMD executor to read the fully qualified class names of the PMD rules directly from `rules.xml`
- Mocks the severity of PMD rules if in a lint context, as lint contexts do not support severity