### PR TITLE
Fix token range calculation for binary expression nodes

### DIFF
--- a/src/main/java/org/sonar/plugins/delphi/antlr/ast/node/DelphiNode.java
+++ b/src/main/java/org/sonar/plugins/delphi/antlr/ast/node/DelphiNode.java
@@ -195,17 +195,16 @@ public abstract class DelphiNode extends AbstractNode implements ScopedNode, Ind
 
   private GenericToken findFirstToken() {
     DelphiToken result = this.token;
-    if (result.isImaginary()) {
-      int index = result.getIndex();
+    int index = result.getIndex();
 
-      for (int i = 0; i < jjtGetNumChildren(); ++i) {
-        DelphiToken childToken = ((DelphiNode) jjtGetChild(i)).jjtGetFirstToken();
-        int childIndex = childToken.getIndex();
-        if (!childToken.isImaginary() && childIndex < index) {
-          result = childToken;
-        }
+    for (int i = 0; i < jjtGetNumChildren(); ++i) {
+      DelphiToken childToken = ((DelphiNode) jjtGetChild(i)).jjtGetFirstToken();
+      int childIndex = childToken.getIndex();
+      if (!childToken.isImaginary() && childIndex < index) {
+        result = childToken;
       }
     }
+
     return result;
   }
 
@@ -214,7 +213,7 @@ public abstract class DelphiNode extends AbstractNode implements ScopedNode, Ind
     int index = result.getIndex();
 
     for (int i = 0; i < jjtGetNumChildren(); ++i) {
-      DelphiToken childToken = ((DelphiNode) jjtGetChild(i)).jjtGetFirstToken();
+      DelphiToken childToken = ((DelphiNode) jjtGetChild(i)).jjtGetLastToken();
       int childIndex = childToken.getIndex();
       if (!childToken.isImaginary() && childIndex > index) {
         result = childToken;


### PR DESCRIPTION
Currently, the token range of nested binary expression nodes is being incorrectly calculated as including only the operator. For example, the expression `1 + 2 + 3 + 4` is broken into the following tree:

```
BinaryExpressionNode with image `1 + 2 + 3 + 4` and token range `1 + 2 + 3 + 4`
  BinaryExpressionNode with image `1 + 2 + 3` and token range `+` (should be `1 + 2 + 3`)
    BinaryExpressionNode with image `1 + 2` and token range `+` (should be `1 + 2`)
```

This is apparently due to a quirk of ANTLR and the specific rule syntax used in `expression` and friends, resulting in the node's start and end token being calculated before the node is the parent of its arguments.

This PR fixes this by resetting the token range of BinaryExpressionNodes to null when they are evaluated in the grammar, which forces the range to be recalculated upon first invocation (at which point the node's arguments will be correctly set up).

In addition, the logic for calculating token range when first and last tokens are not explicitly provided by the parser has changed:

- `findFirstToken` no longer assumes the main token is the first token.
- `findLastToken` now correctly retrieves the last token of the last child node, rather than the first token of the last child node.