### PR TITLE
Fix type resolution for array accessors on Variant

### DIFF
--- a/src/main/java/org/sonar/plugins/delphi/symbol/resolve/ExpressionTypeResolver.java
+++ b/src/main/java/org/sonar/plugins/delphi/symbol/resolve/ExpressionTypeResolver.java
@@ -214,6 +214,8 @@ public final class ExpressionTypeResolver {
         type = handleNameOccurrence(accessor.getImplicitNameOccurrence());
       } else if (type.isArray()) {
         type = ((CollectionType) type).elementType();
+      } else if (type.isVariant()) {
+        type = typeFactory.getIntrinsic(IntrinsicType.VARIANT);
       } else if (TypeUtils.isNarrowString(type)) {
         type = typeFactory.getIntrinsic(IntrinsicType.ANSICHAR);
       } else if (TypeUtils.isWideString(type)) {


### PR DESCRIPTION
SonarDelphi is currently unable to resolve the result type of indexing into a `Variant` or `OleVariant`.

This PR amends the type resolution helper to resolve index results to the same variant type as the original variant - for example, indexing into a `Variant` returns a `Variant` type, while indexing into `OleVariant` returns `OleVariant`.