### PR TITLE
Support identifiers prefixed by double ampersands

### DIFF
--- a/src/main/antlr3/org/sonar/plugins/delphi/antlr/Delphi.g
+++ b/src/main/antlr3/org/sonar/plugins/delphi/antlr/Delphi.g
@@ -89,6 +89,13 @@ package org.sonar.plugins.delphi.antlr;
     return t;
   }
 
+  private Token combineLastNTokens(int count) {
+    CommonToken firstToken = (CommonToken) input.LT(-count);
+    CommonToken lastToken = (CommonToken) input.LT(-1);
+    lastToken.setStartIndex(firstToken.getStartIndex());
+    return lastToken;
+  }
+
   @Override
   public void reportError(RecognitionException e) {
     String hdr = this.getErrorHeader(e);
@@ -815,6 +822,7 @@ dispIDDirective              : 'dispid' expression
 //----------------------------------------------------------------------------
 ident                        : TkIdentifier
                              | '&'! identifierOrKeyword
+                             | '&' '&' identifierOrKeyword -> ^({combineLastNTokens(2)})
                              | keywordsUsedAsNames -> ^({changeTokenType(TkIdentifier)})
                              ;
 identifierOrKeyword          : TkIdentifier

--- a/src/test/java/org/sonar/plugins/delphi/antlr/GrammarTest.java
+++ b/src/test/java/org/sonar/plugins/delphi/antlr/GrammarTest.java
@@ -216,6 +216,11 @@ class GrammarTest {
   }
 
   @Test
+  void testDoubleAmpersands() {
+    parseFile("DoubleAmpersands.pas");
+  }
+
+  @Test
   void testUndefinedInaccessibleNestedIfDef() {
     fileConfig =
         DelphiFile.createConfig(

--- a/src/test/java/org/sonar/plugins/delphi/executor/DelphiSymbolTableExecutorTest.java
+++ b/src/test/java/org/sonar/plugins/delphi/executor/DelphiSymbolTableExecutorTest.java
@@ -853,6 +853,13 @@ class DelphiSymbolTableExecutorTest {
   }
 
   @Test
+  void testAmpersands() {
+    execute("Ampersands.pas");
+    verifyUsages(7, 11, reference(17, 2), reference(18, 2));
+    verifyUsages(11, 11, reference(19, 2));
+  }
+
+  @Test
   void testRegularMethodPreferredOverImplicitSpecializations() {
     execute("generics/RegularMethodPreferredOverImplicitSpecialization.pas");
     verifyUsages(10, 20, reference(10, 26));

--- a/src/test/resources/org/sonar/plugins/delphi/grammar/DoubleAmpersands.pas
+++ b/src/test/resources/org/sonar/plugins/delphi/grammar/DoubleAmpersands.pas
@@ -1,0 +1,36 @@
+unit DoubleAmpersands;
+
+interface
+
+type
+  &&TFoo = class(TObject)
+    procedure MyProc;
+    procedure &&MyProc(&&MyParam: &&TFoo);
+    procedure &Begin;
+  end;
+
+implementation
+
+{ TFoo }
+
+procedure &&TFoo.&&MyProc(&&MyParam: &&TFoo);
+var
+  &&MyVar: &&TFoo;
+  MyVar: &&TFoo;
+begin
+  // Note that &&MyParam is a compiler error if used
+  &&MyVar := Self;
+  MyVar := &&MyVar;
+end;
+
+procedure &&TFoo.&Begin;
+begin
+
+end;
+
+procedure &&TFoo.MyProc;
+begin
+
+end;
+
+end.

--- a/src/test/resources/org/sonar/plugins/delphi/symbol/Ampersands.pas
+++ b/src/test/resources/org/sonar/plugins/delphi/symbol/Ampersands.pas
@@ -1,0 +1,22 @@
+unit Ampersands;
+
+interface
+
+implementation
+
+procedure &Foo;
+begin
+end;
+
+procedure &&Foo;
+begin
+end;
+
+procedure Test;
+begin
+  Foo;
+  &Foo;
+  &&Foo;
+end;
+
+end.


### PR DESCRIPTION
In a bizarre twist, Delphi permits the use of identifiers beginning with double ampersands. This is a feature that the compiler seems to rely on internally, and acts unpredictably - for example, parameters prefixed with double ampersands seem to be inaccessible - but it is a syntax feature and can even be used to override internal compiler behaviour.

This PR modifies the identifier token definition to include an optional ampersand prefix, and rearranges the identifier rule so that a single ampersand is treated as it was previously (by dropping it).