### PR TITLE
Fix crash when encountering the "In" class operator

### DIFF
--- a/src/main/antlr3/org/sonar/plugins/delphi/antlr/Delphi.g
+++ b/src/main/antlr3/org/sonar/plugins/delphi/antlr/Delphi.g
@@ -503,7 +503,11 @@ forwardMethodHeading         : customAttribute? 'class'? methodKey methodDeclara
                                     forwardDirectiveSection
                                  )
                              ;
-methodDeclarationName        : genericNameDeclaration -> ^(TkMethodName<MethodNameNode> genericNameDeclaration)
+methodDeclarationName        : (
+                                 decl=genericNameDeclaration
+                               | decl=specialOpNameDeclaration
+                             )
+                             -> ^(TkMethodName<MethodNameNode> $decl)
                              ;
 methodImplementationName     : nameReference -> ^(TkMethodName<MethodNameNode> nameReference)
                              ;
@@ -850,6 +854,11 @@ genericNameDeclaration       : ident ('.' extendedIdent)* genericDefinition?
                              ;
 qualifiedNameDeclaration     : ident ('.' extendedIdent)*
                              -> ^(TkNameDeclaration<QualifiedNameDeclarationNode> ident extendedIdent*)
+                             ;
+specialOpNameDeclaration     : specialOperatorName
+                             -> ^(TkNameDeclaration<SimpleNameDeclarationNode> specialOperatorName)
+                             ;
+specialOperatorName          : 'in' -> ^({changeTokenType(TkIdentifier)})
                              ;
 nameReference                : ident genericArguments? ('.' extendedNameReference)?
                              -> ^(TkNameReference<NameReferenceNode> ident genericArguments? ('.' extendedNameReference)?)

--- a/src/test/java/org/sonar/plugins/delphi/antlr/GrammarTest.java
+++ b/src/test/java/org/sonar/plugins/delphi/antlr/GrammarTest.java
@@ -232,6 +232,11 @@ class GrammarTest {
   }
 
   @Test
+  void testClassOperators() {
+    parseFile("ClassOperators.pas");
+  }
+
+  @Test
   void testEmptyFileShouldThrow() {
     assertThatThrownBy(() -> DelphiTestFileBuilder.fromResource(BASE_DIR + "EmptyFile.pas").parse())
         .isInstanceOf(DelphiFileConstructionException.class);

--- a/src/test/resources/org/sonar/plugins/delphi/grammar/ClassOperators.pas
+++ b/src/test/resources/org/sonar/plugins/delphi/grammar/ClassOperators.pas
@@ -1,0 +1,50 @@
+unit ClassOperators;
+
+interface
+
+type
+  TMyRecord = record
+    var Value: Integer;
+    class operator Add(a, b: TMyRecord): TMyRecord;
+    class operator Subtract(a, b: TMyRecord): TMyRecord;
+    class operator Implicit(a: Integer): TMyRecord;
+    class operator Implicit(a: TMyRecord): Integer;
+    class operator Explicit(a: Double): TMyRecord;
+    class operator In(a: TMyRecord; b: Integer): Boolean;
+  end;
+
+implementation
+
+{ TMyRecord }
+
+class operator TMyRecord.Add(a, b: TMyRecord): TMyRecord;
+begin
+  Result.Value := a.Value + b.Value;
+end;
+
+class operator TMyRecord.Explicit(a: Double): TMyRecord;
+begin
+  Result.Value := Trunc(a);
+end;
+
+class operator TMyRecord.Implicit(a: Integer): TMyRecord;
+begin
+  Result.Value := a;
+end;
+
+class operator TMyRecord.Implicit(a: TMyRecord): Integer;
+begin
+  Result := a.Value;
+end;
+
+class operator TMyRecord.In(a: TMyRecord; b: Integer): Boolean;
+begin
+  Result := b < a.Value;
+end;
+
+class operator TMyRecord.Subtract(a, b: TMyRecord): TMyRecord;
+begin
+  Result.Value := a.Value - b.Value;
+end;
+
+end.


### PR DESCRIPTION
The behaviour of operators on Delphi records can be modified using `class operator` methods. The class operator `In`, which allows customization of the inbuilt `in` operation, currently causes SonarDelphi to crash as `in` is a reserved word.

This PR modifies the Delphi grammar to treat the `in` keyword as an identifier when parsing a `class operator` method.