### PR TITLE
Fix name collision between generic and non-generic forward declarations

### DIFF
--- a/src/main/java/org/sonar/plugins/delphi/symbol/scope/AbstractDelphiScope.java
+++ b/src/main/java/org/sonar/plugins/delphi/symbol/scope/AbstractDelphiScope.java
@@ -83,11 +83,6 @@ class AbstractDelphiScope implements DelphiScope {
     }
 
     TypeNameDeclaration fullTypeDeclaration = (TypeNameDeclaration) typeDeclaration;
-    if (fullTypeDeclaration.isGeneric()) {
-      // Generic types cannot be forward-declared
-      return;
-    }
-
     Type fullType = fullTypeDeclaration.getType();
     if (!fullType.isStruct()) {
       return;
@@ -99,8 +94,16 @@ class AbstractDelphiScope implements DelphiScope {
             declaration -> {
               if (declaration instanceof TypeNameDeclaration) {
                 TypeNameDeclaration forwardDeclaration = (TypeNameDeclaration) declaration;
-                if (forwardDeclaration.isGeneric()) {
-                  // Generic types cannot be forward-declared
+
+                // A generic type's forward declaration must also be generic, or vice versa
+                if (forwardDeclaration.isGeneric() != fullTypeDeclaration.isGeneric()) {
+                  return false;
+                }
+
+                // A generic type's forward declaration must have matching type parameters
+                if (forwardDeclaration.isGeneric()
+                    && forwardDeclaration.getTypeParameters().size()
+                        != fullTypeDeclaration.getTypeParameters().size()) {
                   return false;
                 }
 

--- a/src/test/java/org/sonar/plugins/delphi/symbol/scope/DelphiScopeTest.java
+++ b/src/test/java/org/sonar/plugins/delphi/symbol/scope/DelphiScopeTest.java
@@ -141,15 +141,13 @@ class DelphiScopeTest {
   }
 
   @Test
-  void testGenericTypesWithDifferentNumbersOfTypeParameterAreDuplicates() {
+  void testGenericTypesWithSameNumberofTypeParametersAreNotDuplicates() {
     scope.addDeclaration(createClassType("Foo", List.of(createType("Bar"))));
-    assertThatThrownBy(
-            () -> scope.addDeclaration(createClassType("Foo", List.of(createType("Bar")))))
-        .isInstanceOf(RuntimeException.class);
+    scope.addDeclaration(createClassType("Foo", List.of(createType("Bar"))));
   }
 
   @Test
-  void testGenericTypesWithSameNumberOfTypeParameterDuplicates() {
+  void testGenericTypesWithDifferentNumberofTypeParametersAreNotDuplicates() {
     scope.addDeclaration(createClassType("Foo"));
     scope.addDeclaration(createClassType("Foo", List.of(createType("Bar"))));
     scope.addDeclaration(createClassType("Foo", List.of(createType("Bar"), createType("Baz"))));


### PR DESCRIPTION
SonarDelphi currently crashes when parsing multiple forward declarations with the same name. This usually occurs when a non-generic type and a generic type share a name and are both forward declared, such as the below:

```delphi
type
  TFoo = class;
  TFoo<T> = class;

  TFoo = class(TObject)
  // ...
  end;

  TFoo<T> = class(TObject)
  // ...
  end;
```

This PR modifies the code that identifies forward declarations to take into account the number of generic parameters of a declaration. This resolves the crash and correctly matches a full declaration to its forward declaration.