### PR TITLE
Remove incorrect type conversion between pointers and arrays

### DIFF
--- a/src/main/java/org/sonar/plugins/delphi/symbol/resolve/TypeComparer.java
+++ b/src/main/java/org/sonar/plugins/delphi/symbol/resolve/TypeComparer.java
@@ -670,9 +670,7 @@ class TypeComparer {
   }
 
   private static EqualityType comparePointerToArray(PointerType from, CollectionType to) {
-    if (equals(from.dereferencedType(), to.elementType())) {
-      return CONVERT_LEVEL_3;
-    } else if (to.isDynamicArray() && (from.isNilPointer() || from.isUntypedPointer())) {
+    if (to.isDynamicArray() && (from.isNilPointer() || from.isUntypedPointer())) {
       return CONVERT_LEVEL_5;
     }
 

--- a/src/test/java/org/sonar/plugins/delphi/symbol/resolve/TypeComparerTest.java
+++ b/src/test/java/org/sonar/plugins/delphi/symbol/resolve/TypeComparerTest.java
@@ -367,7 +367,7 @@ class TypeComparerTest {
     compare(fromIncompatibleOpenArray, toFixedArray, INCOMPATIBLE_TYPES);
     compare(fromDynamicArray, toFixedArray, INCOMPATIBLE_TYPES);
 
-    compare(pointerTo(IntrinsicType.INTEGER), toOpenArray, CONVERT_LEVEL_3);
+    compare(pointerTo(IntrinsicType.INTEGER), toOpenArray, INCOMPATIBLE_TYPES);
     compare(nilPointer(), toDynamicArray, CONVERT_LEVEL_5);
     compare(untypedPointer(), toDynamicArray, CONVERT_LEVEL_5);
     compare(pointerTo(IntrinsicType.UNICODESTRING), toOpenArray, INCOMPATIBLE_TYPES);


### PR DESCRIPTION
SonarDelphi incorrectly converts pointer types to array types for the purposes of overload resolution, resulting in ambiguity crashes when such overloads are rejected by the compiler but accepted by SonarDelphi.

This PR removes the comparison between pointer types and array types, making implicit conversion between those types impossible.