### PR TITLE
Lower strength of fixed to dynamic array comparison

### DIFF
--- a/src/main/java/org/sonar/plugins/delphi/symbol/resolve/TypeComparer.java
+++ b/src/main/java/org/sonar/plugins/delphi/symbol/resolve/TypeComparer.java
@@ -630,7 +630,7 @@ class TypeComparer {
 
   private static EqualityType compareDynamicArray(CollectionType from, CollectionType to) {
     if (equals(from.elementType(), to.elementType())) {
-      return from.isDynamicArray() ? EQUAL : CONVERT_LEVEL_2;
+      return from.isDynamicArray() ? EQUAL : CONVERT_LEVEL_5;
     }
     return INCOMPATIBLE_TYPES;
   }

--- a/src/test/java/org/sonar/plugins/delphi/symbol/resolve/TypeComparerTest.java
+++ b/src/test/java/org/sonar/plugins/delphi/symbol/resolve/TypeComparerTest.java
@@ -343,7 +343,7 @@ class TypeComparerTest {
 
     compare(IntrinsicType.INTEGER, toOpenArray, CONVERT_LEVEL_3);
     compare(fromDynamicArray, toDynamicArray, EQUAL);
-    compare(fromFixedArray, toDynamicArray, CONVERT_LEVEL_2);
+    compare(fromFixedArray, toDynamicArray, CONVERT_LEVEL_5);
     compare(dynamicArray(null, IntrinsicType.UNICODESTRING), toDynamicArray, INCOMPATIBLE_TYPES);
 
     compare(fromDynamicArray, toOpenArray, CONVERT_LEVEL_1);


### PR DESCRIPTION
When converting from a fixed char array, SonarDelphi currently favours a dynamic char array conversion over a string conversion. The Delphi compiler favours string conversion in all cases.

This PR downgrades a fixed array to dynamic array conversion from `CONVERT_LEVEL_2` down to `CONVERT_LEVEL_5`.