### PR TITLE
Allow Self to be shadowed in method scopes

### DIFF
--- a/src/test/java/org/sonar/plugins/delphi/executor/DelphiSymbolTableExecutorTest.java
+++ b/src/test/java/org/sonar/plugins/delphi/executor/DelphiSymbolTableExecutorTest.java
@@ -282,6 +282,13 @@ class DelphiSymbolTableExecutorTest {
   }
 
   @Test
+  void testSelfInNestedProcedures() {
+    execute("SelfInNestedProcedures.pas");
+    verifyUsages(17, 11, reference(34, 2));
+    verifyUsages(19, 11, reference(29, 4), reference(38, 4));
+  }
+
+  @Test
   void testInitializationFinalization() {
     execute("InitializationFinalization.pas");
     verifyUsages(6, 2, reference(14, 7), reference(17, 9));

--- a/src/test/resources/org/sonar/plugins/delphi/symbol/SelfInNestedProcedures.pas
+++ b/src/test/resources/org/sonar/plugins/delphi/symbol/SelfInNestedProcedures.pas
@@ -1,0 +1,56 @@
+unit SelfInNestedProcedures;
+
+interface
+
+type
+  TBar = class(TObject)
+  end;
+
+  TBaz = class(TObject)
+  end;
+
+  TFoo = class(TObject)
+    var Self: TBar;
+    procedure MyProc;
+  end;
+
+ procedure Test(Obj: TFoo); overload;
+ procedure Test(Obj: TBar); overload;
+ procedure Test(Obj: TBaz); overload;
+
+implementation
+
+uses System.SysUtils;
+
+procedure TFoo.MyProc;
+
+  procedure SubProc(Self: TBaz);
+  begin
+    Test(Self); // Test(TBaz)
+  end;
+
+var Anonymous: TProc<TBaz>;
+begin
+  Test(Self); // Test(TFoo)
+  SubProc(TBaz.Create);
+
+  Anonymous := procedure(Self: TBaz) begin
+    Test(Self); // Test(TBaz)
+  end;
+
+  Anonymous(TBaz.Create);
+end;
+
+procedure Test(Obj: TFoo);
+begin
+end;
+
+procedure Test(Obj: TBar);
+begin
+end;
+
+procedure Test(Obj: TBaz);
+begin
+end;
+
+end.


### PR DESCRIPTION
SonarDelphi currently crashes when encountering an object method containing a subprocedure with a `Self` parameter, see below:

```delphi
procedure TFoo.Proc;

  procedure SubProc(Self: TBar);
  begin
    Test(Self);
  end;

begin
  SubProc(TBar.Create);
end;
```

This PR fixes the issue by including an exception in `MethodScope` to allow multiple declarations of `Self`. Note that this is a fix, not an ideal approach, and should be replaced with a more optimal solution in future.