### PR TITLE
Add rule to check for non-linear object casts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `DigitGrouping` analysis rule, which flags numeric literals that use non-standard digit groupings.
 - `AddressOfCharacterData` analysis rule, which flags attempts to manually get the address of the
   first character in a string.
+- `NonLinearCast` analysis rule, which flags unsafe object and pointer casts.
 
 ### Changed
 

--- a/delphi-checks/src/main/java/au/com/integradev/delphi/checks/CheckList.java
+++ b/delphi-checks/src/main/java/au/com/integradev/delphi/checks/CheckList.java
@@ -102,6 +102,7 @@ public final class CheckList {
           MissingSemicolonCheck.class,
           MixedNamesCheck.class,
           NilComparisonCheck.class,
+          NonLinearCastCheck.class,
           NoSonarCheck.class,
           ObjectTypeCheck.class,
           PascalStyleResultCheck.class,

--- a/delphi-checks/src/main/java/au/com/integradev/delphi/checks/NonLinearCastCheck.java
+++ b/delphi-checks/src/main/java/au/com/integradev/delphi/checks/NonLinearCastCheck.java
@@ -1,0 +1,59 @@
+/*
+ * Sonar Delphi Plugin
+ * Copyright (C) 2023 Integrated Application Development
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02
+ */
+package au.com.integradev.delphi.checks;
+
+import org.sonar.check.Rule;
+import org.sonar.plugins.communitydelphi.api.type.Type;
+import org.sonar.plugins.communitydelphi.api.type.Type.PointerType;
+import org.sonar.plugins.communitydelphi.api.type.Type.StructType;
+
+@Rule(key = "NonLinearCast")
+public class NonLinearCastCheck extends AbstractCastCheck {
+  @Override
+  protected boolean isViolation(Type originalType, Type castType) {
+    if (originalType.isStruct() && castType.isStruct()) {
+      return !isValidStructToStructCast((StructType) originalType, (StructType) castType);
+    } else if (originalType.isStruct() && castType.isPointer()) {
+      return !isValidStructToPointerCast((StructType) originalType, (PointerType) castType);
+    } else {
+      return false;
+    }
+  }
+
+  private boolean isValidStructToStructCast(StructType from, StructType to) {
+    if (!from.isClass() || !to.isClass()) {
+      return true;
+    } else {
+      return from.is(to) || from.isSubTypeOf(to) || to.isSubTypeOf(from);
+    }
+  }
+
+  private boolean isValidStructToPointerCast(StructType from, PointerType to) {
+    if (!from.isClass() || to.isUntypedPointer() || !to.dereferencedType().isClass()) {
+      return true;
+    } else {
+      return isValidStructToStructCast(from, (StructType) to.dereferencedType());
+    }
+  }
+
+  @Override
+  protected String getIssueMessage() {
+    return "Remove this unsafe object cast.";
+  }
+}

--- a/delphi-checks/src/main/resources/org/sonar/l10n/delphi/rules/community-delphi/NonLinearCast.html
+++ b/delphi-checks/src/main/resources/org/sonar/l10n/delphi/rules/community-delphi/NonLinearCast.html
@@ -1,0 +1,39 @@
+<h2>Why is this an issue?</h2>
+<p>Casting an object to a type that is not guaranteed to have the same memory configuration can
+cause access violations if used improperly.</p>
+<h2>How to fix it</h2>
+<p>Remove the improper cast by refactoring the code. If the intention is to provide additional
+  methods to operate on an object, consider using a class helper instead.
+</p>
+<pre data-diff-id="1" data-diff-type="noncompliant">
+type
+  TAdditionalFunctionality = class(TObject)
+  public
+    procedure DebugPrint;
+  end;
+
+procedure DoStuff(MyObj: TSecretString);
+begin
+  TAdditionalFunctionality(MyObj).DebugPrint;
+end;
+</pre>
+<pre data-diff-id="2" data-diff-type="compliant">
+type
+  TAdditionalFunctionality = class helper for TSecretString
+  public
+    procedure DebugPrint;
+  end;
+
+procedure DoStuff(MyObj: TSecretString);
+begin
+  MyObj.DebugPrint;
+end;
+</pre>
+<h2>Resources</h2>
+<ul>
+  <li>
+    <a href="https://docwiki.embarcadero.com/RADStudio/en/Class_and_Record_Helpers_(Delphi)">
+      RAD Studio documentation: Class and Record Helpers (Delphi)
+    </a>
+  </li>
+</ul>

--- a/delphi-checks/src/main/resources/org/sonar/l10n/delphi/rules/community-delphi/NonLinearCast.json
+++ b/delphi-checks/src/main/resources/org/sonar/l10n/delphi/rules/community-delphi/NonLinearCast.json
@@ -1,0 +1,19 @@
+{
+  "title": "Object casts should only be to ancestor or child classes",
+  "type": "BUG",
+  "status": "ready",
+  "remediation": {
+    "func": "Constant/Issue",
+    "constantCost": "10min"
+  },
+  "code": {
+    "attribute": "LOGICAL",
+    "impacts": {
+      "RELIABILITY": "MEDIUM"
+    }
+  },
+  "tags": ["unpredictable", "suspicious"],
+  "defaultSeverity": "Critical",
+  "scope": "ALL",
+  "quickfix": "unknown"
+}

--- a/delphi-checks/src/main/resources/org/sonar/l10n/delphi/rules/community-delphi/Sonar_way_profile.json
+++ b/delphi-checks/src/main/resources/org/sonar/l10n/delphi/rules/community-delphi/Sonar_way_profile.json
@@ -49,6 +49,7 @@
     "MissingSemicolon",
     "MixedNames",
     "NilComparison",
+    "NonLinearCast",
     "NoSonar",
     "ObjectType",
     "PascalStyleResult",

--- a/delphi-checks/src/test/java/au/com/integradev/delphi/checks/NonLinearCastCheckTest.java
+++ b/delphi-checks/src/test/java/au/com/integradev/delphi/checks/NonLinearCastCheckTest.java
@@ -1,0 +1,261 @@
+/*
+ * Sonar Delphi Plugin
+ * Copyright (C) 2023 Integrated Application Development
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02
+ */
+package au.com.integradev.delphi.checks;
+
+import au.com.integradev.delphi.builders.DelphiTestUnitBuilder;
+import au.com.integradev.delphi.checks.verifier.CheckVerifier;
+import org.junit.jupiter.api.Test;
+
+class NonLinearCastCheckTest {
+  @Test
+  void testCastToGrandparentClassShouldNotAddIssue() {
+    CheckVerifier.newVerifier()
+        .withCheck(new NonLinearCastCheck())
+        .onFile(
+            new DelphiTestUnitBuilder()
+                .appendDecl("type")
+                .appendDecl("  TGrandparent = class(TObject)")
+                .appendDecl("  end;")
+                .appendDecl("  TParent = class(TGrandparent)")
+                .appendDecl("  end;")
+                .appendDecl("  TChild = class(TParent)")
+                .appendDecl("  end;")
+                .appendImpl("function AsGrandparent(Obj: TChild): TGrandparent;")
+                .appendImpl("begin")
+                .appendImpl("  Result := TGrandparent(Obj);")
+                .appendImpl("end;"))
+        .verifyNoIssues();
+  }
+
+  @Test
+  void testCastToParentClassShouldNotAddIssue() {
+    CheckVerifier.newVerifier()
+        .withCheck(new NonLinearCastCheck())
+        .onFile(
+            new DelphiTestUnitBuilder()
+                .appendDecl("type")
+                .appendDecl("  TParent = class(TObject)")
+                .appendDecl("  end;")
+                .appendDecl("  TChild = class(TParent)")
+                .appendDecl("  end;")
+                .appendImpl("function AsParent(Obj: TChild): TParent;")
+                .appendImpl("begin")
+                .appendImpl("  Result := TParent(Obj);")
+                .appendImpl("end;"))
+        .verifyNoIssues();
+  }
+
+  @Test
+  void testCastToChildClassShouldNotAddIssue() {
+    CheckVerifier.newVerifier()
+        .withCheck(new NonLinearCastCheck())
+        .onFile(
+            new DelphiTestUnitBuilder()
+                .appendDecl("type")
+                .appendDecl("  TParent = class(TObject)")
+                .appendDecl("  end;")
+                .appendDecl("  TChild = class(TParent)")
+                .appendDecl("  end;")
+                .appendImpl("function AsChild(Obj: TParent): TChild;")
+                .appendImpl("begin")
+                .appendImpl("  Result := TChild(Obj);")
+                .appendImpl("end;"))
+        .verifyNoIssues();
+  }
+
+  @Test
+  void testCastToGrandchildClassShouldNotAddIssue() {
+    CheckVerifier.newVerifier()
+        .withCheck(new NonLinearCastCheck())
+        .onFile(
+            new DelphiTestUnitBuilder()
+                .appendDecl("type")
+                .appendDecl("  TParent = class(TObject)")
+                .appendDecl("  end;")
+                .appendDecl("  TChild = class(TParent)")
+                .appendDecl("  end;")
+                .appendDecl("  TGrandchild = class(TChild)")
+                .appendDecl("  end;")
+                .appendImpl("function AsGrandchild(Obj: TParent): TGrandchild;")
+                .appendImpl("begin")
+                .appendImpl("  Result := TGrandchild(Obj);")
+                .appendImpl("end;"))
+        .verifyNoIssues();
+  }
+
+  @Test
+  void testCastToTObjectShouldNotAddIssue() {
+    CheckVerifier.newVerifier()
+        .withCheck(new NonLinearCastCheck())
+        .onFile(
+            new DelphiTestUnitBuilder()
+                .appendDecl("type")
+                .appendDecl("  TMyType = class(TObject)")
+                .appendDecl("  end;")
+                .appendImpl("function AsObject(Obj: TMyType): TObject;")
+                .appendImpl("begin")
+                .appendImpl("  Result := TObject(Obj);")
+                .appendImpl("end;"))
+        .verifyNoIssues();
+  }
+
+  @Test
+  void testCastToSelfShouldNotAddIssue() {
+    CheckVerifier.newVerifier()
+        .withCheck(new NonLinearCastCheck())
+        .onFile(
+            new DelphiTestUnitBuilder()
+                .appendDecl("type")
+                .appendDecl("  TMyType = class(TObject)")
+                .appendDecl("  end;")
+                .appendImpl("function AsSame(Obj: TMyType): TMyType;")
+                .appendImpl("begin")
+                .appendImpl("  Result := TMyType(Obj);")
+                .appendImpl("end;"))
+        .verifyNoIssues();
+  }
+
+  @Test
+  void testCastToSiblingClassShouldAddIssue() {
+    CheckVerifier.newVerifier()
+        .withCheck(new NonLinearCastCheck())
+        .onFile(
+            new DelphiTestUnitBuilder()
+                .appendDecl("type")
+                .appendDecl("  TParent = class(TObject)")
+                .appendDecl("  end;")
+                .appendDecl("  TChild = class(TParent)")
+                .appendDecl("  end;")
+                .appendDecl("  TOtherChild = class(TParent)")
+                .appendDecl("  end;")
+                .appendImpl("function AsOtherChild(Obj: TChild): TOtherChild;")
+                .appendImpl("begin")
+                .appendImpl("  Result := TOtherChild(Obj);")
+                .appendImpl("end;"))
+        .verifyIssueOnLine(17);
+  }
+
+  @Test
+  void testCastToUnrelatedObjectShouldAddIssue() {
+    CheckVerifier.newVerifier()
+        .withCheck(new NonLinearCastCheck())
+        .onFile(
+            new DelphiTestUnitBuilder()
+                .appendDecl("type")
+                .appendDecl("  TDog = class(TObject)")
+                .appendDecl("  end;")
+                .appendDecl("  TCat = class(TObject)")
+                .appendDecl("  end;")
+                .appendImpl("function AsCat(Obj: TDog): TCat;")
+                .appendImpl("begin")
+                .appendImpl("  Result := TCat(Obj);")
+                .appendImpl("end;"))
+        .verifyIssueOnLine(15);
+  }
+
+  @Test
+  void testCastToUntypedPointerShouldNotAddIssue() {
+    CheckVerifier.newVerifier()
+        .withCheck(new NonLinearCastCheck())
+        .onFile(
+            new DelphiTestUnitBuilder()
+                .appendDecl("type")
+                .appendDecl("  TMyType = class(TObject)")
+                .appendDecl("  end;")
+                .appendImpl("function AsPointer(Obj: TMyType): Pointer;")
+                .appendImpl("begin")
+                .appendImpl("  Result := Pointer(Obj);")
+                .appendImpl("end;"))
+        .verifyNoIssues();
+  }
+
+  @Test
+  void testCastToSelfTypedPointerShouldNotAddIssue() {
+    CheckVerifier.newVerifier()
+        .withCheck(new NonLinearCastCheck())
+        .onFile(
+            new DelphiTestUnitBuilder()
+                .appendDecl("type")
+                .appendDecl("  TMyType = class(TObject)")
+                .appendDecl("  end;")
+                .appendDecl("  PMyType = ^TMyType;")
+                .appendImpl("function AsPointer(Obj: TMyType): PMyType;")
+                .appendImpl("begin")
+                .appendImpl("  Result := PMyType(Obj);")
+                .appendImpl("end;"))
+        .verifyNoIssues();
+  }
+
+  @Test
+  void testCastToParentTypedPointerShouldNotAddIssue() {
+    CheckVerifier.newVerifier()
+        .withCheck(new NonLinearCastCheck())
+        .onFile(
+            new DelphiTestUnitBuilder()
+                .appendDecl("type")
+                .appendDecl("  TParent = class(TObject)")
+                .appendDecl("  end;")
+                .appendDecl("  TChild = class(TParent)")
+                .appendDecl("  end;")
+                .appendDecl("  PParent = ^TParent;")
+                .appendImpl("function AsPointer(Obj: TChild): PParent;")
+                .appendImpl("begin")
+                .appendImpl("  Result := PParent(Obj);")
+                .appendImpl("end;"))
+        .verifyNoIssues();
+  }
+
+  @Test
+  void testCastToChildTypedPointerShouldNotAddIssue() {
+    CheckVerifier.newVerifier()
+        .withCheck(new NonLinearCastCheck())
+        .onFile(
+            new DelphiTestUnitBuilder()
+                .appendDecl("type")
+                .appendDecl("  TParent = class(TObject)")
+                .appendDecl("  end;")
+                .appendDecl("  TChild = class(TParent)")
+                .appendDecl("  end;")
+                .appendDecl("  PChild = ^TChild;")
+                .appendImpl("function AsPointer(Obj: TParent): PChild;")
+                .appendImpl("begin")
+                .appendImpl("  Result := PChild(Obj);")
+                .appendImpl("end;"))
+        .verifyNoIssues();
+  }
+
+  @Test
+  void testCastToUnrelatedPointerShouldAddIssue() {
+    CheckVerifier.newVerifier()
+        .withCheck(new NonLinearCastCheck())
+        .onFile(
+            new DelphiTestUnitBuilder()
+                .appendDecl("type")
+                .appendDecl("  TDog = class(TObject)")
+                .appendDecl("  end;")
+                .appendDecl("  TCat = class(TObject)")
+                .appendDecl("  end;")
+                .appendDecl("  PCat = ^TCat;")
+                .appendImpl("function AsPointer(Obj: TDog): PCat;")
+                .appendImpl("begin")
+                .appendImpl("  Result := PCat(Obj);")
+                .appendImpl("end;"))
+        .verifyIssueOnLine(16);
+  }
+}


### PR DESCRIPTION
Adds a rule checking that casts for an object of class `C` only take the following forms:

- To an object that is a parent or child of `C`.
- To an untyped pointer.
- To a typed pointer `^T`, where the dereferenced type `T` is a parent or child class of `C`.

This prevents casting an object to an unrelated type, which can result in code that is a minefield of access violations.