### PR TITLE
Use hasURI instead of hasPath in DelphiProjectHelper.getFile

### DIFF
--- a/src/main/java/org/sonar/plugins/delphi/msbuild/DelphiProjectHelper.java
+++ b/src/main/java/org/sonar/plugins/delphi/msbuild/DelphiProjectHelper.java
@@ -30,6 +30,7 @@ import com.google.common.collect.Iterables;
 import java.io.File;
 import java.nio.charset.Charset;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -351,7 +352,7 @@ public class DelphiProjectHelper {
   }
 
   public InputFile getFile(String path) {
-    return fs.inputFile(fs.predicates().hasPath(path));
+    return fs.inputFile(fs.predicates().hasURI(Paths.get(path).toUri()));
   }
 
   public InputFile getFile(File file) {


### PR DESCRIPTION
`DelphiProjectHelper.getFile` gets a file by its absolute path by returning files matching a predicate constructed with `FilePredicates.hasPath`. SonarLint's `FilePredicates` implementation does not support `hasPath` or other similar path-related predicates, but does support the similar `hasURI` predicate.

This PR changes `DelphiProjectHelper` to use `hasURI`, resulting in the same behaviour when running in a SonarQube context and a SonarLint context.

All tests pass, including a test scan.