### PR TITLE
Add rule to forbid TEncoding.Default

### DIFF
--- a/delphi-checks/src/main/java/au/com/integradev/delphi/checks/CheckList.java
+++ b/delphi-checks/src/main/java/au/com/integradev/delphi/checks/CheckList.java
@@ -80,6 +80,7 @@ public final class CheckList {
           GroupedVariableDeclarationCheck.class,
           HelperNameCheck.class,
           IfThenShortCircuitCheck.class,
+          ImplicitDefaultEncodingCheck.class,
           ImportSpecificityCheck.class,
           IndexLastListElementCheck.class,
           InheritedMethodWithNoCodeCheck.class,

--- a/delphi-checks/src/main/java/au/com/integradev/delphi/checks/ImplicitDefaultEncodingCheck.java
+++ b/delphi-checks/src/main/java/au/com/integradev/delphi/checks/ImplicitDefaultEncodingCheck.java
@@ -1,0 +1,138 @@
+/*
+ * Sonar Delphi Plugin
+ * Copyright (C) 2023 Integrated Application Development
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02
+ */
+package au.com.integradev.delphi.checks;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
+import java.util.stream.Collectors;
+import org.sonar.check.Rule;
+import org.sonar.plugins.communitydelphi.api.ast.NameReferenceNode;
+import org.sonar.plugins.communitydelphi.api.check.DelphiCheck;
+import org.sonar.plugins.communitydelphi.api.check.DelphiCheckContext;
+import org.sonar.plugins.communitydelphi.api.symbol.declaration.MethodNameDeclaration;
+import org.sonar.plugins.communitydelphi.api.symbol.declaration.NameDeclaration;
+import org.sonar.plugins.communitydelphi.api.type.Parameter;
+import org.sonar.plugins.communitydelphi.api.type.Type;
+
+@Rule(key = "ImplicitDefaultEncoding")
+public class ImplicitDefaultEncodingCheck extends DelphiCheck {
+  private static final String MESSAGE = "Explicitly pass the encoding to this method.";
+
+  private static final Map<String, Signature> FORBIDDEN_SIGNATURES =
+      createSignatures(
+          signature(
+              "Vcl.Outline.TOutlineNode.WriteNode",
+              List.of("array of System.Byte <DYNAMIC>", "System.Classes.TStream"),
+              List.of("System.PWideChar", "System.Classes.TStream")),
+          signature("Vcl.Outline.TCustomOutline.LoadFromFile", List.of("System.UnicodeString")),
+          signature("Vcl.Outline.TCustomOutline.LoadFromStream", List.of("System.Classes.TStream")),
+          signature("Vcl.Outline.TCustomOutline.SaveToFile", List.of("System.UnicodeString")),
+          signature("Vcl.Outline.TCustomOutline.SaveToStream", List.of("System.Classes.TStream")),
+          signature("System.Classes.TStrings.LoadFromFile", List.of("System.UnicodeString")),
+          signature("System.Classes.TStrings.LoadFromStream", List.of("System.Classes.TStream")),
+          signature("System.Classes.TStrings.SaveToFile", List.of("System.UnicodeString")),
+          signature("System.Classes.TStrings.SaveToStream", List.of("System.Classes.TStream")),
+          signature(
+              "System.Classes.TStringStream.Create",
+              Collections.emptyList(),
+              List.of("System.UnicodeString"),
+              List.of("System.RawByteString"),
+              List.of("array of System.Byte <DYNAMIC>")),
+          signature(
+              "System.Classes.TStreamReader.Create",
+              List.of("System.Classes.TStream"),
+              List.of("System.Classes.TStream", "System.Boolean"),
+              List.of("System.UnicodeString"),
+              List.of("System.UnicodeString", "System.Boolean")),
+          signature(
+              "System.Classes.TStreamWriter.Create",
+              List.of("System.Classes.TStream"),
+              List.of("System.UnicodeString"),
+              List.of("System.UnicodeString", "System.Boolean")));
+
+  @Override
+  public DelphiCheckContext visit(NameReferenceNode reference, DelphiCheckContext context) {
+    NameDeclaration declaration = reference.getNameDeclaration();
+    if (declaration instanceof MethodNameDeclaration
+        && isForbiddenOverload((MethodNameDeclaration) declaration)) {
+      reportIssue(context, reference.getIdentifier(), MESSAGE);
+    }
+
+    return super.visit(reference, context);
+  }
+
+  private static boolean isForbiddenOverload(MethodNameDeclaration method) {
+    Signature signature = FORBIDDEN_SIGNATURES.get(method.fullyQualifiedName());
+    return signature != null
+        && signature.hasParameterTypes(
+            method.getParameters().stream()
+                .map(Parameter::getType)
+                .collect(Collectors.toUnmodifiableList()));
+  }
+
+  private static Map<String, Signature> createSignatures(Signature... signatures) {
+    TreeMap<String, Signature> map = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
+    for (var signature : signatures) {
+      map.put(signature.getName(), signature);
+    }
+    return Collections.unmodifiableMap(map);
+  }
+
+  @SafeVarargs
+  @SuppressWarnings("varargs")
+  private static Signature signature(String name, List<String>... parameterLists) {
+    return new Signature(name, parameterLists);
+  }
+
+  private static final class Signature {
+    private final String name;
+    private final List<String>[] parameterLists;
+
+    private Signature(String name, List<String>[] parameterLists) {
+      this.name = name;
+      this.parameterLists = parameterLists;
+    }
+
+    public String getName() {
+      return name;
+    }
+
+    public boolean hasParameterTypes(List<Type> types) {
+      return Arrays.stream(parameterLists)
+          .anyMatch(typeImages -> typesMatchImages(types, typeImages));
+    }
+
+    private static boolean typesMatchImages(List<Type> types, List<String> typeImages) {
+      if (types.size() != typeImages.size()) {
+        return false;
+      }
+
+      for (int i = 0; i < types.size(); ++i) {
+        if (!types.get(i).is(typeImages.get(i))) {
+          return false;
+        }
+      }
+
+      return true;
+    }
+  }
+}

--- a/delphi-checks/src/main/resources/org/sonar/l10n/delphi/rules/community-delphi/ImplicitDefaultEncoding.html
+++ b/delphi-checks/src/main/resources/org/sonar/l10n/delphi/rules/community-delphi/ImplicitDefaultEncoding.html
@@ -1,0 +1,40 @@
+<h2>Why is this an issue?</h2>
+<p>
+  Implicitly using <code>TEncoding.Default</code> causes a platform-dependent default encoding to be
+  used. The defaults are <code>TEncoding.ANSI</code> on Windows and <code>TEncoding.UTF8</code> on
+  all other platforms.
+</p>
+
+<p>The methods that can implicitly use <code>TEncoding.Default</code> are:</p>
+<ul>
+  <li><code>Vcl.Outline.TOutlineNode.WriteNode</code></li>
+  <li><code>Vcl.Outline.TOutlineNode.LoadFromFile</code></li>
+  <li><code>Vcl.Outline.TOutlineNode.LoadFromStream</code></li>
+  <li><code>Vcl.Outline.TOutlineNode.SaveToFile</code></li>
+  <li><code>Vcl.Outline.TOutlineNode.SaveToStream</code></li>
+  <li><code>System.Classes.TStrings.LoadFromFile</code></li>
+  <li><code>System.Classes.TStrings.LoadFromStream</code></li>
+  <li><code>System.Classes.TStrings.SaveToFile</code></li>
+  <li><code>System.Classes.TStrings.SaveToStream</code></li>
+  <li><code>System.Classes.TStringStream.Create</code></li>
+  <li><code>System.Classes.TStreamReader.Create</code></li>
+  <li><code>System.Classes.TStreamWriter.Create</code></li>
+</ul>
+
+<h2>How to fix it</h2>
+<p>Explicitly specify the encoding:</p>
+<pre data-diff-id="1" data-diff-type="noncompliant">
+MyStringList.LoadFromFile(FileName);
+</pre>
+<pre data-diff-id="1" data-diff-type="compliant">
+MyStringList.LoadFromFile(FileName, TEncoding.UTF8);
+</pre>
+
+<h2>Resources</h2>
+<ul>
+  <li>
+    <a href="https://docwiki.embarcadero.com/Libraries/en/System.SysUtils.TEncoding.Default">
+      Rad Studio API documentation: System.SysUtils.TEncoding.Default
+    </a>
+  </li>
+</ul>

--- a/delphi-checks/src/main/resources/org/sonar/l10n/delphi/rules/community-delphi/ImplicitDefaultEncoding.json
+++ b/delphi-checks/src/main/resources/org/sonar/l10n/delphi/rules/community-delphi/ImplicitDefaultEncoding.json
@@ -1,0 +1,19 @@
+{
+  "title": "Methods implicitly using TEncoding.Default should not be used",
+  "type": "CODE_SMELL",
+  "status": "ready",
+  "remediation": {
+    "func": "Constant/Issue",
+    "constantCost": "5min"
+  },
+  "code": {
+    "attribute": "CLEAR",
+    "impacts": {
+      "MAINTAINABILITY": "MEDIUM"
+    }
+  },
+  "tags": ["bad-practice", "pitfall", "unpredictable"],
+  "defaultSeverity": "Major",
+  "scope": "ALL",
+  "quickfix": "unknown"
+}

--- a/delphi-checks/src/test/java/au/com/integradev/delphi/checks/ImplicitDefaultEncodingCheckTest.java
+++ b/delphi-checks/src/test/java/au/com/integradev/delphi/checks/ImplicitDefaultEncodingCheckTest.java
@@ -1,0 +1,279 @@
+/*
+ * Sonar Delphi Plugin
+ * Copyright (C) 2023 Integrated Application Development
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02
+ */
+package au.com.integradev.delphi.checks;
+
+import au.com.integradev.delphi.builders.DelphiTestUnitBuilder;
+import au.com.integradev.delphi.checks.verifier.CheckVerifier;
+import org.junit.jupiter.api.Test;
+
+class ImplicitDefaultEncodingCheckTest {
+  private DelphiTestUnitBuilder getSystem() {
+    return new DelphiTestUnitBuilder()
+        .unitName("System")
+        .appendDecl("type")
+        .appendDecl("  TObject = class")
+        .appendDecl("  end;")
+        .appendDecl("  IInterface = interface")
+        .appendDecl("  end;")
+        .appendDecl("  TClassHelperBase = class")
+        .appendDecl("  end;")
+        .appendDecl("  TVarRec = record")
+        .appendDecl("  end;")
+        .appendDecl("  RawByteString = type AnsiString($ffff);")
+        .appendDecl("  TArray<T> = array of T;");
+  }
+
+  private DelphiTestUnitBuilder getSystemClasses() {
+    return new DelphiTestUnitBuilder()
+        .unitName("System.Classes")
+        .appendDecl("uses System.SysUtils;")
+        .appendDecl("type")
+        .appendDecl("  TStream = class(TObject)")
+        .appendDecl("  end;")
+        .appendDecl("  TStrings = class(TObject)")
+        .appendDecl("  public")
+        .appendDecl("    procedure LoadFromFile(const FileName: string); overload; virtual;")
+        .appendDecl("    procedure LoadFromFile(")
+        .appendDecl("      const FileName: string; Encoding: TEncoding); overload; virtual;")
+        .appendDecl("    procedure LoadFromStream(Stream: TStream); overload; virtual;")
+        .appendDecl("    procedure LoadFromStream(")
+        .appendDecl("      Stream: TStream; Encoding: TEncoding); overload; virtual;")
+        .appendDecl("    procedure SaveToFile(const FileName: string); overload; virtual;")
+        .appendDecl("    procedure SaveToFile(")
+        .appendDecl("      const FileName: string; Encoding: TEncoding); overload; virtual;")
+        .appendDecl("    procedure SaveToStream(Stream: TStream); overload; virtual;")
+        .appendDecl("    procedure SaveToStream(")
+        .appendDecl("      Stream: TStream; Encoding: TEncoding); overload; virtual;")
+        .appendDecl("  end;")
+        .appendDecl("  TBytesStream = class(TStream);")
+        .appendDecl("  TStringStream = class(TBytesStream)")
+        .appendDecl("  public")
+        .appendDecl("    constructor Create; overload;")
+        .appendDecl("    constructor Create(const AString: string); overload;")
+        .appendDecl("    constructor Create(const AString: RawByteString); overload;")
+        .appendDecl("    constructor Create(")
+        .appendDecl("      const AString: string;")
+        .appendDecl("      AEncoding: TEncoding;")
+        .appendDecl("      AOwnsEncoding: Boolean = True")
+        .appendDecl("    ); overload;")
+        .appendDecl("    constructor Create(const AString: string; ACodePage: Integer); overload;")
+        .appendDecl("    constructor Create(const ABytes: TBytes); overload;")
+        .appendDecl("  end;")
+        .appendDecl("  TStreamReader = class(TObject)")
+        .appendDecl("  public")
+        .appendDecl("    constructor Create(Stream: TStream); overload;")
+        .appendDecl("    constructor Create(Stream: TStream; DetectBOM: Boolean); overload;")
+        .appendDecl("    constructor Create(")
+        .appendDecl("      Stream: TStream;")
+        .appendDecl("      Encoding: TEncoding;")
+        .appendDecl("      DetectBOM: Boolean = False;")
+        .appendDecl("      BufferSize: Integer = 4096")
+        .appendDecl("    ); overload;")
+        .appendDecl("    constructor Create(const Filename: string); overload;")
+        .appendDecl("    constructor Create(const Filename: string; DetectBOM: Boolean); overload;")
+        .appendDecl("    constructor Create(const Filename: string; Encoding: TEncoding;")
+        .appendDecl("    DetectBOM: Boolean = False; BufferSize: Integer = 4096); overload;")
+        .appendDecl("  end;")
+        .appendDecl("  TStreamWriter = class(TObject)")
+        .appendDecl("  public")
+        .appendDecl("    constructor Create(Stream: TStream); overload;")
+        .appendDecl("    constructor Create(")
+        .appendDecl("      Stream: TStream;")
+        .appendDecl("      Encoding: TEncoding;")
+        .appendDecl("      BufferSize: Integer = 4096")
+        .appendDecl("    ); overload;")
+        .appendDecl("    constructor Create(")
+        .appendDecl("      const Filename: string;")
+        .appendDecl("      Append: Boolean = False")
+        .appendDecl("    ); overload;")
+        .appendDecl("    constructor Create(")
+        .appendDecl("      const Filename: string;")
+        .appendDecl("      Append: Boolean;")
+        .appendDecl("      Encoding: TEncoding;")
+        .appendDecl("      BufferSize: Integer = 4096")
+        .appendDecl("    ); overload;")
+        .appendDecl("  end;");
+  }
+
+  private DelphiTestUnitBuilder getSystemSysUtils() {
+    return new DelphiTestUnitBuilder()
+        .unitName("System.SysUtils")
+        .appendDecl("type")
+        .appendDecl("  TBytes = TArray<Byte>;")
+        .appendDecl("  TEncoding = class(TObject)")
+        .appendDecl("  end;");
+  }
+
+  private DelphiTestUnitBuilder getVclOutline() {
+    return new DelphiTestUnitBuilder()
+        .unitName("Vcl.Outline")
+        .appendDecl("uses System.SysUtils, System.Classes;")
+        .appendDecl("type")
+        .appendDecl("  TOutlineNode = class(TObject)")
+        .appendDecl("  public")
+        .appendDecl("     procedure WriteNode(")
+        .appendDecl("       Buffer: TBytes;")
+        .appendDecl("       Stream: TStream")
+        .appendDecl("     ); overload; deprecated;")
+        .appendDecl("     procedure WriteNode(")
+        .appendDecl("       Buffer: PChar;")
+        .appendDecl("       Stream: TStream")
+        .appendDecl("     ); overload; deprecated;")
+        .appendDecl("     procedure WriteNode(Stream: TStream; Encoding: TEncoding); overload;")
+        .appendDecl("  end;")
+        .appendDecl("  TCustomOutline = class(TObject)")
+        .appendDecl("  public")
+        .appendDecl("    procedure LoadFromFile(const FileName: string); overload;")
+        .appendDecl("    procedure LoadFromFile(")
+        .appendDecl("      const FileName: string;")
+        .appendDecl("      Encoding: TEncoding")
+        .appendDecl("    ); overload;")
+        .appendDecl("    procedure LoadFromStream(Stream: TStream); overload;")
+        .appendDecl("    procedure LoadFromStream(Stream: TStream; Encoding: TEncoding); overload;")
+        .appendDecl("    procedure SaveToFile(const FileName: string); overload;")
+        .appendDecl("    procedure SaveToFile(")
+        .appendDecl("      const FileName: string;")
+        .appendDecl("      Encoding: TEncoding")
+        .appendDecl("    ); overload;")
+        .appendDecl("    procedure SaveToFile(")
+        .appendDecl("      const FileName: string;")
+        .appendDecl("      Encoding: TEncoding")
+        .appendDecl("    ); overload;")
+        .appendDecl("    procedure SaveToStream(Stream: TStream); overload;")
+        .appendDecl("    procedure SaveToStream(Stream: TStream; Encoding: TEncoding); overload;")
+        .appendDecl("  end; ");
+  }
+
+  @Test
+  void testUnrelatedFunctionInvocationShouldNotAddIssue() {
+    CheckVerifier.newVerifier()
+        .withCheck(new ImplicitDefaultEncodingCheck())
+        .onFile(
+            new DelphiTestUnitBuilder()
+                .appendImpl("procedure Unrelated; begin end;")
+                .appendImpl("procedure Unrelated(Str: String); begin end;")
+                .appendImpl("procedure Test;")
+                .appendImpl("begin")
+                .appendImpl("  Unrelated;")
+                .appendImpl("  Unrelated('abc');")
+                .appendImpl("end;"))
+        .verifyNoIssues();
+  }
+
+  @Test
+  void testPermittedOverloadsShouldNotAddIssue() {
+    CheckVerifier.newVerifier()
+        .withCheck(new ImplicitDefaultEncodingCheck())
+        .withStandardLibraryUnit(getSystem())
+        .withStandardLibraryUnit(getSystemSysUtils())
+        .withStandardLibraryUnit(getSystemClasses())
+        .withStandardLibraryUnit(getVclOutline())
+        .onFile(
+            new DelphiTestUnitBuilder()
+                .appendImpl("uses System.SysUtils, System.Classes, Vcl.Controls;")
+                .appendImpl("procedure Test;")
+                .appendImpl("var")
+                .appendImpl("  Node: TOutlineNode;")
+                .appendImpl("  Outline: TCustomOutline;")
+                .appendImpl("  Strings: TStrings;")
+                .appendImpl("  StringStream: TStringStream;")
+                .appendImpl("  StreamReader: TStreamReader;")
+                .appendImpl("  StreamWriter: TStreamWriter;")
+                .appendImpl("  StringArg: String;")
+                .appendImpl("  IntegerArg: Integer;")
+                .appendImpl("  BooleanArg: Boolean;")
+                .appendImpl("  Encoding: TEncoding;")
+                .appendImpl("begin")
+                .appendImpl("  Node.WriteNode(StreamArg, Encoding);")
+                .appendImpl("  Outline.LoadFromFile(StringArg, Encoding);")
+                .appendImpl("  Outline.LoadFromStream(StreamArg, Encoding);")
+                .appendImpl("  Outline.SaveToFile(StringArg, Encoding);")
+                .appendImpl("  Outline.SaveToStream(StreamArg, Encoding);")
+                .appendImpl("  Strings.LoadFromFile(StringArg, Encoding);")
+                .appendImpl("  Strings.LoadFromStream(StreamArg, Encoding);")
+                .appendImpl("  Strings.SaveToFile(StringArg, Encoding);")
+                .appendImpl("  Strings.SaveToStream(StreamArg, Encoding);")
+                .appendImpl("  StringStream.Create(StringArg, Encoding);")
+                .appendImpl("  StringStream.Create(StringArg, Encoding, BooleanArg);")
+                .appendImpl("  StringStream.Create(StringArg, nil);")
+                .appendImpl("  StringStream.Create(StringArg, nil, BooleanArg);")
+                .appendImpl("  StringStream.Create(StringArg, IntegerArg);")
+                .appendImpl("  StreamReader.Create(StreamArg, Encoding);")
+                .appendImpl("  StreamReader.Create(StringArg, Encoding);")
+                .appendImpl("  StreamReader.Create(StreamArg, Encoding, BooleanArg);")
+                .appendImpl("  StreamReader.Create(StringArg, Encoding, BooleanArg);")
+                .appendImpl("  StreamReader.Create(StreamArg, Encoding, BooleanArg, IntegerArg);")
+                .appendImpl("  StreamReader.Create(StringArg, Encoding, BooleanArg, IntegerArg);")
+                .appendImpl("  StreamWriter.Create(StreamArg, Encoding);")
+                .appendImpl("  StreamWriter.Create(StreamArg, Encoding, IntegerArg);")
+                .appendImpl("  StreamWriter.Create(StringArg, BooleanArg, Encoding);")
+                .appendImpl("  StreamWriter.Create(StringArg, BooleanArg, Encoding, IntegerArg);")
+                .appendImpl("end;"))
+        .verifyNoIssues();
+  }
+
+  @Test
+  void testForbiddenOverloadsAddIssues() {
+    CheckVerifier.newVerifier()
+        .withCheck(new ImplicitDefaultEncodingCheck())
+        .withStandardLibraryUnit(getSystem())
+        .withStandardLibraryUnit(getSystemSysUtils())
+        .withStandardLibraryUnit(getSystemClasses())
+        .withStandardLibraryUnit(getVclOutline())
+        .onFile(
+            new DelphiTestUnitBuilder()
+                .appendImpl("uses System.SysUtils, System.Classes, Vcl.Outline;")
+                .appendImpl("procedure Test;")
+                .appendImpl("var")
+                .appendImpl("  Node: TOutlineNode;")
+                .appendImpl("  Outline: TCustomOutline;")
+                .appendImpl("  Strings: TStrings;")
+                .appendImpl("  StringStream: TStringStream;")
+                .appendImpl("  StreamReader: TStreamReader;")
+                .appendImpl("  StreamWriter: TStreamWriter;")
+                .appendImpl("  StringArg: String;")
+                .appendImpl("  PCharArg: PChar;")
+                .appendImpl("  StreamArg: TStream;")
+                .appendImpl("  RawByteStringArg: RawByteString;")
+                .appendImpl("  BytesArg: TBytes;")
+                .appendImpl("  BooleanArg: Boolean;")
+                .appendImpl("begin")
+                .appendImpl("  Node.WriteNode(BytesArg, StreamArg); // Noncompliant")
+                .appendImpl("  Node.WriteNode(PCharArg, StreamArg); // Noncompliant")
+                .appendImpl("  Outline.LoadFromFile(StringArg); // Noncompliant")
+                .appendImpl("  Outline.LoadFromStream(StreamArg); // Noncompliant")
+                .appendImpl("  Outline.SaveToFile(StringArg); // Noncompliant")
+                .appendImpl("  Outline.SaveToStream(StreamArg); // Noncompliant")
+                .appendImpl("  Strings.LoadFromFile(StringArg); // Noncompliant")
+                .appendImpl("  Strings.LoadFromStream(StreamArg); // Noncompliant")
+                .appendImpl("  Strings.SaveToFile(StringArg); // Noncompliant")
+                .appendImpl("  Strings.SaveToStream(StreamArg); // Noncompliant")
+                .appendImpl("  StringStream.Create; // Noncompliant")
+                .appendImpl("  StringStream.Create(StringArg); // Noncompliant")
+                .appendImpl("  StringStream.Create(RawByteStringArg); // Noncompliant")
+                .appendImpl("  StringStream.Create(BytesArg); // Noncompliant")
+                .appendImpl("  StreamReader.Create(StreamArg); // Noncompliant")
+                .appendImpl("  StreamReader.Create(StreamArg, BooleanArg); // Noncompliant")
+                .appendImpl("  StreamWriter.Create(StreamArg); // Noncompliant")
+                .appendImpl("  StreamWriter.Create(StringArg); // Noncompliant")
+                .appendImpl("  StreamWriter.Create(StringArg, BooleanArg); // Noncompliant")
+                .appendImpl("end;"))
+        .verifyIssues();
+  }
+}


### PR DESCRIPTION
This rule ensures that the TEncoding behaviour of the standard library function is explicit. By forbidding certain overloads that internally use the TEncoding.Default type, this rule can ensure expected behaviour in the encodings of the files and streams in question.  