### PR TITLE
Include DCCReference files in project analysis

### DIFF
--- a/src/main/java/org/sonar/plugins/delphi/DelphiSensor.java
+++ b/src/main/java/org/sonar/plugins/delphi/DelphiSensor.java
@@ -96,7 +96,7 @@ public class DelphiSensor implements Sensor {
     TypeFactory typeFactory = new TypeFactory(toolchain, compilerVersion);
     Iterable<InputFile> inputFiles = delphiProjectHelper.mainFiles();
     List<Path> sourceFiles = inputFilesToPaths(inputFiles);
-
+    List<Path> referencedFiles = delphiProjectHelper.getReferencedFiles();
     List<Path> searchPathDirectories = new ArrayList<>();
     searchPathDirectories.addAll(delphiProjectHelper.getSearchDirectories());
     searchPathDirectories.addAll(delphiProjectHelper.getDebugSourceDirectories());
@@ -106,6 +106,7 @@ public class DelphiSensor implements Sensor {
         SymbolTable.builder()
             .typeFactory(typeFactory)
             .sourceFiles(sourceFiles)
+            .referencedFiles(referencedFiles)
             .encoding(delphiProjectHelper.encoding())
             .searchPath(searchPath)
             .conditionalDefines(delphiProjectHelper.getConditionalDefines())

--- a/src/main/java/org/sonar/plugins/delphi/msbuild/DelphiProjectHelper.java
+++ b/src/main/java/org/sonar/plugins/delphi/msbuild/DelphiProjectHelper.java
@@ -70,6 +70,7 @@ public class DelphiProjectHelper {
   private final CompilerVersion compilerVersion;
   private final List<Path> searchDirectories;
   private final List<Path> debugSourceDirectories;
+  private final List<Path> referencedFiles;
   private final Set<String> conditionalDefines;
   private final Set<String> unitScopeNames;
   private final Map<String, String> unitAliases;
@@ -93,6 +94,7 @@ public class DelphiProjectHelper {
     this.compilerVersion = getCompilerVersionFromSettings();
     this.searchDirectories = getSearchDirectoriesFromSettings();
     this.debugSourceDirectories = new ArrayList<>();
+    this.referencedFiles = new ArrayList<>();
     this.conditionalDefines = getPredefinedConditionalDefines();
     this.unitScopeNames = getSetFromSettings(DelphiPlugin.UNIT_SCOPE_NAMES_KEY);
     this.unitAliases = getUnitAliasesFromSettings();
@@ -201,6 +203,7 @@ public class DelphiProjectHelper {
       searchDirectories.addAll(project.getSearchDirectories());
       debugSourceDirectories.addAll(project.getDebugSourceDirectories());
       conditionalDefines.addAll(project.getConditionalDefines());
+      referencedFiles.addAll(project.getSourceFiles());
       unitScopeNames.addAll(project.getUnitScopeNames());
       unitAliases.putAll(project.getUnitAliases());
     }
@@ -340,6 +343,11 @@ public class DelphiProjectHelper {
   public Map<String, String> getUnitAliases() {
     indexProjects();
     return unitAliases;
+  }
+
+  public List<Path> getReferencedFiles() {
+    indexProjects();
+    return referencedFiles;
   }
 
   public Iterable<InputFile> mainFiles() {

--- a/src/main/java/org/sonar/plugins/delphi/symbol/SymbolTableBuilder.java
+++ b/src/main/java/org/sonar/plugins/delphi/symbol/SymbolTableBuilder.java
@@ -74,6 +74,7 @@ public class SymbolTableBuilder {
   private Path standardLibraryPath;
   private SearchPath searchPath = SearchPath.create(Collections.emptyList());
   private List<Path> sourceFiles = Collections.emptyList();
+  private List<Path> referencedFiles = Collections.emptyList();
   private Set<String> conditionalDefines = Collections.emptySet();
   private Set<String> unitScopeNames = Collections.emptySet();
   private Map<String, String> unitAliases = Collections.emptyMap();
@@ -93,6 +94,11 @@ public class SymbolTableBuilder {
 
   public SymbolTableBuilder sourceFiles(@NotNull List<Path> sourceFiles) {
     this.sourceFiles = sourceFiles;
+    return this;
+  }
+
+  public SymbolTableBuilder referencedFiles(@NotNull List<Path> referencedFiles) {
+    this.referencedFiles = referencedFiles;
     return this;
   }
 
@@ -431,6 +437,7 @@ public class SymbolTableBuilder {
 
     processStandardLibrarySearchPaths();
     searchPath.getRootDirectories().forEach(this::processSearchPath);
+    referencedFiles.forEach(file -> this.createUnitData(file, false));
     sourceFiles.forEach(file -> this.createUnitData(file, true));
 
     ProgressReport progressReport =


### PR DESCRIPTION
Delphi source files can be included in a `.dproj` using `DCCReference` tags. Although SonarDelphi parses `DCCReference` tags, it doesn't currently generate unit data for units referenced in that way - meaning that if a scan does not include a source file explicitly, SonarDelphi won't be able to find it.

This PR treats `DCCReference` source files in the same way as files found in search directories - by generating non-source file unit data for them.