### PR TITLE
Allow anonymous methods in array constructor expressions

### DIFF
--- a/src/main/antlr3/org/sonar/plugins/delphi/antlr/Delphi.g
+++ b/src/main/antlr3/org/sonar/plugins/delphi/antlr/Delphi.g
@@ -630,9 +630,14 @@ expressionOrRange            : expression ('..'<RangeExpressionNode>^ expression
 expressionOrAnonymousMethod  : anonymousMethod
                              | expression
                              ;
+exprOrRangeOrAnonMethod      : anonymousMethod
+                             | expression ('..'<RangeExpressionNode>^ expression)?
+                             ;
 expressionList               : (expression (','!)?)+
                              ;
 expressionOrRangeList        : (expressionOrRange (','!)?)+
+                             ;
+exprOrRangeOrAnonMethodList  : (exprOrRangeOrAnonMethod (','!)?)+
                              ;
 textLiteral                  : textLiteral_ -> ^(TkTextLiteral<TextLiteralNode> textLiteral_)
                              ;
@@ -644,8 +649,8 @@ escapedCharacter             : TkCharacterEscapeCode
                              ;
 nilLiteral                   : 'nil'<NilLiteralNode>
                              ;
-arrayConstructor             : lbrack expressionOrRangeList? rbrack
-                             -> ^(TkArrayConstructor<ArrayConstructorNode> lbrack expressionOrRangeList? rbrack)
+arrayConstructor             : lbrack exprOrRangeOrAnonMethodList? rbrack
+                             -> ^(TkArrayConstructor<ArrayConstructorNode> lbrack exprOrRangeOrAnonMethodList? rbrack)
                              ;
 addOperator                  : '+'<BinaryExpressionNode>
                              | '-'<BinaryExpressionNode>
@@ -684,7 +689,7 @@ recordExpression             : '('<RecordExpressionNode>^ (recordExpressionItem 
 recordExpressionItem         : ident ':' constExpression
                              -> ^(TkRecordExpressionItem<RecordExpressionItemNode> ident constExpression)
                              ;
-arrayExpression              : '('<ArrayExpressionNode>^ (constExpression (','!)?)* ')'
+arrayExpression              : '('<ArrayExpressionNode>^ (expression (','!)?)* ')'
                              ;
 
 //----------------------------------------------------------------------------

--- a/src/test/java/org/sonar/plugins/delphi/antlr/GrammarTest.java
+++ b/src/test/java/org/sonar/plugins/delphi/antlr/GrammarTest.java
@@ -176,6 +176,11 @@ class GrammarTest {
   }
 
   @Test
+  void testArrayWithAnonymousMethods() {
+    parseFile("ArrayWithAnonymousMethods.pas");
+  }
+
+  @Test
   void testRecordHelperConstants() {
     parseFile("RecordHelperConstants.pas");
   }

--- a/src/test/resources/org/sonar/plugins/delphi/grammar/ArrayWithAnonymousMethods.pas
+++ b/src/test/resources/org/sonar/plugins/delphi/grammar/ArrayWithAnonymousMethods.pas
@@ -1,0 +1,19 @@
+unit ArrayWithAnonymousMethods;
+
+interface
+
+implementation
+
+uses System.Generics.Collections;
+
+procedure Test;
+var
+  MyArr: TArray<string>;
+begin
+  MyArr := [
+    procedure begin
+    end
+  ];
+end;
+
+end.


### PR DESCRIPTION
Delphi allows anonymous method expressions in array constructor expressions, but SonarDelphi currently does not. For example:

```pascal
procedure Test;
var
  MyArr: TArray<string>;
begin
  MyArr := [
    procedure begin
    end
  ];
end;
```

This PR modifies the grammar to permit this in SonarDelphi.