### PR TITLE
Fix typo in build action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,7 @@ jobs:
       HTTP_PROXY_PORT: ''
     steps:
       - uses: actions/checkout@v3
-      - name: Setup JDK 11
+      - name: Setup Java
         uses: actions/setup-java@v3
         with:
           java-version: '17'


### PR DESCRIPTION
In #35 the Build workflow was upgraded to Java 17, but the name of the step was unchanged at "Setup JDK 11". This PR fixes this incorrect name by replacing it with the less opinionated "Setup Java".