### PR TITLE
Include slf4j-simple in tests

### DIFF
--- a/delphi-checks-testkit/pom.xml
+++ b/delphi-checks-testkit/pom.xml
@@ -27,6 +27,12 @@
       <version>${slf4j.version}</version>
       <scope>provided</scope>
     </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-simple</artifactId>
+      <version>${slf4j.version}</version>
+      <scope>test</scope>
+    </dependency>
 
     <dependency>
       <groupId>org.sonarsource.api.plugin</groupId>

--- a/delphi-checks/pom.xml
+++ b/delphi-checks/pom.xml
@@ -27,6 +27,12 @@
       <version>${slf4j.version}</version>
       <scope>provided</scope>
     </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-simple</artifactId>
+      <version>${slf4j.version}</version>
+      <scope>test</scope>
+    </dependency>
 
     <dependency>
       <groupId>org.sonarsource.analyzer-commons</groupId>

--- a/delphi-frontend/pom.xml
+++ b/delphi-frontend/pom.xml
@@ -30,6 +30,12 @@
       <version>${slf4j.version}</version>
       <scope>provided</scope>
     </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-simple</artifactId>
+      <version>${slf4j.version}</version>
+      <scope>test</scope>
+    </dependency>
 
     <dependency>
       <groupId>com.google.guava</groupId>

--- a/docs/delphi-custom-rules-example/pom.xml
+++ b/docs/delphi-custom-rules-example/pom.xml
@@ -77,6 +77,12 @@
       <version>${slf4j.version}</version>
       <scope>provided</scope>
     </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-simple</artifactId>
+      <version>${slf4j.version}</version>
+      <scope>test</scope>
+    </dependency>
 
     <dependency>
       <groupId>au.com.integradev.delphi</groupId>

--- a/sonar-delphi-plugin/pom.xml
+++ b/sonar-delphi-plugin/pom.xml
@@ -44,6 +44,12 @@
       <version>${slf4j.version}</version>
       <scope>provided</scope>
     </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-simple</artifactId>
+      <version>${slf4j.version}</version>
+      <scope>test</scope>
+    </dependency>
 
     <dependency>
       <groupId>org.sonarsource.api.plugin</groupId>


### PR DESCRIPTION
In commit [ca64fa4](https://github.com/integrated-application-development/sonar-delphi/commit/ca64fa43b4ebe9cd6b986b62bb38da68fcedf2e9), SonarDelphi's internal logging was migrated to SLF4J, which SonarQube automatically provides in the plugin context. When running tests, however, there is no SLF4J implementation provided, which produces an error message and falls back to a no-op logger.

This PR includes slf4j-simple as a test dependency, which provides a simple logging implementation that writes all logs to standard error.