### PR TITLE
Add method declarations and implementations to UnitLevelKeywordIndentation rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Exclude dpr and dpk files in `UnusedImport`.
 - Exclude dpr and dpk files in `ImportSpecificity`.
 - Exclude uses clauses of dpr and dpk files in `LineTooLong`.
+- Include methods in `UnitLevelKeywordIndentation`.
 - Always enforce the `Attribute` suffix in `AttributeName`.
 - Improve name resolution for declarations within types.
 - Improve type resolution for array accesses into variants.

--- a/delphi-checks/src/test/java/au/com/integradev/delphi/checks/UnitLevelKeywordIndentationCheckTest.java
+++ b/delphi-checks/src/test/java/au/com/integradev/delphi/checks/UnitLevelKeywordIndentationCheckTest.java
@@ -46,7 +46,7 @@ class UnitLevelKeywordIndentationCheckTest {
     CheckVerifier.newVerifier()
         .withCheck(new UnitLevelKeywordIndentationCheck())
         .onFile(DelphiTestFileBuilder.fromResource(INDENTED_PAS))
-        .verifyIssueOnLine(1, 3, 5, 9, 13, 15, 19, 23, 25, 27);
+        .verifyIssueOnLine(1, 3, 5, 9, 13, 15, 17, 21, 28, 29, 31, 33, 34, 36, 38, 40, 42);
   }
 
   @Test

--- a/delphi-checks/src/test/resources/au/com/integradev/delphi/checks/UnitLevelKeywordIndentationCheck/Correct.pas
+++ b/delphi-checks/src/test/resources/au/com/integradev/delphi/checks/UnitLevelKeywordIndentationCheck/Correct.pas
@@ -10,6 +10,8 @@ type
   TMyObject = class(TObject)
   end;
 
+procedure MyProc;
+
 implementation
 
 uses
@@ -17,8 +19,20 @@ uses
   Math;
 
 type
-  TMyObject = class(TObject)
+  TMyOtherObject = class(TObject)
+  private
+    class procedure MyClassProc;
   end;
+
+class procedure TMyOtherObject.MyClassProc;
+begin
+  Writeln('Hello world');
+end;
+
+procedure MyProc;
+begin
+  Writeln('Hello world');
+end;
 
 initialization
 

--- a/delphi-checks/src/test/resources/au/com/integradev/delphi/checks/UnitLevelKeywordIndentationCheck/Indented.pas
+++ b/delphi-checks/src/test/resources/au/com/integradev/delphi/checks/UnitLevelKeywordIndentationCheck/Indented.pas
@@ -10,6 +10,8 @@
     TMyObject = class(TObject)
     end;
 
+    procedure MyProc;
+
         implementation
 
       uses
@@ -17,8 +19,21 @@
       Math;
 
     type
-        TMyObject = class(TObject)
+        TMyOtherObject = class(TObject)
+        private
+          class procedure MyClassProc;
         end;
+
+
+  class procedure TMyOtherObject.MyClassProc;
+  begin
+    Writeln('Hello world');
+  end;
+
+  procedure MyProc;
+  begin
+    Writeln('Hello world');
+  end;
 
  initialization
 


### PR DESCRIPTION
This PR expands the UnitLevelKeywordIndentation rule to also pick up unindented:

- Top-level method declarations (i.e. not in a type section)
- Method implementation headings
- `begin` and `end` keywords for method implementations

To reflect that it is now handling more than just single keywords, the message has also been changed to "Unindent this top-level statement."