### PR TITLE
Ignore legitimately out-of-order visibility sections in VisibilitySectionOrder

### DIFF
--- a/delphi-checks/src/main/resources/org/sonar/l10n/delphi/rules/community-delphi/VisibilitySectionOrder.html
+++ b/delphi-checks/src/main/resources/org/sonar/l10n/delphi/rules/community-delphi/VisibilitySectionOrder.html
@@ -12,6 +12,24 @@
   <li>public</li>
   <li>published</li>
 </ol>
+<h3>Exceptions</h3>
+<p>
+  This rule excludes cases where visibility sections declare a member that is used in later
+  visibility sections, such as the below:
+</p>
+<pre>
+type
+  TMyType = class(TObject)
+  public
+    type
+      TMySubType = class(TObject);
+      end;
+  private
+    procedure DoSecretThing(Obj: TMySubType);
+  public
+    procedure DoPublicThing(Obj: TMySubType);
+  end;
+</pre>
 <h2>How to fix it</h2>
 <p>Reorder the visibility sections within the type declaration into ascending order.</p>
 <h2>Resources</h2>

--- a/delphi-checks/src/test/java/au/com/integradev/delphi/checks/VisibilitySectionOrderCheckTest.java
+++ b/delphi-checks/src/test/java/au/com/integradev/delphi/checks/VisibilitySectionOrderCheckTest.java
@@ -84,7 +84,7 @@ class VisibilitySectionOrderCheckTest {
             new DelphiTestUnitBuilder()
                 .appendDecl("type")
                 .appendDecl("  TFoo = class(TObject)")
-                .appendDecl("  public // Noncompliant")
+                .appendDecl("  public")
                 .appendDecl("    procedure Bar;")
                 .appendDecl("    property Baz: Integer;")
                 .appendDecl("  public")
@@ -115,6 +115,44 @@ class VisibilitySectionOrderCheckTest {
   }
 
   @Test
+  void testMultipleReferencedOutOfOrderSectionsShouldNotAddIssue() {
+    CheckVerifier.newVerifier()
+        .withCheck(new VisibilitySectionOrderCheck())
+        .onFile(
+            new DelphiTestUnitBuilder()
+                .appendDecl("type")
+                .appendDecl("  TFoo = class(TObject)")
+                .appendDecl("  public")
+                .appendDecl("    type TBar = string;")
+                .appendDecl("  public")
+                .appendDecl("    const CBaz = 'abcd';")
+                .appendDecl("  private")
+                .appendDecl("    procedure Flarp(Arg: TBar = CBaz);")
+                .appendDecl(" end;"))
+        .verifyNoIssues();
+  }
+
+  @Test
+  void testOutOfOrderSectionAfterMultipleReferencedOutOfOrderSectionsShouldAddIssue() {
+    CheckVerifier.newVerifier()
+        .withCheck(new VisibilitySectionOrderCheck())
+        .onFile(
+            new DelphiTestUnitBuilder()
+                .appendDecl("type")
+                .appendDecl("  TFoo = class(TObject)")
+                .appendDecl("  protected")
+                .appendDecl("    FMyVar: Integer;")
+                .appendDecl("  public")
+                .appendDecl("    type TBar = string;")
+                .appendDecl("  public")
+                .appendDecl("    const CBaz = 'abcd';")
+                .appendDecl("  private // Noncompliant")
+                .appendDecl("    procedure Flarp(Arg: TBar = CBaz);")
+                .appendDecl(" end;"))
+        .verifyIssues();
+  }
+
+  @Test
   void testImplicitPublishedFollowedByPrivateShouldNotAddIssue() {
     CheckVerifier.newVerifier()
         .withCheck(new VisibilitySectionOrderCheck())
@@ -125,6 +163,111 @@ class VisibilitySectionOrderCheckTest {
                 .appendDecl("    procedure Bar;")
                 .appendDecl("  private")
                 .appendDecl("    procedure Baz;")
+                .appendDecl(" end;"))
+        .verifyNoIssues();
+  }
+
+  @Test
+  void testOutOfOrderUnreferencedVisibilitySectionShouldAddIssue() {
+    CheckVerifier.newVerifier()
+        .withCheck(new VisibilitySectionOrderCheck())
+        .onFile(
+            new DelphiTestUnitBuilder()
+                .appendDecl("type")
+                .appendDecl("  TFoo = class(TObject)")
+                .appendDecl("  public")
+                .appendDecl("    const")
+                .appendDecl("      CMyConst = 'abcd';")
+                .appendDecl("    type")
+                .appendDecl("      TBar = TFlarp;")
+                .appendDecl("    FZorp: string;")
+                .appendDecl("    function GetMyInt: Integer;")
+                .appendDecl("  private // Noncompliant")
+                .appendDecl("    procedure Baz;")
+                .appendDecl(" end;"))
+        .verifyIssues();
+  }
+
+  @Test
+  void testOutOfOrderVisibilitySectionWithReferencedConstantShouldNotAddIssue() {
+    CheckVerifier.newVerifier()
+        .withCheck(new VisibilitySectionOrderCheck())
+        .onFile(
+            new DelphiTestUnitBuilder()
+                .appendDecl("type")
+                .appendDecl("  TFoo = class(TObject)")
+                .appendDecl("  public")
+                .appendDecl("    const")
+                .appendDecl("      CMyConst = 'abcd';")
+                .appendDecl("    type")
+                .appendDecl("      TBar = TFlarp;")
+                .appendDecl("    FZorp: string;")
+                .appendDecl("    function GetMyInt: Integer;")
+                .appendDecl("  private")
+                .appendDecl("    procedure Baz(MyArg: string = CMyConst);")
+                .appendDecl(" end;"))
+        .verifyNoIssues();
+  }
+
+  @Test
+  void testOutOfOrderVisibilitySectionWithReferencedTypeShouldNotAddIssue() {
+    CheckVerifier.newVerifier()
+        .withCheck(new VisibilitySectionOrderCheck())
+        .onFile(
+            new DelphiTestUnitBuilder()
+                .appendDecl("type")
+                .appendDecl("  TFoo = class(TObject)")
+                .appendDecl("  public")
+                .appendDecl("    const")
+                .appendDecl("      CMyConst = 'abcd';")
+                .appendDecl("    type")
+                .appendDecl("      TBar = TFlarp;")
+                .appendDecl("    FZorp: string;")
+                .appendDecl("    function GetMyInt: Integer;")
+                .appendDecl("  private")
+                .appendDecl("    procedure Baz(MyArg: TBar);")
+                .appendDecl(" end;"))
+        .verifyNoIssues();
+  }
+
+  @Test
+  void testOutOfOrderVisibilitySectionWithReferencedVarShouldNotAddIssue() {
+    CheckVerifier.newVerifier()
+        .withCheck(new VisibilitySectionOrderCheck())
+        .onFile(
+            new DelphiTestUnitBuilder()
+                .appendDecl("type")
+                .appendDecl("  TFoo = class(TObject)")
+                .appendDecl("  public")
+                .appendDecl("    const")
+                .appendDecl("      CMyConst = 'abcd';")
+                .appendDecl("    type")
+                .appendDecl("      TBar = TFlarp;")
+                .appendDecl("    FZorp: string;")
+                .appendDecl("    function GetMyInt: Integer;")
+                .appendDecl("  private")
+                .appendDecl("    property Baz: string read FZorp;")
+                .appendDecl(" end;"))
+        .verifyNoIssues();
+  }
+
+  @Test
+  void testOutOfOrderVisibilitySectionWithReferencedFunctionShouldNotAddIssue() {
+    CheckVerifier.newVerifier()
+        .withCheck(new VisibilitySectionOrderCheck())
+        .onFile(
+            new DelphiTestUnitBuilder()
+                .appendDecl("type")
+                .appendDecl("  TFoo = class(TObject)")
+                .appendDecl("  public")
+                .appendDecl("    const")
+                .appendDecl("      CMyConst = 'abcd';")
+                .appendDecl("    type")
+                .appendDecl("      TBar = TFlarp;")
+                .appendDecl("    FZorp: string;")
+                .appendDecl("    function GetMyInt: Integer;")
+                .appendDecl("  private")
+                .appendDecl("    property Baz: Integer read GetMyInt;")
                 .appendDecl(" end;"))
         .verifyNoIssues();
   }


### PR DESCRIPTION
The VisibilitySectionOrder check currently requires that visibility sections be exactly in ascending order of visibility. There are times in which this is impractical, particularly when public types or constants are then used in later declarations:

```delphi
type
  TFoo = class(TObject)
  public type
    TBar = class(TObject)
      // ...
    end;
  protected
    procedure ProtectedBarProc(Bar: TBar);
  public
    procedure PublicBarProc(Bar: TBar);
  end;
```

This PR excludes visibility sections with only a single `type` or `const` from being checked by the ordering rule.