### PR TITLE
Add 'AddressOfFirstChar' rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `DigitSeparator` analysis rule, which flags numeric literals that should use digit separators to
   improve readability.
 - `DigitGrouping` analysis rule, which flags numeric literals that use non-standard digit groupings.
+- `AddressOfCharacterData` analysis rule, which flags attempts to manually get the address of the
+  first character in a string.
 
 ### Changed
 

--- a/delphi-checks/src/main/java/au/com/integradev/delphi/checks/AddressOfCharacterDataCheck.java
+++ b/delphi-checks/src/main/java/au/com/integradev/delphi/checks/AddressOfCharacterDataCheck.java
@@ -1,0 +1,84 @@
+/*
+ * Sonar Delphi Plugin
+ * Copyright (C) 2023 Integrated Application Development
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02
+ */
+package au.com.integradev.delphi.checks;
+
+import org.sonar.check.Rule;
+import org.sonar.plugins.communitydelphi.api.ast.ArrayAccessorNode;
+import org.sonar.plugins.communitydelphi.api.ast.DelphiNode;
+import org.sonar.plugins.communitydelphi.api.ast.ExpressionNode;
+import org.sonar.plugins.communitydelphi.api.ast.IntegerLiteralNode;
+import org.sonar.plugins.communitydelphi.api.ast.NameReferenceNode;
+import org.sonar.plugins.communitydelphi.api.ast.Node;
+import org.sonar.plugins.communitydelphi.api.ast.UnaryExpressionNode;
+import org.sonar.plugins.communitydelphi.api.check.DelphiCheck;
+import org.sonar.plugins.communitydelphi.api.check.DelphiCheckContext;
+import org.sonar.plugins.communitydelphi.api.directive.SwitchDirective.SwitchKind;
+import org.sonar.plugins.communitydelphi.api.operator.UnaryOperator;
+
+@Rule(key = "AddressOfCharacterData")
+public class AddressOfCharacterDataCheck extends DelphiCheck {
+  @Override
+  public DelphiCheckContext visit(UnaryExpressionNode expressionNode, DelphiCheckContext context) {
+    ExpressionNode operand = expressionNode.getOperand().skipParentheses();
+    if (expressionNode.getOperator() == UnaryOperator.ADDRESS
+        && operand.getChildren().size() == 2
+        && isReferenceToString(operand.getChild(0))
+        && isArrayAccessToFirstChar(context, operand.getChild(1))) {
+      reportIssue(
+          context,
+          expressionNode,
+          "Cast this string to Pointer instead of addressing the first character.");
+    }
+
+    return super.visit(expressionNode, context);
+  }
+
+  private static boolean isArrayAccessToFirstChar(DelphiCheckContext context, DelphiNode second) {
+    if (!(second instanceof ArrayAccessorNode)) {
+      return false;
+    }
+    if (second.getChildren().size() != 1) {
+      return false;
+    }
+    return isLiteralForFirstCharIndex(context, second.getChild(0));
+  }
+
+  private static boolean isLiteralForFirstCharIndex(DelphiCheckContext context, DelphiNode inner) {
+    if (inner instanceof ExpressionNode) {
+      inner = ((ExpressionNode) inner).skipParentheses();
+    }
+    if (inner.getChildren().size() != 1) {
+      return false;
+    }
+    var intLiteral = inner.getFirstChildOfType(IntegerLiteralNode.class);
+
+    return intLiteral != null
+        && intLiteral.getValueAsInt() == (isZeroBasedStrings(intLiteral, context) ? 0 : 1);
+  }
+
+  private static boolean isReferenceToString(DelphiNode node) {
+    return node instanceof NameReferenceNode && ((NameReferenceNode) node).getType().isString();
+  }
+
+  private static boolean isZeroBasedStrings(Node expressionNode, DelphiCheckContext context) {
+    return context
+        .getCompilerSwitchRegistry()
+        .isActiveSwitch(SwitchKind.ZEROBASEDSTRINGS, expressionNode.getTokenIndex());
+  }
+}

--- a/delphi-checks/src/main/java/au/com/integradev/delphi/checks/CheckList.java
+++ b/delphi-checks/src/main/java/au/com/integradev/delphi/checks/CheckList.java
@@ -27,6 +27,7 @@ public final class CheckList {
   private static final List<Class<? extends DelphiCheck>> ALL_CHECKS =
       List.of(
           // Listed alphabetically
+          AddressOfCharacterDataCheck.class,
           AddressOfSubroutineCheck.class,
           AssertMessageCheck.class,
           AssignedAndFreeCheck.class,

--- a/delphi-checks/src/main/resources/org/sonar/l10n/delphi/rules/community-delphi/AddressOfCharacterData.html
+++ b/delphi-checks/src/main/resources/org/sonar/l10n/delphi/rules/community-delphi/AddressOfCharacterData.html
@@ -1,0 +1,30 @@
+<h2>Why is this an issue?</h2>
+<p>
+  Using an array index to compute the address of the first character in a string can lead to a range
+  check error if range checking is enabled and the string is empty. When range checking is disabled,
+  such an expression evaluates to <code>nil</code>. In all cases except that of empty strings with
+  range checking enabled, casting to an <i>untyped</i> pointer type is equivalent.
+</p>
+<p>
+  If a non-nil pointer is required, then the result of the cast can be checked and handled
+  appropriately.
+</p>
+<p>
+  This is especially relevant to interactions with the WinAPI, where strings are always passed by
+  character pointer.
+</p>
+
+<h2>How to fix it</h2>
+<p>
+  Cast the string to <code>Pointer</code> to get the address of the first character without the
+  possibility of a range check error.
+</p>
+
+<h2>Resources</h2>
+<ul>
+  <li>
+    <a href="https://docwiki.embarcadero.com/RADStudio/Alexandria/en/String_Types_(Delphi)#Mixing_Delphi_Strings_and_Null-Terminated_Strings">
+      RAD Studio documentation: String Types (Delphi)
+    </a>
+  </li>
+</ul>

--- a/delphi-checks/src/main/resources/org/sonar/l10n/delphi/rules/community-delphi/AddressOfCharacterData.json
+++ b/delphi-checks/src/main/resources/org/sonar/l10n/delphi/rules/community-delphi/AddressOfCharacterData.json
@@ -1,0 +1,19 @@
+{
+  "title": "The first character in a string should not be addressed by index.",
+  "type": "BUG",
+  "status": "ready",
+  "remediation": {
+    "func": "Constant/Issue",
+    "constantCost": "1min"
+  },
+  "code": {
+    "attribute": "logical",
+    "impacts": {
+      "RELIABILITY": "MEDIUM"
+    }
+  },
+  "tags": [],
+  "defaultSeverity": "Major",
+  "scope": "ALL",
+  "quickfix": "unknown"
+}

--- a/delphi-checks/src/main/resources/org/sonar/l10n/delphi/rules/community-delphi/Sonar_way_profile.json
+++ b/delphi-checks/src/main/resources/org/sonar/l10n/delphi/rules/community-delphi/Sonar_way_profile.json
@@ -1,6 +1,7 @@
 {
   "name": "Sonar way",
   "ruleKeys": [
+    "AddressOfCharacterData",
     "AddressOfSubroutine",
     "AssertMessage",
     "AssignedAndFree",

--- a/delphi-checks/src/test/java/au/com/integradev/delphi/checks/AddressOfCharacterDataCheckTest.java
+++ b/delphi-checks/src/test/java/au/com/integradev/delphi/checks/AddressOfCharacterDataCheckTest.java
@@ -1,0 +1,111 @@
+/*
+ * Sonar Delphi Plugin
+ * Copyright (C) 2023 Integrated Application Development
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02
+ */
+package au.com.integradev.delphi.checks;
+
+import au.com.integradev.delphi.builders.DelphiTestUnitBuilder;
+import au.com.integradev.delphi.checks.verifier.CheckVerifier;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+class AddressOfCharacterDataCheckTest {
+
+  @ParameterizedTest
+  @ValueSource(
+      strings = {
+        "@S[1]",
+        "@(S[1])",
+        "@S[(1)]",
+        "@S[Integer(@S[1])]",
+      })
+  void testAddressOfStringIndexedWithExpressionOfOneShouldAddIssue(String expr) {
+    CheckVerifier.newVerifier()
+        .withCheck(new AddressOfCharacterDataCheck())
+        .onFile(
+            new DelphiTestUnitBuilder()
+                .appendImpl("procedure Test;")
+                .appendImpl("var")
+                .appendImpl("  S: String;")
+                .appendImpl("begin")
+                .appendImpl("  " + expr)
+                .appendImpl("end;"))
+        .verifyIssueOnLine(11);
+  }
+
+  @ParameterizedTest
+  @ValueSource(
+      strings = {
+        "Pointer(S)",
+        "PChar(S)",
+      })
+  void testStringToPointerCastsShouldNotAddIssue(String expr) {
+    CheckVerifier.newVerifier()
+        .withCheck(new AddressOfCharacterDataCheck())
+        .onFile(
+            new DelphiTestUnitBuilder()
+                .appendImpl("procedure Test;")
+                .appendImpl("var")
+                .appendImpl("  S: String;")
+                .appendImpl("begin")
+                .appendImpl("  " + expr)
+                .appendImpl("end;"))
+        .verifyNoIssues();
+  }
+
+  @ParameterizedTest
+  @ValueSource(
+      strings = {
+        "String",
+        "UnicodeString",
+        "AnsiString",
+        "ShortString",
+      })
+  void testAddressOfAllStringTypesIndexedWithOneShouldAddIssue(String type) {
+    CheckVerifier.newVerifier()
+        .withCheck(new AddressOfCharacterDataCheck())
+        .onFile(
+            new DelphiTestUnitBuilder()
+                .appendImpl("procedure Test;")
+                .appendImpl("var")
+                .appendImpl("  S: " + type + ";")
+                .appendImpl("begin")
+                .appendImpl("  @S[1];")
+                .appendImpl("end;"))
+        .verifyIssueOnLine(11);
+  }
+
+  @Test
+  void testAddressOfStringIndexedWithZeroWhileZeroBasedStringsShouldAddIssue() {
+    CheckVerifier.newVerifier()
+        .withCheck(new AddressOfCharacterDataCheck())
+        .onFile(
+            new DelphiTestUnitBuilder()
+                .appendImpl("procedure Test;")
+                .appendImpl("var")
+                .appendImpl("  S: String;")
+                .appendImpl("begin")
+                .appendImpl("  @S[{$ZEROBASEDSTRINGS ON} 0]")
+                // This isn't quite correct, because the compiler actually effects the switch
+                // directive at the start of the [] context. We don't model that correctly yet.
+                .appendImpl("  @S[0 {$ZEROBASEDSTRINGS OFF}]")
+                .appendImpl("  @S[1]")
+                .appendImpl("end;"))
+        .verifyIssueOnLine(11, 12, 13);
+  }
+}


### PR DESCRIPTION
Adds a rule checking for code like `@S[1]` where `S` is a string type.

Such code results in a range check error when the string is empty, while `Pointer(S)` would return `nil`. In all other cases the pointer cast is equivalent. 

Note that a _typed_ pointer cast is not equivalent; `PChar('')` returns a pointer to a static null byte.

This rule is especially relevant for interaction with the WinAPI, where string arguments are always expected as character pointers.