### PR TITLE
Add 'IndexLastListElement' rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `AddressOfCharacterData` analysis rule, which flags attempts to manually get the address of the
   first character in a string.
 - `NonLinearCast` analysis rule, which flags unsafe object and pointer casts.
+- `IndexLastListElement` analysis rule, which flags places where `TList.Last` should be used instead
+  of manually indexing into the list.
 
 ### Changed
 

--- a/delphi-checks/src/main/java/au/com/integradev/delphi/checks/CheckList.java
+++ b/delphi-checks/src/main/java/au/com/integradev/delphi/checks/CheckList.java
@@ -81,6 +81,7 @@ public final class CheckList {
           HelperNameCheck.class,
           IfThenShortCircuitCheck.class,
           ImportSpecificityCheck.class,
+          IndexLastListElementCheck.class,
           InheritedMethodWithNoCodeCheck.class,
           InheritedTypeNameCheck.class,
           InlineAssemblyCheck.class,

--- a/delphi-checks/src/main/java/au/com/integradev/delphi/checks/IndexLastListElementCheck.java
+++ b/delphi-checks/src/main/java/au/com/integradev/delphi/checks/IndexLastListElementCheck.java
@@ -1,0 +1,117 @@
+/*
+ * Sonar Delphi Plugin
+ * Copyright (C) 2023 Integrated Application Development
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02
+ */
+package au.com.integradev.delphi.checks;
+
+import java.util.List;
+import java.util.Optional;
+import org.sonar.check.Rule;
+import org.sonar.plugins.communitydelphi.api.ast.ArrayAccessorNode;
+import org.sonar.plugins.communitydelphi.api.ast.BinaryExpressionNode;
+import org.sonar.plugins.communitydelphi.api.ast.CommonDelphiNode;
+import org.sonar.plugins.communitydelphi.api.ast.DelphiNode;
+import org.sonar.plugins.communitydelphi.api.ast.ExpressionNode;
+import org.sonar.plugins.communitydelphi.api.ast.IdentifierNode;
+import org.sonar.plugins.communitydelphi.api.ast.NameReferenceNode;
+import org.sonar.plugins.communitydelphi.api.check.DelphiCheck;
+import org.sonar.plugins.communitydelphi.api.check.DelphiCheckContext;
+import org.sonar.plugins.communitydelphi.api.operator.BinaryOperator;
+import org.sonar.plugins.communitydelphi.api.symbol.declaration.PropertyNameDeclaration;
+import org.sonar.plugins.communitydelphi.api.token.DelphiTokenType;
+
+@Rule(key = "IndexLastListElement")
+public class IndexLastListElementCheck extends DelphiCheck {
+
+  @Override
+  public DelphiCheckContext visit(ArrayAccessorNode arrayTypeNode, DelphiCheckContext context) {
+    doVisit(arrayTypeNode, context);
+
+    return super.visit(arrayTypeNode, context);
+  }
+
+  private void doVisit(ArrayAccessorNode arrayTypeNode, DelphiCheckContext context) {
+    List<ExpressionNode> expressions = arrayTypeNode.getExpressions();
+    if (expressions.size() != 1) {
+      return;
+    }
+    ExpressionNode indexExpr = expressions.get(0);
+
+    if (arrayTypeNode.getChildIndex() <= 0) {
+      return;
+    }
+    DelphiNode arrayVar = arrayTypeNode.getParent().getChild(arrayTypeNode.getChildIndex() - 1);
+
+    Optional.ofNullable(indexExpr)
+        .map(ExpressionNode::skipParentheses)
+        .filter(BinaryExpressionNode.class::isInstance)
+        .map(BinaryExpressionNode.class::cast)
+        .filter(b -> isSubOne(b))
+        .flatMap(b -> getArrayPropertyReference(b.getLeft(), arrayVar.getImage()))
+        .ifPresent(
+            propertyName -> {
+              if (propertyName.equalsIgnoreCase("System.Classes.TList.Count")) {
+                reportIssue(context, arrayTypeNode, "Use TList.Last.");
+              } else if (propertyName.equalsIgnoreCase(
+                  "System.Generics.Collections.TList<T>.Count")) {
+                reportIssue(context, arrayTypeNode, "Use TList<T>.Last.");
+              }
+            });
+  }
+
+  private static boolean isSubOne(BinaryExpressionNode binary) {
+    return binary.getOperator() == BinaryOperator.SUBTRACT && isIntLiteral(binary.getRight(), 1);
+  }
+
+  private static Optional<String> getArrayPropertyReference(ExpressionNode node, String arrayVar) {
+    node = node.skipParentheses();
+
+    if (node.getChildren().size() != 1) {
+      return Optional.empty();
+    }
+    return Optional.of(node.getChild(0))
+        .filter(left -> left.getChildren().size() == 3)
+        .filter(left -> sameIdentifier(left.getChild(0), arrayVar))
+        .filter(left -> isDot(left.getChild(1)))
+        .flatMap(left -> getPropertyReference(left.getChild(2)));
+  }
+
+  private static boolean isIntLiteral(ExpressionNode right, int i) {
+    return right.isIntegerLiteral()
+        && Optional.ofNullable(right.extractLiteral())
+            .filter(literal -> literal.getValueAsInt() == i)
+            .isPresent();
+  }
+
+  private static Optional<String> getPropertyReference(DelphiNode child) {
+    return Optional.of(child)
+        .filter(NameReferenceNode.class::isInstance)
+        .map(NameReferenceNode.class::cast)
+        .map(NameReferenceNode::getNameDeclaration)
+        .filter(PropertyNameDeclaration.class::isInstance)
+        .map(PropertyNameDeclaration.class::cast)
+        .map(PropertyNameDeclaration::fullyQualifiedName);
+  }
+
+  private static boolean isDot(DelphiNode child) {
+    return child instanceof CommonDelphiNode && child.getToken().getType() == DelphiTokenType.DOT;
+  }
+
+  private static boolean sameIdentifier(DelphiNode child, String arrayVar) {
+    return child instanceof IdentifierNode && child.getImage().equals(arrayVar);
+  }
+}

--- a/delphi-checks/src/main/resources/org/sonar/l10n/delphi/rules/community-delphi/IndexLastListElement.html
+++ b/delphi-checks/src/main/resources/org/sonar/l10n/delphi/rules/community-delphi/IndexLastListElement.html
@@ -1,0 +1,24 @@
+<h2>Why is this an issue?</h2>
+<p>
+  Manually computing the index of the last element in a <code>TList</code> descendant is less clear
+  and less terse than using <code>TList.Last</code>. The <code>Last</code> method is equivalent in
+  functionality, and it's inlined so there shouldn't be any performance difference.
+</p>
+
+<h2>How to fix it</h2>
+<p>
+  Use <code>TList.Last</code> instead of indexing with <code>Count - 1</code>.
+</p>
+
+<ul>
+  <li>
+    <a href="https://docwiki.embarcadero.com/Libraries/en/Special:Search/System.Generics.Collections.TList.Last">
+      RAD Studio documentation: System.Generics.Collections.TList.Last
+    </a>
+  </li>
+  <li>
+    <a href="https://docwiki.embarcadero.com/Libraries/en/Special:Search/System.Classes.TList.Last">
+      RAD Studio documentation: System.Classes.TList.Last
+    </a>
+  </li>
+</ul>

--- a/delphi-checks/src/main/resources/org/sonar/l10n/delphi/rules/community-delphi/IndexLastListElement.json
+++ b/delphi-checks/src/main/resources/org/sonar/l10n/delphi/rules/community-delphi/IndexLastListElement.json
@@ -1,0 +1,21 @@
+{
+  "title": "The last element in a `TList` descendant should be retrieved with the `Last` method.",
+  "type": "CODE_SMELL",
+  "status": "ready",
+  "remediation": {
+    "func": "Constant/Issue",
+    "constantCost": "1min"
+  },
+  "code": {
+    "attribute": "CLEAR",
+    "impacts": {
+      "MAINTAINABILITY": "LOW"
+    }
+  },
+  "tags": [
+    "clumsy"
+  ],
+  "defaultSeverity": "Minor",
+  "scope": "ALL",
+  "quickfix": "unknown"
+}

--- a/delphi-checks/src/main/resources/org/sonar/l10n/delphi/rules/community-delphi/Sonar_way_profile.json
+++ b/delphi-checks/src/main/resources/org/sonar/l10n/delphi/rules/community-delphi/Sonar_way_profile.json
@@ -35,6 +35,7 @@
     "HelperName",
     "IfThenShortCircuit",
     "ImportSpecificity",
+    "IndexLastListElement",
     "InheritedMethodWithNoCode",
     "InlineDeclarationCapturedByAnonymousMethod",
     "InstanceInvokedConstructor",

--- a/delphi-checks/src/test/java/au/com/integradev/delphi/checks/IndexLastListElementCheckTest.java
+++ b/delphi-checks/src/test/java/au/com/integradev/delphi/checks/IndexLastListElementCheckTest.java
@@ -1,0 +1,200 @@
+/*
+ * Sonar Delphi Plugin
+ * Copyright (C) 2023 Integrated Application Development
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02
+ */
+package au.com.integradev.delphi.checks;
+
+import au.com.integradev.delphi.builders.DelphiTestUnitBuilder;
+import au.com.integradev.delphi.checks.verifier.CheckVerifier;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+class IndexLastListElementCheckTest {
+  private static DelphiTestUnitBuilder systemClassesWithTList() {
+    return new DelphiTestUnitBuilder()
+        .unitName("System.Classes")
+        .appendDecl("type")
+        .appendDecl("  TList = class")
+        .appendDecl("    FCount: Integer;")
+        .appendDecl("    function GetItem(Index: Integer): TObject;")
+        .appendDecl("    property Items[Index: Integer]: TObject read GetItem; default;")
+        .appendDecl("    property Count: Integer read FCount;")
+        .appendDecl("  end;");
+  }
+
+  private static DelphiTestUnitBuilder systemContnrsWithTObjectList() {
+    return new DelphiTestUnitBuilder()
+        .unitName("System.Contnrs")
+        .appendDecl("uses")
+        .appendDecl("  System.Classes;")
+        .appendDecl("type")
+        .appendDecl("  TObjectList = class(TList)")
+        .appendDecl("  end;");
+  }
+
+  private static DelphiTestUnitBuilder systemGenericsCollections() {
+    return new DelphiTestUnitBuilder()
+        .unitName("System.Generics.Collections")
+        .appendDecl("type")
+        .appendDecl("  TList<T> = class")
+        .appendDecl("    FCount: Integer;")
+        .appendDecl("    function GetItem(Index: Integer): T;")
+        .appendDecl("    property Items[Index: Integer]: T read GetItem; default;")
+        .appendDecl("    property Count: Integer read FCount;")
+        .appendDecl("  end;")
+        .appendDecl("")
+        .appendDecl("  TObjectList<T> = class(TList<T>)")
+        .appendDecl("  end;");
+  }
+
+  @Test
+  void testTListDescendantShouldAddIssue() {
+    CheckVerifier.newVerifier()
+        .withCheck(new IndexLastListElementCheck())
+        .withStandardLibraryUnit(systemClassesWithTList())
+        .withStandardLibraryUnit(systemContnrsWithTObjectList())
+        .onFile(
+            new DelphiTestUnitBuilder()
+                .appendImpl("uses")
+                .appendImpl("  System.Contnrs;")
+                .appendImpl("procedure Test;")
+                .appendImpl("var")
+                .appendImpl("  List: TObjectList;")
+                .appendImpl("begin")
+                .appendImpl("  List[List.Count - 1]; // Noncompliant")
+                .appendImpl("end;"))
+        .verifyIssues();
+  }
+
+  @Test
+  void testNonTListDescendantShouldNotAddIssue() {
+    CheckVerifier.newVerifier()
+        .withCheck(new IndexLastListElementCheck())
+        .onFile(
+            new DelphiTestUnitBuilder()
+                .appendImpl("type")
+                .appendImpl("  TList = class")
+                .appendImpl("    FCount: Integer;")
+                .appendImpl("    function GetItem(Index: Integer): TObject;")
+                .appendImpl("    property Items[Index: Integer]: TObject read GetItem; default;")
+                .appendImpl("    property Count: Integer read FCount;")
+                .appendImpl("  end;")
+                .appendImpl("")
+                .appendImpl("procedure TList.GetItem(Index: Integer): TObject; begin end;")
+                .appendImpl("")
+                .appendImpl("procedure Test;")
+                .appendImpl("var")
+                .appendImpl("  List: TList;")
+                .appendImpl("begin")
+                .appendImpl("  List[List.Count - 1];")
+                .appendImpl("end;"))
+        .verifyNoIssues();
+  }
+
+  @Test
+  void testGenericTListShouldAddIssue() {
+    CheckVerifier.newVerifier()
+        .withCheck(new IndexLastListElementCheck())
+        .withStandardLibraryUnit(systemGenericsCollections())
+        .onFile(
+            new DelphiTestUnitBuilder()
+                .appendImpl("uses")
+                .appendImpl("  System.Generics.Collections;")
+                .appendImpl("procedure Test;")
+                .appendImpl("var")
+                .appendImpl("  List: TList<Integer>;")
+                .appendImpl("begin")
+                .appendImpl("  List[List.Count - 1]; // Noncompliant")
+                .appendImpl("end;"))
+        .verifyIssues();
+  }
+
+  @Test
+  void testGenericTObjectListShouldAddIssue() {
+    CheckVerifier.newVerifier()
+        .withCheck(new IndexLastListElementCheck())
+        .withStandardLibraryUnit(systemGenericsCollections())
+        .onFile(
+            new DelphiTestUnitBuilder()
+                .appendImpl("uses")
+                .appendImpl("  System.Generics.Collections;")
+                .appendImpl("procedure Test;")
+                .appendImpl("var")
+                .appendImpl("  List: TObjectList<Integer>;")
+                .appendImpl("begin")
+                .appendImpl("  List[List.Count - 1]; // Noncompliant")
+                .appendImpl("end;"))
+        .verifyIssues();
+  }
+
+  @ParameterizedTest
+  @ValueSource(
+      strings = {
+        "List[List2.Count - 1]",
+        "List2[List.Count - 1]",
+        "List[List.Count]",
+        "List[List.Count + 1]",
+        "List[List.Count - 1 - 1]",
+        "List[+List.Count - 1]",
+        "List[List.Count - 0]",
+      })
+  void testNotMatchingExpressionShouldNotAddIssue(String use) {
+    CheckVerifier.newVerifier()
+        .withCheck(new IndexLastListElementCheck())
+        .withStandardLibraryUnit(systemClassesWithTList())
+        .onFile(
+            new DelphiTestUnitBuilder()
+                .appendImpl("uses")
+                .appendImpl("  System.Classes;")
+                .appendImpl("procedure Test;")
+                .appendImpl("var")
+                .appendImpl("  List: TList;")
+                .appendImpl("  List2: TList;")
+                .appendImpl("begin")
+                .appendImpl("  " + use)
+                .appendImpl("end;"))
+        .verifyNoIssues();
+  }
+
+  @ParameterizedTest
+  @ValueSource(
+      strings = {
+        "List[List.Count - 1]",
+        "List[(List.Count - 1)]",
+        "List[(List.Count) - (1)]",
+        "List[List.Count - (1)]",
+        "List[(((List.Count)) - ((1)))]",
+        "List[Integer(List[List.Count - 1])]",
+      })
+  void testMatchingExpressionShouldAddIssue(String use) {
+    CheckVerifier.newVerifier()
+        .withCheck(new IndexLastListElementCheck())
+        .withStandardLibraryUnit(systemClassesWithTList())
+        .onFile(
+            new DelphiTestUnitBuilder()
+                .appendImpl("uses")
+                .appendImpl("  System.Classes;")
+                .appendImpl("procedure Test;")
+                .appendImpl("var")
+                .appendImpl("  List: TList;")
+                .appendImpl("begin")
+                .appendImpl("  " + use + " // Noncompliant")
+                .appendImpl("end;"))
+        .verifyIssues();
+  }
+}


### PR DESCRIPTION
Adds a rule checking for code like `List[List.Count - 1]`. 

Such code is equivalent to the much simpler `List.Last` when `List` is a descendant of `System.Generics.Collections.TList` or `System.Classes.TList`.