### PR TITLE
Fix casing in AddressOfCharacterData metadata

### DIFF
--- a/delphi-checks/src/main/resources/org/sonar/l10n/delphi/rules/community-delphi/AddressOfCharacterData.json
+++ b/delphi-checks/src/main/resources/org/sonar/l10n/delphi/rules/community-delphi/AddressOfCharacterData.json
@@ -7,7 +7,7 @@
     "constantCost": "1min"
   },
   "code": {
-    "attribute": "logical",
+    "attribute": "LOGICAL",
     "impacts": {
       "RELIABILITY": "MEDIUM"
     }


### PR DESCRIPTION
Integration tests were failing because of an invalid value in the AddressOfCharacterData metadata, introduced in #47. The clean code attribute should be the uppercased attribute name, but it was lowercased. This would also cause an actual SonarQube instance to fail on startup.