### PR TITLE
Add issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,56 @@
+name: Bug Report
+description: Report a bug in SonarDelphi
+title: "[Bug]: "
+labels: ["bug", "triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to fill out a bug report!
+        Please make sure to be as specific as possible in your description and title.
+  - type: checkboxes
+    attributes:
+      label: Prerequisites
+      description: |
+        Please check the following before filing a bug report.
+      options:
+        - label: This bug is in SonarDelphi, not SonarQube or my Delphi code.
+          required: true
+        - label: This bug has not already been reported.
+          required: true
+  - type: input
+    attributes:
+      label: SonarDelphi version
+      description: >
+        Specify the SonarDelphi version, including the Git commit hash if using a development build.
+        If you use a development build, please test if your issue is reproducible in a release version too.
+      placeholder: "1.0.0"
+    validations:
+      required: true
+  - type: input
+    attributes:
+      label: SonarQube version
+      description: >
+        If applicable, specify the SonarQube version you are using.
+      placeholder: "10.0"
+  - type: textarea
+    attributes:
+      label: Issue description
+      description: |
+        Describe your issue briefly. What doesn't work, and how do you expect it to work instead?
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: Steps to reproduce
+      description: |
+        Provide steps that can be used to reproduce the issue. Issues that are not reproducible are
+        unlikely to be resolved. If you include a minimal Delphi project below, you can detail what to look for here.
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: Minimal Delphi code exhibiting the issue
+      description: |
+        If applicable, a zip file of a minimal Delphi project that exhibits the issue when scanned.
+        Drag and drop a ZIP archive to upload it.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issue_enabled: false

--- a/.github/ISSUE_TEMPLATE/docs_improvement.yml
+++ b/.github/ISSUE_TEMPLATE/docs_improvement.yml
@@ -1,0 +1,34 @@
+name: Documentation Improvement
+description: Suggest a documentation improvement
+title: "[Docs Improvement]: "
+labels: ["documentation", "triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for suggesting an improvement to the SonarDelphi documentation!
+        Please make sure to be as specific as possible in your description and title.
+  - type: checkboxes
+    attributes:
+      label: Prerequisites
+      description: |
+        Please check the following before suggesting a documentation improvement.
+      options:
+        - label: This improvement has not already been suggested.
+          required: true
+        - label: This improvement relates specifically to SonarDelphi, not SonarQube or Delphi.
+          required: true
+  - type: textarea
+    attributes:
+      label: Improvement description
+      description: |
+        Describe the improvement. What's currently missing, or should be changed?
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: Rationale
+      description: |
+        Explain the utility of the proposed improvement. Why is this beneficial?
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/engine_improvement.yml
+++ b/.github/ISSUE_TEMPLATE/engine_improvement.yml
@@ -1,0 +1,48 @@
+name: Engine Improvement
+description: Suggest an engine improvement
+title: "[Engine Improvement]: "
+labels: ["enhancement", "triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for suggesting an improvement!
+        Please make sure to be as specific as possible in your description and title.
+  - type: checkboxes
+    attributes:
+      label: Prerequisites
+      description: |
+        Please check the following before suggesting an engine improvement.
+      options:
+        - label: This improvement has not already been suggested.
+          required: true
+        - label: This improvement would be generally useful, not specific to my code or setup.
+          required: true
+  - type: dropdown
+    attributes:
+      label: Engine area
+      description: >
+        Supply the area of SonarDelphi that the improvement affects.
+      options:
+        - Delphi language support
+        - Rule execution
+        - Testing
+        - Metrics calculation
+        - Other
+      default: 0
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: Improvement description
+      description: |
+        Describe the improvement. What's currently missing, or should be changed?
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: Rationale
+      description: |
+        Explain the utility of the proposed improvement. Why is this beneficial?
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/inquiry.yml
+++ b/.github/ISSUE_TEMPLATE/inquiry.yml
@@ -1,0 +1,27 @@
+name: Inquiry
+description: Suggest an inquiry
+title: "[Inquiry]: "
+labels: ["question", "triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for inquiring about SonarDelphi!
+        Please make sure to be as specific as possible in your description and title.
+  - type: checkboxes
+    attributes:
+      label: Prerequisites
+      description: |
+        Please check the following before making an inquiry.
+      options:
+        - label: This question has not already been answered.
+          required: true
+        - label: This question is about SonarDelphi, not SonarQube or Delphi.
+          required: true
+  - type: textarea
+    attributes:
+      label: Inquiry
+      description: |
+        What's your question?
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/new_rule.yml
+++ b/.github/ISSUE_TEMPLATE/new_rule.yml
@@ -1,0 +1,50 @@
+name: New Rule
+description: Propose a new rule
+title: "[New Rule]: "
+labels: ["enhancement", "triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for proposing a new rule!
+        Please make sure to be as specific as possible in your description and title.
+  - type: checkboxes
+    attributes:
+      label: Prerequisites
+      description: |
+        Please check the following before proposing a new rule:
+      options:
+        - label: This rule has not already been suggested.
+          required: true
+        - label: This should be a new rule, not an improvement to an existing rule.
+          required: true
+        - label: This rule would be generally useful, not specific to my code or setup.
+          required: true
+  - type: input
+    attributes:
+      label: Suggested rule title
+      description: |
+        Provide a short description of the rule as it would appear on the SonarQube interface.
+
+        This should follow the [SonarSource rule title guidelines](https://docs.sonarsource.com/sonarqube/latest/extension-guide/adding-coding-rules/#titles):
+
+        * The title of the rule should follow the pattern "X should [not] Y", excepting finding rules, which should be "Track X"
+        * The positive form is preferred
+        * Titles should be written in plural form if possible
+        * Titles should be as concise as possible
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: Rule description
+      description: |
+        Describe the proposed rule. What cases would it pick up, and how would it work?
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: Rationale
+      description: |
+        Explain the utility of the proposed rule. Why is this helpful? How does this rule address the root problem?
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/rule_improvement.yml
+++ b/.github/ISSUE_TEMPLATE/rule_improvement.yml
@@ -1,0 +1,41 @@
+name: Rule Improvement
+description: Suggest a rule improvement
+title: "[Rule Improvement]: "
+labels: ["enhancement", "triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for suggesting an improvement!
+        Please make sure to be as specific as possible in your description and title.
+  - type: checkboxes
+    attributes:
+      label: Prerequisites
+      description: |
+        Please check the following before suggesting a rule improvement:
+      options:
+        - label: This improvement has not already been suggested.
+          required: true
+        - label: This improvement should not be implemented as a separate rule.
+          required: true
+  - type: input
+    attributes:
+      label: Rule to improve
+      description: >
+        Supply the name of the rule that the improvement affects.
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: Improvement description
+      description: |
+        Describe the improvement. What's currently missing, or should be changed about the rule?
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: Rationale
+      description: |
+        Explain the utility of the proposed rule improvement. Why is this helpful? How does this improvement address the root problem?
+    validations:
+      required: true


### PR DESCRIPTION
This PR adds a number of issue templates for the SonarDelphi repository:

- Inquiry
- Bug report
- New rule
- Rule improvement
- Engine improvement
- Docs improvement

Blank issues are disabled.