### PR TITLE
Relax `HelperName` rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Include implicit attribute constructor calls in `ForbiddenMethod`.
 - Always enforce the `Attribute` suffix in `AttributeName`.
 - Allow the `Attribute` suffix to be omitted for attribute references in `MixedNames`.
+- Allow the extended type name to be anywhere in the helper name (rather than requiring it at the
+  start) in `HelperName`.
 - Improve name resolution for declarations within types.
 - Improve type resolution for array accesses into variants.
 - Improve parsing and type modeling around `AnsiString` types with specified code pages.


### PR DESCRIPTION
- Only enforce that the helped class name occurs as a substring in the helper class name, rather than requiring it at the start (e.g. allow `TMyFooHelper = class helper for TFoo`)