### PR TITLE
Re-enable build workflow on PRs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,6 +4,14 @@ on:
   push:
     branches:
       - 'master'
+  pull_request:
+    paths-ignore:
+      - '**.md'
+      - '**.svg'
+      - '**.png'
+      - 'LICENSE.txt'
+      - 'NOTICE.txt'
+      - '.git*'
 
 jobs:
   verify:


### PR DESCRIPTION
The GitHub Actions build workflow was disabled on PRs in #12. In preparation for open sourcing, this PR re-enables the build workflow on PRs. It will **not** run if only the following files are changed:

- `.md` files, `LICENSE.txt`, and `NOTICE.txt`
- `.svg` and `.png` images
- Git files (e.g. `.gitignore`)

The behaviour is unchanged for master - it will run on every merge regardless of which files are changed.