### PR TITLE
Exclude subprocedures and anonymous methods from UnitLevelKeywordIndentation

### DIFF
--- a/delphi-checks/src/main/java/au/com/integradev/delphi/checks/UnitLevelKeywordIndentationCheck.java
+++ b/delphi-checks/src/main/java/au/com/integradev/delphi/checks/UnitLevelKeywordIndentationCheck.java
@@ -177,7 +177,8 @@ public class UnitLevelKeywordIndentationCheck extends DelphiCheck {
       checkNodeIndentation(getEnd(block), context);
     }
 
-    return super.visit(methodImplementationNode, context);
+    // Exclude nested methods
+    return context;
   }
 
   @Override

--- a/delphi-checks/src/test/resources/au/com/integradev/delphi/checks/UnitLevelKeywordIndentationCheck/Correct.pas
+++ b/delphi-checks/src/test/resources/au/com/integradev/delphi/checks/UnitLevelKeywordIndentationCheck/Correct.pas
@@ -30,8 +30,15 @@ begin
 end;
 
 procedure MyProc;
+  procedure MySubProc;
+  begin
+  end;
+var
+  Anon: TProc;
 begin
-  Writeln('Hello world');
+  Anon :=
+    procedure begin
+    end;
 end;
 
 initialization

--- a/delphi-checks/src/test/resources/au/com/integradev/delphi/checks/UnitLevelKeywordIndentationCheck/Indented.pas
+++ b/delphi-checks/src/test/resources/au/com/integradev/delphi/checks/UnitLevelKeywordIndentationCheck/Indented.pas
@@ -31,8 +31,15 @@
   end; // Noncompliant
 
   procedure MyProc; // Noncompliant
+    procedure MySubProc;
+    begin
+    end;
+  var
+    Anon: TProc;
   begin // Noncompliant
-    Writeln('Hello world');
+    Anon :=
+    procedure begin
+    end;
   end; // Noncompliant
 
  initialization // Noncompliant


### PR DESCRIPTION
#43 enforced unit-level indentation for methods and procedures, but had the unfortunate side effect of also enforcing unit-level indentation for subprocedures and anonymous methods. This PR excludes those cases and adds extra testing to cover them.