### PR TITLE
Provide SCM information to changelog generator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1030,7 +1030,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Copy/paste detection. (CPD)
 - Syntax highlighting.
 
-## [0.1.0] - 2019-07-29
+## 0.1.0 - 2019-07-29
 
 ### Added
 
@@ -1117,4 +1117,3 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [0.4.0]: https://github.com/integrated-application-development/sonar-delphi/compare/v0.3.0...v0.4.0
 [0.3.0]: https://github.com/integrated-application-development/sonar-delphi/compare/v0.2.0...v0.3.0
 [0.2.0]: https://github.com/integrated-application-development/sonar-delphi/compare/v0.1.0...v0.2.0
-[0.1.0]: https://github.com/integrated-application-development/sonar-delphi/releases/tag/v0.1.0

--- a/pom.xml
+++ b/pom.xml
@@ -24,6 +24,13 @@
       <distribution>repo</distribution>
     </license>
   </licenses>
+  
+  <scm>
+    <connection>scm:git:git@github.com:integrated-application-development/sonar-delphi.git</connection>
+    <developerConnection>scm:git:git@github.com:integrated-application-development/sonar-delphi.git</developerConnection>
+    <url>https://github.com/integrated-application-development/sonar-delphi</url>
+    <tag>HEAD</tag>
+  </scm>
 
   <developers>
     <developer>

--- a/sonar-delphi-plugin/pom.xml
+++ b/sonar-delphi-plugin/pom.xml
@@ -16,15 +16,6 @@
   <name>SonarDelphi :: Plugin</name>
   <description>Code Analyzer for Delphi</description>
   <url>https://github.com/integrated-application-development/sonar-delphi</url>
-  <scm>
-    <connection>scm:git:git@github.com:integrated-application-development/sonar-delphi.git
-    </connection>
-    <developerConnection>
-      scm:git:git@github.com:integrated-application-development/sonar-delphi.git
-    </developerConnection>
-    <url>https://github.com/integrated-application-development/sonar-delphi</url>
-    <tag>HEAD</tag>
-  </scm>
 
   <dependencies>
     <dependency>


### PR DESCRIPTION
The keepachangelog Maven plugin expects SCM information to be provided in the top-level POM, and will not generate header link implementations if it can't find it. SonarDelphi's SCM information is erroneously in `sonar-delphi-plugin/pom.xml`, not `/pom.xml`, and so running `mvn keepachangelog:release` will remove all existing header links.

This PR moves the SCM information into the correct place and slightly adjusts the changelog to match the plugin's generated output.