### PR TITLE
Fix type resolution of constructor calls on types accessed through an array access

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   expression.
 - Improve name resolution for declarations within types.
 - Improve type resolution for array accesses into variants.
+- Improve type resolution around constructor calls following array accesses in primary expressions.
 - Improve parsing and type modeling around `AnsiString` types with specified code pages.
 
 ### Removed

--- a/delphi-checks/src/test/java/au/com/integradev/delphi/checks/NonLinearCastCheckTest.java
+++ b/delphi-checks/src/test/java/au/com/integradev/delphi/checks/NonLinearCastCheckTest.java
@@ -132,6 +132,54 @@ class NonLinearCastCheckTest {
   }
 
   @Test
+  void testCastOfInstanceCreatedFromFunctionCallShouldNotAddIssue() {
+    CheckVerifier.newVerifier()
+        .withCheck(new NonLinearCastCheck())
+        .onFile(
+            new DelphiTestUnitBuilder()
+                .appendDecl("type")
+                .appendDecl("  TMyClass = class of TMyType;")
+                .appendDecl("  TMyType = class abstract(TObject)")
+                .appendDecl("  public")
+                .appendDecl("    class function GetResultClass(const Str: string): TMyClass;")
+                .appendDecl("  end;")
+                .appendDecl("  TOtherType = class(TObject)")
+                .appendDecl("    procedure Bar;")
+                .appendDecl("  end;")
+                .appendImpl("procedure TOtherType.Bar;")
+                .appendImpl("var")
+                .appendImpl("  MyObj: TMyType;")
+                .appendImpl("begin")
+                .appendImpl("  MyObj := TMyType.GetResultClass('abc').Create as TMyType;")
+                .appendImpl("end;"))
+        .verifyNoIssues();
+  }
+
+  @Test
+  void testCastOfInstanceCreatedFromArrayAccessShouldNotAddIssue() {
+    CheckVerifier.newVerifier()
+        .withCheck(new NonLinearCastCheck())
+        .onFile(
+            new DelphiTestUnitBuilder()
+                .appendDecl("type")
+                .appendDecl("  TMyClass = class of TMyType;")
+                .appendDecl("  TMyType = class abstract(TObject)")
+                .appendDecl("  end;")
+                .appendDecl("  TOtherType = class(TObject)")
+                .appendDecl("    procedure Bar;")
+                .appendDecl("  end;")
+                .appendImpl("procedure TOtherType.Bar;")
+                .appendImpl("const")
+                .appendImpl("  C_Classes: array of TMyClass = (TMyType);")
+                .appendImpl("var")
+                .appendImpl("  MyObj: TObject;")
+                .appendImpl("begin")
+                .appendImpl("  MyObj := C_Classes[0].Create as TMyType;")
+                .appendImpl("end;"))
+        .verifyNoIssues();
+  }
+
+  @Test
   void testCastToSiblingClassShouldAddIssue() {
     CheckVerifier.newVerifier()
         .withCheck(new NonLinearCastCheck())

--- a/delphi-frontend/src/main/java/au/com/integradev/delphi/symbol/resolve/ExpressionTypeResolver.java
+++ b/delphi-frontend/src/main/java/au/com/integradev/delphi/symbol/resolve/ExpressionTypeResolver.java
@@ -99,7 +99,7 @@ public final class ExpressionTypeResolver {
 
     for (DelphiNode child : expression.getChildren()) {
       if (child instanceof Typed) {
-        type = handleTyped((Typed) child);
+        type = handleTyped((Typed) child, type.isUnknown() ? null : type);
       } else if (child instanceof ArgumentListNode) {
         List<ExpressionNode> arguments = ((ArgumentListNode) child).getArguments();
         if (classReference) {
@@ -230,15 +230,15 @@ public final class ExpressionTypeResolver {
     return type;
   }
 
-  private Type handleTyped(Typed typed) {
+  private Type handleTyped(Typed typed, Type parentType) {
     if (typed instanceof NameReferenceNode) {
-      return handleNameReference((NameReferenceNode) typed);
+      return handleNameReference((NameReferenceNode) typed, parentType);
     }
     return typed.getType();
   }
 
-  private Type handleNameReference(NameReferenceNode reference) {
-    Type type = null;
+  private Type handleNameReference(NameReferenceNode reference, Type parentType) {
+    Type type = parentType;
 
     for (NameReferenceNode name : reference.flatten()) {
       NameOccurrence occurrence = name.getNameOccurrence();


### PR DESCRIPTION
When performing type resolution, SonarDelphi erroneously resolves the type of the `Create` call in this example to `TEnclosingType`:

```pascal
type
  TActualType = class(TObject)
  end;

  TEnclosingType = class(TObject)
    procedure MyProc;
  end;

procedure Foo(Obj: TActualType); overload;
begin
  WriteLn('Actual');
end;

procedure Foo(Obj: TEnclosingType); overload;
begin
  WriteLn('Enclosing');
end;

// ...

procedure TEnclosingType.Bar;
type
  TActualTypeClass = class of TActualType;
const
  CActualTypes: array of TActualTypeClass = (TActualType);
begin
  Foo(CActualTypes[0].Create); // Should resolve to TActualType, but resolves to TEnclosingType instead
end;
```

This bug discards any elements in a primary expression that are prior to a series of name references. and was identified from a number of false positive NonLinearCast issues. This PR fixes this bug and adds some extra tests to NonLinearCast to ensure these cases are caught.