### PR TITLE
Fix Sonar issues for dedicated exceptions and overloaded test lambdas

### DIFF
--- a/delphi-checks/src/test/java/au/com/integradev/delphi/checks/StringLiteralRegularExpressionCheckTest.java
+++ b/delphi-checks/src/test/java/au/com/integradev/delphi/checks/StringLiteralRegularExpressionCheckTest.java
@@ -59,15 +59,14 @@ class StringLiteralRegularExpressionCheckTest {
 
   @Test
   void testInvalidRegexShouldThrow() {
-    assertThatThrownBy(
-            () ->
-                CheckVerifier.newVerifier()
-                    .withCheck(createCheck("*"))
-                    .onFile(
-                        new DelphiTestUnitBuilder()
-                            .appendDecl("const")
-                            .appendDecl("  C_HardcodedIDRef = 'FOO1234X6U8BAR';"))
-                    .verifyIssues())
-        .isInstanceOf(FatalAnalysisError.class);
+    var verifier =
+        CheckVerifier.newVerifier()
+            .withCheck(createCheck("*"))
+            .onFile(
+                new DelphiTestUnitBuilder()
+                    .appendDecl("const")
+                    .appendDecl("  C_HardcodedIDRef = 'FOO1234X6U8BAR';"));
+
+    assertThatThrownBy(verifier::verifyIssues).isInstanceOf(FatalAnalysisError.class);
   }
 }

--- a/delphi-frontend/src/main/java/au/com/integradev/delphi/file/DelphiFile.java
+++ b/delphi-frontend/src/main/java/au/com/integradev/delphi/file/DelphiFile.java
@@ -84,6 +84,12 @@ public interface DelphiFile {
     }
   }
 
+  class EmptyDelphiFileException extends RuntimeException {
+    EmptyDelphiFileException(String message) {
+      super(message);
+    }
+  }
+
   static DelphiFileConfig createConfig(
       String encoding,
       DelphiPreprocessorFactory preprocessorFactory,
@@ -125,7 +131,7 @@ public interface DelphiFile {
       delphiFile.setSourceCodeLines(readLines(sourceFile, config.getEncoding()));
       delphiFile.setTokens(createTokenList(delphiFile, preprocessor.getTokenStream()));
       delphiFile.setComments(extractComments(delphiFile.getTokens()));
-    } catch (IOException | RecognitionException | RuntimeException e) {
+    } catch (IOException | RecognitionException | EmptyDelphiFileException e) {
       throw new DelphiFileConstructionException(e);
     }
   }
@@ -154,7 +160,7 @@ public interface DelphiFile {
                     token.getChannel() == Token.HIDDEN_CHANNEL || token.getType() == Token.EOF);
 
     if (isEmptyFile) {
-      throw new RuntimeException("Empty files are not allowed.");
+      throw new EmptyDelphiFileException("Empty files are not allowed.");
     }
 
     DelphiParser parser = new DelphiParser(tokenStream);

--- a/delphi-frontend/src/main/java/au/com/integradev/delphi/preprocessor/DelphiPreprocessor.java
+++ b/delphi-frontend/src/main/java/au/com/integradev/delphi/preprocessor/DelphiPreprocessor.java
@@ -223,8 +223,8 @@ public class DelphiPreprocessor {
         String path = includeFile.toAbsolutePath().normalize().toString();
 
         if (path.equals(lexer.getSourceName())) {
-          throw new RuntimeException(
-              "Self-referencing include file <" + includeFile.toAbsolutePath() + ">");
+          throw new SelfReferencingIncludeFileException(
+              "Include file <" + includeFile.toAbsolutePath() + "> references itself");
         }
 
         DelphiFileStream fileStream = new DelphiFileStream(path, config.getEncoding());
@@ -317,5 +317,11 @@ public class DelphiPreprocessor {
 
   public TypeFactory getTypeFactory() {
     return config.getTypeFactory();
+  }
+
+  static class SelfReferencingIncludeFileException extends RuntimeException {
+    SelfReferencingIncludeFileException(String message) {
+      super(message);
+    }
   }
 }

--- a/delphi-frontend/src/main/java/au/com/integradev/delphi/symbol/scope/DelphiScopeImpl.java
+++ b/delphi-frontend/src/main/java/au/com/integradev/delphi/symbol/scope/DelphiScopeImpl.java
@@ -159,7 +159,8 @@ public class DelphiScopeImpl implements DelphiScope {
       return;
     }
 
-    throw new RuntimeException(declaration.getImage() + " is already in the symbol table");
+    throw new DuplicatedDeclarationException(
+        declaration.getImage() + " is already in the symbol table");
   }
 
   private boolean isAcceptableDuplicate(NameDeclaration declaration) {

--- a/delphi-frontend/src/main/java/au/com/integradev/delphi/symbol/scope/DuplicatedDeclarationException.java
+++ b/delphi-frontend/src/main/java/au/com/integradev/delphi/symbol/scope/DuplicatedDeclarationException.java
@@ -1,0 +1,25 @@
+/*
+ * Sonar Delphi Plugin
+ * Copyright (C) 2023 Integrated Application Development
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02
+ */
+package au.com.integradev.delphi.symbol.scope;
+
+public class DuplicatedDeclarationException extends RuntimeException {
+  public DuplicatedDeclarationException(String message) {
+    super(message);
+  }
+}

--- a/delphi-frontend/src/test/java/au/com/integradev/delphi/antlr/GrammarTest.java
+++ b/delphi-frontend/src/test/java/au/com/integradev/delphi/antlr/GrammarTest.java
@@ -33,6 +33,7 @@ import au.com.integradev.delphi.preprocessor.search.SearchPath;
 import au.com.integradev.delphi.utils.DelphiUtils;
 import au.com.integradev.delphi.utils.files.DelphiFileUtils;
 import au.com.integradev.delphi.utils.types.TypeFactoryUtils;
+import java.io.File;
 import java.nio.charset.StandardCharsets;
 import java.util.Collections;
 import java.util.Set;
@@ -240,11 +241,10 @@ class GrammarTest {
 
   @Test
   void testEmptyFileShouldThrow() {
-    assertThatThrownBy(
-            () ->
-                DelphiFile.from(
-                    DelphiUtils.getResource(BASE_DIR + "EmptyFile.pas"),
-                    DelphiFileUtils.mockConfig()))
+    File emptyFile = DelphiUtils.getResource(BASE_DIR + "EmptyFile.pas");
+    DelphiFileConfig config = DelphiFileUtils.mockConfig();
+
+    assertThatThrownBy(() -> DelphiFile.from(emptyFile, config))
         .isInstanceOf(DelphiFileConstructionException.class);
   }
 }

--- a/delphi-frontend/src/test/java/au/com/integradev/delphi/file/DelphiFileTest.java
+++ b/delphi-frontend/src/test/java/au/com/integradev/delphi/file/DelphiFileTest.java
@@ -21,6 +21,7 @@ package au.com.integradev.delphi.file;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import au.com.integradev.delphi.file.DelphiFile.DelphiFileConstructionException;
+import au.com.integradev.delphi.file.DelphiFile.EmptyDelphiFileException;
 import au.com.integradev.delphi.utils.DelphiUtils;
 import au.com.integradev.delphi.utils.files.DelphiFileUtils;
 import java.io.File;
@@ -34,6 +35,6 @@ class DelphiFileTest {
 
     assertThatThrownBy(() -> DelphiFile.from(sourceFile, config))
         .isInstanceOf(DelphiFileConstructionException.class)
-        .hasCauseInstanceOf(RuntimeException.class);
+        .hasCauseInstanceOf(EmptyDelphiFileException.class);
   }
 }

--- a/delphi-frontend/src/test/java/au/com/integradev/delphi/msbuild/condition/ConditionParserTest.java
+++ b/delphi-frontend/src/test/java/au/com/integradev/delphi/msbuild/condition/ConditionParserTest.java
@@ -64,12 +64,10 @@ class ConditionParserTest {
     assertThat(parse("Foo()")).isInstanceOf(FunctionCallExpression.class);
     assertThatThrownBy(() -> parse("HasTrailingSlash('./foo/bar'"))
         .isInstanceOf(ConditionParserError.class);
-    assertThatThrownBy(
-            () -> {
-              ConditionParser parser = new ConditionParser();
-              parser.parse(List.of(new Token(TokenType.FUNCTION, "HasTrailingSlash")));
-            })
-        .isInstanceOf(ConditionParserError.class);
+
+    ConditionParser parser = new ConditionParser();
+    List<Token> tokenList = List.of(new Token(TokenType.FUNCTION, "HasTrailingSlash"));
+    assertThatThrownBy(() -> parser.parse(tokenList)).isInstanceOf(ConditionParserError.class);
   }
 
   @Test

--- a/delphi-frontend/src/test/java/au/com/integradev/delphi/operator/OperatorInvocableCollectorTest.java
+++ b/delphi-frontend/src/test/java/au/com/integradev/delphi/operator/OperatorInvocableCollectorTest.java
@@ -31,6 +31,7 @@ import org.sonar.plugins.communitydelphi.api.operator.BinaryOperator;
 import org.sonar.plugins.communitydelphi.api.operator.Operator;
 import org.sonar.plugins.communitydelphi.api.operator.UnaryOperator;
 import org.sonar.plugins.communitydelphi.api.type.IntrinsicType;
+import org.sonar.plugins.communitydelphi.api.type.Type;
 import org.sonar.plugins.communitydelphi.api.type.TypeFactory;
 
 class OperatorInvocableCollectorTest {
@@ -38,7 +39,8 @@ class OperatorInvocableCollectorTest {
   void testUnhandledOperatorShouldThrow() {
     TypeFactory typeFactory = TypeFactoryUtils.defaultFactory();
     OperatorInvocableCollector collector = new OperatorInvocableCollector(typeFactory);
-    assertThatThrownBy(() -> collector.collect(TypeFactory.unknownType(), mock(Operator.class)))
+    Type unknownType = TypeFactory.unknownType();
+    assertThatThrownBy(() -> collector.collect(unknownType, mock(Operator.class)))
         .withFailMessage("Unhandled Operator")
         .isInstanceOf(AssertionError.class);
   }

--- a/delphi-frontend/src/test/java/au/com/integradev/delphi/symbol/QualifiedNameTest.java
+++ b/delphi-frontend/src/test/java/au/com/integradev/delphi/symbol/QualifiedNameTest.java
@@ -21,12 +21,14 @@ package au.com.integradev.delphi.symbol;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.Collections;
+import java.util.List;
 import org.junit.jupiter.api.Test;
 
 class QualifiedNameTest {
   @Test
   void testEmptyQualifiedNameShouldThrow() {
-    assertThatThrownBy(() -> new QualifiedNameImpl(Collections.emptyList()))
+    List<String> emptyList = Collections.emptyList();
+    assertThatThrownBy(() -> new QualifiedNameImpl(emptyList))
         .isInstanceOf(IllegalArgumentException.class);
     assertThatThrownBy(QualifiedNameImpl::of).isInstanceOf(IllegalArgumentException.class);
   }

--- a/delphi-frontend/src/test/java/au/com/integradev/delphi/symbol/resolve/TypeComparerTest.java
+++ b/delphi-frontend/src/test/java/au/com/integradev/delphi/symbol/resolve/TypeComparerTest.java
@@ -160,8 +160,10 @@ class TypeComparerTest {
     compare(IntrinsicType.EXTENDED, IntrinsicType.CURRENCY, CONVERT_LEVEL_7);
     compare(IntrinsicType.EXTENDED, IntrinsicType.COMP, CONVERT_LEVEL_7);
 
-    assertThatThrownBy(
-            () -> TypeComparer.compareRealToReal(unknownType(), toType(IntrinsicType.SINGLE)))
+    Type unknown = unknownType();
+    Type single = toType(IntrinsicType.SINGLE);
+
+    assertThatThrownBy(() -> TypeComparer.compareRealToReal(unknown, single))
         .isInstanceOf(AssertionError.class);
   }
 
@@ -212,10 +214,9 @@ class TypeComparerTest {
 
     compare(typeType("Test", IntrinsicType.UNICODESTRING), IntrinsicType.UNICODESTRING, EQUAL);
 
-    assertThatThrownBy(
-            () ->
-                TypeComparer.compareStringToString(
-                    unknownType(), toType(IntrinsicType.UNICODESTRING)))
+    Type unknown = unknownType();
+    Type unicodeString = toType(IntrinsicType.UNICODESTRING);
+    assertThatThrownBy(() -> TypeComparer.compareStringToString(unknown, unicodeString))
         .isInstanceOf(AssertionError.class);
   }
 
@@ -274,7 +275,8 @@ class TypeComparerTest {
     compare(IntrinsicType.CHAR, IntrinsicType.SHORTSTRING, CONVERT_LEVEL_6);
     assertThat(TypeComparer.compareWideCharToString(unknownType())).isEqualTo(INCOMPATIBLE_TYPES);
 
-    assertThatThrownBy(() -> TypeComparer.compareCharToString(unknownType(), unknownType()))
+    Type unknown = unknownType();
+    assertThatThrownBy(() -> TypeComparer.compareCharToString(unknown, unknown))
         .isInstanceOf(AssertionError.class);
   }
 
@@ -285,10 +287,10 @@ class TypeComparerTest {
     compare(IntrinsicType.WIDECHAR, IntrinsicType.ANSICHAR, CONVERT_LEVEL_2);
     assertThat(TypeComparer.compareWideCharToChar(unknownType())).isEqualTo(INCOMPATIBLE_TYPES);
 
-    assertThatThrownBy(() -> TypeComparer.compareCharToString(unknownType(), unknownType()))
+    Type unknown = unknownType();
+    assertThatThrownBy(() -> TypeComparer.compareCharToString(unknown, unknown))
         .isInstanceOf(AssertionError.class);
-
-    assertThatThrownBy(() -> TypeComparer.compareCharToChar(unknownType(), unknownType()))
+    assertThatThrownBy(() -> TypeComparer.compareCharToChar(unknown, unknown))
         .isInstanceOf(AssertionError.class);
   }
 
@@ -384,7 +386,8 @@ class TypeComparerTest {
     compare(unknownType(), toDynamicArray, INCOMPATIBLE_TYPES);
     compare(unknownType(), toFixedArray, INCOMPATIBLE_TYPES);
 
-    assertThat(TypeComparer.compareOpenArray(set(IntrinsicType.INTEGER), toOpenArray))
+    CollectionType integerSet = set(IntrinsicType.INTEGER);
+    assertThat(TypeComparer.compareOpenArray(integerSet, toOpenArray))
         .isEqualTo(INCOMPATIBLE_TYPES);
   }
 

--- a/delphi-frontend/src/test/java/au/com/integradev/delphi/symbol/scope/DelphiScopeImplTest.java
+++ b/delphi-frontend/src/test/java/au/com/integradev/delphi/symbol/scope/DelphiScopeImplTest.java
@@ -110,7 +110,8 @@ class DelphiScopeImplTest {
   void testVariableAndTypeWithSameNameAreDuplicates() {
     scope.addDeclaration(createVariable("Foo"));
 
-    assertThatThrownBy(() -> scope.addDeclaration(createClassType("Foo")))
+    TypeNameDeclaration classType = createClassType("Foo");
+    assertThatThrownBy(() -> scope.addDeclaration(classType))
         .isInstanceOf(DuplicatedDeclarationException.class);
   }
 
@@ -118,7 +119,8 @@ class DelphiScopeImplTest {
   void testTypesWithDifferentKindAndSameNameAreDuplicates() {
     scope.addDeclaration(createType("Bar"));
 
-    assertThatThrownBy(() -> scope.addDeclaration(createClassType("Bar")))
+    TypeNameDeclaration classType = createClassType("Bar");
+    assertThatThrownBy(() -> scope.addDeclaration(classType))
         .isInstanceOf(DuplicatedDeclarationException.class);
   }
 

--- a/delphi-frontend/src/test/java/au/com/integradev/delphi/symbol/scope/DelphiScopeImplTest.java
+++ b/delphi-frontend/src/test/java/au/com/integradev/delphi/symbol/scope/DelphiScopeImplTest.java
@@ -111,7 +111,7 @@ class DelphiScopeImplTest {
     scope.addDeclaration(createVariable("Foo"));
 
     assertThatThrownBy(() -> scope.addDeclaration(createClassType("Foo")))
-        .isInstanceOf(RuntimeException.class);
+        .isInstanceOf(DuplicatedDeclarationException.class);
   }
 
   @Test
@@ -119,7 +119,7 @@ class DelphiScopeImplTest {
     scope.addDeclaration(createType("Bar"));
 
     assertThatThrownBy(() -> scope.addDeclaration(createClassType("Bar")))
-        .isInstanceOf(RuntimeException.class);
+        .isInstanceOf(DuplicatedDeclarationException.class);
   }
 
   @Test


### PR DESCRIPTION
This PR fixes [15 SonarCloud issues](https://sonarcloud.io/project/issues?resolved=false&rules=java%3AS112%2Cjava%3AS5778&types=CODE_SMELL&id=integrated-application-development_sonar-delphi&open=AYuyR9CGfd4wpt45YCY6) for the following rules:

- [Only one method invocation is expected when testing runtime exceptions](https://sonarcloud.io/organizations/integrated-application-development/rules?open=java%3AS5778&rule_key=java%3AS5778)
- [Generic exceptions should never be thrown](https://sonarcloud.io/organizations/integrated-application-development/rules?open=java%3AS112&rule_key=java%3AS112)