### PR TITLE
Add rules API option to Engine Improvement issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/engine_improvement.yml
+++ b/.github/ISSUE_TEMPLATE/engine_improvement.yml
@@ -25,9 +25,10 @@ body:
         Supply the area of SonarDelphi that the improvement affects.
       options:
         - Delphi language support
+        - Rules API
         - Rule execution
-        - Testing
         - Metrics calculation
+        - Testing
         - Other
       default: 0
     validations:


### PR DESCRIPTION
This PR adds a "Rules API" category for the Engine Improvement issue template. This helps fill the gap of requests that improve the API. 