### PR TITLE
Skip integration tests by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ read the [contributing guide](docs/CONTRIBUTING.md).
 
 ## Development
 
-SonarDelphi can be built with JDK 17+ using [Maven](https://maven.apache.org/).
+SonarDelphi can be built with JDK 11+ using [Maven](https://maven.apache.org/).
 
 To build the project and run unit tests, execute the following command from the project's root directory:
 

--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ read the [contributing guide](docs/CONTRIBUTING.md).
 
 SonarDelphi can be built with JDK 17+ using [Maven](https://maven.apache.org/).
 
-To build the project and run all tests, execute the following command from the project's root directory:
+To build the project and run unit tests, execute the following command from the project's root directory:
 
 ```bash
 mvn clean install

--- a/its/pom.xml
+++ b/its/pom.xml
@@ -15,6 +15,7 @@
   <name>SonarDelphi :: ITs</name>
 
   <properties>
+    <skipTests>${skipITs}</skipTests>
     <proxyHost/>
     <proxyPort/>
   </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -104,6 +104,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.min.version>3.3.9</maven.min.version>
     <jdk.min.version>11</jdk.min.version>
+    <skipITs>true</skipITs>
     <!-- SonarCloud scan -->
     <sonar.organization>integrated-application-development</sonar.organization>
     <sonar.host.url>https://sonarcloud.io</sonar.host.url>
@@ -483,6 +484,7 @@
       <id>ci</id>
       <properties>
         <license.failIfMissing>true</license.failIfMissing>
+        <skipITs>false</skipITs>
       </properties>
     </profile>
 


### PR DESCRIPTION
Because integration tests spin up a SonarQube server, they share SonarQube's Java requirements.

SonarQube only runs under Java 17 (no other versions are supported), meaning that the integration tests require the developer to be running JDK 17 *exactly*.

This is a weird/inconvenient limitation to impose on contributors.