### PR TITLE
Upload plugin jar artifact in build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,3 +28,8 @@ jobs:
           cache: maven
       - name: Maven Install
         run: mvn clean install -Pci --batch-mode --no-transfer-progress
+      - name: Upload plugin jar
+        uses: actions/upload-artifact@v3
+        with:
+          name: sonar-delphi-plugin-jar
+          path: sonar-delphi-plugin/target/sonar-delphi-plugin-*.jar


### PR DESCRIPTION
This PR adds a step to the build workflow to save the generated sonar-delphi-plugin jar as an artifact. This saves having to check out the repository and run a `mvn install` when retrieving a specific version of the jar.