### PR TITLE
Update `VisibilityKeywordIndentation` to refer to 'leading' whitespace

### DIFF
--- a/delphi-checks/src/main/resources/org/sonar/l10n/delphi/rules/community-delphi/VisibilityKeywordIndentation.html
+++ b/delphi-checks/src/main/resources/org/sonar/l10n/delphi/rules/community-delphi/VisibilityKeywordIndentation.html
@@ -4,7 +4,7 @@
   differentiate between fields, routines, and properties of different visibilities.
 </p>
 <p>
-  Please note that this rule checks for an exact match on trailing whitespace - mixed indentation
+  Please note that this rule checks for an exact match on leading whitespace - mixed indentation
   may yield unexpected results.
 </p>
 <h2>How to fix it</h2>


### PR DESCRIPTION
The rule description erroneously refered to 'trailing' whitespace, but it checks indentation which is actually leading whitespace.