### PR TITLE
Update issue templates to use new labels

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,6 +1,5 @@
 name: Bug Report
 description: Report a bug
-title: "[Bug]: "
 labels: ["bug", "triage"]
 body:
   - type: markdown

--- a/.github/ISSUE_TEMPLATE/docs_improvement.yml
+++ b/.github/ISSUE_TEMPLATE/docs_improvement.yml
@@ -1,6 +1,5 @@
 name: Documentation Improvement
 description: Suggest a documentation improvement
-title: "[Docs Improvement]: "
 labels: ["documentation", "triage"]
 body:
   - type: markdown

--- a/.github/ISSUE_TEMPLATE/engine_improvement.yml
+++ b/.github/ISSUE_TEMPLATE/engine_improvement.yml
@@ -1,7 +1,6 @@
 name: Engine Improvement
 description: Suggest an engine improvement
-title: "[Engine Improvement]: "
-labels: ["enhancement", "triage"]
+labels: ["engine", "enhancement", "triage"]
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/inquiry.yml
+++ b/.github/ISSUE_TEMPLATE/inquiry.yml
@@ -1,6 +1,5 @@
 name: Inquiry
 description: Ask a question
-title: "[Inquiry]: "
 labels: ["question", "triage"]
 body:
   - type: markdown

--- a/.github/ISSUE_TEMPLATE/new_rule.yml
+++ b/.github/ISSUE_TEMPLATE/new_rule.yml
@@ -1,7 +1,6 @@
 name: New Rule
 description: Propose a new rule
-title: "[New Rule]: "
-labels: ["enhancement", "triage"]
+labels: ["rule", "feature", "triage"]
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/rule_improvement.yml
+++ b/.github/ISSUE_TEMPLATE/rule_improvement.yml
@@ -1,7 +1,6 @@
 name: Rule Improvement
 description: Suggest a rule improvement
-title: "[Rule Improvement]: "
-labels: ["enhancement", "triage"]
+labels: ["rule", "enhancement", "triage"]
 body:
   - type: markdown
     attributes:


### PR DESCRIPTION
This PR modifies the issue templates to:

- Remove the `[Rule Type]:` prefix
- Use more descriptive labels (in particular the new `rule`, `feature`, and `engine` labels)