### PR TITLE
Include test files in scan

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Test sources were erroneously excluded from analysis.
 - Stack overflow on class reference types that reference their containing type.
 - Scan failures on redundant unit aliases in .dproj files.
 - Incorrect file position calculation for multiline compiler directives.

--- a/delphi-frontend/src/main/java/au/com/integradev/delphi/msbuild/DelphiProjectHelper.java
+++ b/delphi-frontend/src/main/java/au/com/integradev/delphi/msbuild/DelphiProjectHelper.java
@@ -352,9 +352,9 @@ public class DelphiProjectHelper {
     return referencedFiles;
   }
 
-  public Iterable<InputFile> mainFiles() {
+  public Iterable<InputFile> inputFiles() {
     FilePredicates p = fs.predicates();
-    return fs.inputFiles(p.and(p.hasLanguage(Delphi.KEY), p.hasType(InputFile.Type.MAIN)));
+    return fs.inputFiles(p.and(p.hasLanguage(Delphi.KEY)));
   }
 
   public boolean shouldExecuteOnProject() {

--- a/delphi-frontend/src/test/java/au/com/integradev/delphi/msbuild/DelphiProjectHelperTest.java
+++ b/delphi-frontend/src/test/java/au/com/integradev/delphi/msbuild/DelphiProjectHelperTest.java
@@ -324,7 +324,7 @@ class DelphiProjectHelperTest {
     DelphiProjectHelper delphiProjectHelper =
         new DelphiProjectHelper(settings, fs, environmentVariableProvider);
 
-    assertThat(delphiProjectHelper.mainFiles()).isEmpty();
+    assertThat(delphiProjectHelper.inputFiles()).isEmpty();
     assertThat(delphiProjectHelper.shouldExecuteOnProject()).isFalse();
   }
 
@@ -336,7 +336,7 @@ class DelphiProjectHelperTest {
     DelphiProjectHelper delphiProjectHelper =
         new DelphiProjectHelper(settings, fs, environmentVariableProvider);
 
-    assertThat(delphiProjectHelper.mainFiles()).isEmpty();
+    assertThat(delphiProjectHelper.inputFiles()).isEmpty();
     assertThat(delphiProjectHelper.shouldExecuteOnProject()).isFalse();
   }
 
@@ -348,7 +348,7 @@ class DelphiProjectHelperTest {
     DelphiProjectHelper delphiProjectHelper =
         new DelphiProjectHelper(settings, fs, environmentVariableProvider);
 
-    assertThat(delphiProjectHelper.mainFiles()).isEmpty();
+    assertThat(delphiProjectHelper.inputFiles()).isEmpty();
     assertThat(delphiProjectHelper.shouldExecuteOnProject()).isFalse();
   }
 }

--- a/sonar-delphi-plugin/src/main/java/au/com/integradev/delphi/DelphiSensor.java
+++ b/sonar-delphi-plugin/src/main/java/au/com/integradev/delphi/DelphiSensor.java
@@ -96,7 +96,7 @@ public class DelphiSensor implements Sensor {
 
     var preprocessorFactory = new DelphiPreprocessorFactory(toolchain.platform);
     var typeFactory = new TypeFactoryImpl(toolchain, compilerVersion);
-    Iterable<InputFile> inputFiles = delphiProjectHelper.mainFiles();
+    Iterable<InputFile> inputFiles = delphiProjectHelper.inputFiles();
     List<Path> sourceFiles = inputFilesToPaths(inputFiles);
     List<Path> referencedFiles = delphiProjectHelper.getReferencedFiles();
     List<Path> searchPathDirectories = new ArrayList<>();

--- a/sonar-delphi-plugin/src/test/java/au/com/integradev/delphi/DelphiSensorTest.java
+++ b/sonar-delphi-plugin/src/test/java/au/com/integradev/delphi/DelphiSensorTest.java
@@ -90,7 +90,7 @@ class DelphiSensorTest {
     InputFile inputFile = mock(InputFile.class);
     when(inputFile.uri()).thenReturn(sourceFilePath.toUri());
 
-    when(delphiProjectHelper.mainFiles()).thenReturn(List.of(inputFile));
+    when(delphiProjectHelper.inputFiles()).thenReturn(List.of(inputFile));
     when(delphiProjectHelper.getFile(anyString())).thenReturn(inputFile);
     when(delphiProjectHelper.standardLibraryPath()).thenReturn(standardLibraryPath);
   }


### PR DESCRIPTION
This PR adds support for SonarDelphi to recognise `sonar.tests` as test code and scan accordingly.

Test code in SonarDelphi is usually identified using the `sonar.delphi.testAttribute` or `sonar.delphi.testType` properties.
This is different to the normal Sonar approach, in which units can also be specified as test units by specifying them in `sonar.tests` instead of `sonar.sources`. Currently, SonarDelphi disregards any files provided through the `sonar.tests` option. 