### PR TITLE
Exclude routines, properties, and fields with attributes from dead code checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `ConstSectionNode::isResourceStringSection` API method.
 - `AttributeListNode::getAttributeTypes` API method.
 - `RoutineNameDeclaration::getAttributeTypes` API method.
+- `PropertyNameDeclaration::getAttributeTypes` API method.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `VarSectionNode::isThreadVarSection` API method.
 - `ConstSectionNode::isResourceStringSection` API method.
 - `AttributeListNode::getAttributeTypes` API method.
+- `RoutineNameDeclaration::getAttributeTypes` API method.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Improve type resolution on binary expressions where the operands are integer types.
 - Improve type comparisons between signed and unsigned integer types.
 - Exclude routines annotated with attributes in `UnusedRoutine`.
+- Exclude properties annotated with attributes in `UnusedProperty`.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   be merged.
 - `VarSectionNode::isThreadVarSection` API method.
 - `ConstSectionNode::isResourceStringSection` API method.
+- `AttributeListNode::getAttributeTypes` API method.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,9 +19,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   be merged.
 - `VarSectionNode::isThreadVarSection` API method.
 - `ConstSectionNode::isResourceStringSection` API method.
-- `AttributeListNode::getAttributeTypes` API method.
-- `RoutineNameDeclaration::getAttributeTypes` API method.
-- `PropertyNameDeclaration::getAttributeTypes` API method.
 
 ### Changed
 
@@ -29,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Improve type comparisons between signed and unsigned integer types.
 - Exclude routines annotated with attributes in `UnusedRoutine`.
 - Exclude properties annotated with attributes in `UnusedProperty`.
+- Exclude fields annotated with attributes in `UnusedField`.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Improve type resolution on binary expressions where the operands are integer types.
 - Improve type comparisons between signed and unsigned integer types.
+- Exclude routines annotated with attributes in `UnusedRoutine`.
 
 ### Fixed
 

--- a/delphi-checks/src/main/java/au/com/integradev/delphi/checks/UnusedFieldCheck.java
+++ b/delphi-checks/src/main/java/au/com/integradev/delphi/checks/UnusedFieldCheck.java
@@ -19,6 +19,7 @@
 package au.com.integradev.delphi.checks;
 
 import org.sonar.check.Rule;
+import org.sonar.plugins.communitydelphi.api.ast.AttributeListNode;
 import org.sonar.plugins.communitydelphi.api.ast.FieldDeclarationNode;
 import org.sonar.plugins.communitydelphi.api.check.DelphiCheck;
 import org.sonar.plugins.communitydelphi.api.check.DelphiCheckContext;
@@ -34,9 +35,12 @@ public class UnusedFieldCheck extends DelphiCheck {
   @Override
   public DelphiCheckContext visit(FieldDeclarationNode field, DelphiCheckContext context) {
     if (!field.isPublished()) {
-      field.getDeclarationList().getDeclarations().stream()
-          .filter(node -> node.getUsages().isEmpty())
-          .forEach(node -> reportIssue(context, node, MESSAGE));
+      AttributeListNode attributeList = field.getAttributeList();
+      if (attributeList == null || attributeList.getAttributes().isEmpty()) {
+        field.getDeclarationList().getDeclarations().stream()
+            .filter(node -> node.getUsages().isEmpty())
+            .forEach(node -> reportIssue(context, node, MESSAGE));
+      }
     }
     return context;
   }

--- a/delphi-checks/src/main/java/au/com/integradev/delphi/checks/UnusedPropertyCheck.java
+++ b/delphi-checks/src/main/java/au/com/integradev/delphi/checks/UnusedPropertyCheck.java
@@ -45,6 +45,7 @@ public class UnusedPropertyCheck extends DelphiCheck {
 
   private static boolean isUnused(PropertyNameDeclaration declaration) {
     return !declaration.isPublished()
+        && declaration.getAttributeTypes().isEmpty()
         && declaration.getScope().getOccurrencesFor(declaration).isEmpty()
         && declaration.getRedeclarations().stream().allMatch(UnusedPropertyCheck::isUnused);
   }

--- a/delphi-checks/src/main/java/au/com/integradev/delphi/checks/UnusedRoutineCheck.java
+++ b/delphi-checks/src/main/java/au/com/integradev/delphi/checks/UnusedRoutineCheck.java
@@ -89,6 +89,11 @@ public class UnusedRoutineCheck extends DelphiCheck {
       return false;
     }
 
+    if (routineDeclaration.getTypeDeclaration() != null
+        && !routineDeclaration.getAttributeTypes().isEmpty()) {
+      return false;
+    }
+
     if (routineDeclaration.getName().equalsIgnoreCase("Register")
         && routineDeclaration.getScope() instanceof UnitScope) {
       return false;

--- a/delphi-checks/src/main/resources/org/sonar/l10n/delphi/rules/community-delphi/UnusedField.html
+++ b/delphi-checks/src/main/resources/org/sonar/l10n/delphi/rules/community-delphi/UnusedField.html
@@ -3,9 +3,11 @@
   Having unused fields adversely affects code readability, as their presence is confusing. Code
   that is never used should be removed to keep codebases clean and maintainable.
 </p>
-<p>
-  Note that this rule excludes unused published fields, as these are often accessed via reflection
-  or used by the Delphi IDE for design-time configuration.
-</p>
+<h3>Exceptions</h3>
+<ul>
+  <li>Fields annotated with attributes, as these are often accessed via reflection.</li>
+  <li>Fields with <code>published</code> visibility, as these are often accessed via reflection or
+    used by the Delphi IDE for design-time configuration.</li>
+</ul>
 <h2>How to fix it</h2>
 <p>Remove the unused field.</p>

--- a/delphi-checks/src/main/resources/org/sonar/l10n/delphi/rules/community-delphi/UnusedProperty.html
+++ b/delphi-checks/src/main/resources/org/sonar/l10n/delphi/rules/community-delphi/UnusedProperty.html
@@ -1,11 +1,13 @@
 <h2>Why is this an issue?</h2>
 <p>
-  Having unused property adversely affects code readability, as their presence is confusing. Code
+  Having unused properties adversely affects code readability, as their presence is confusing. Code
   that is never used should be removed to keep codebases clean and maintainable.
 </p>
-<p>
-  Note that this rule excludes unused published properties, as these are often accessed via
-  reflection or used by the Delphi IDE for design-time configuration.
-</p>
+<h3>Exceptions</h3>
+<ul>
+  <li>Properties annotated with attributes, as these are often accessed via reflection.</li>
+  <li>Properties with <code>published</code> visibility, as these are often accessed via reflection or
+    used by the Delphi IDE for design-time configuration.</li>
+</ul>
 <h2>How to fix it</h2>
 <p>Remove the unused property.</p>

--- a/delphi-checks/src/main/resources/org/sonar/l10n/delphi/rules/community-delphi/UnusedRoutine.html
+++ b/delphi-checks/src/main/resources/org/sonar/l10n/delphi/rules/community-delphi/UnusedRoutine.html
@@ -5,6 +5,7 @@
 </p>
 <h3>Exceptions</h3>
 <ul>
+  <li>Methods annotated with attributes, as these are often accessed via reflection.</li>
   <li>Methods with <code>published</code> visibility, as these are often accessed via reflection or
     used by the Delphi IDE for design-time configuration.</li>
   <li>Methods marked <code>override</code>.</li>

--- a/delphi-checks/src/test/java/au/com/integradev/delphi/checks/UnusedFieldCheckTest.java
+++ b/delphi-checks/src/test/java/au/com/integradev/delphi/checks/UnusedFieldCheckTest.java
@@ -37,6 +37,34 @@ class UnusedFieldCheckTest {
   }
 
   @Test
+  void testUnusedPublicFieldWithAttributeShouldNotAddIssue() {
+    CheckVerifier.newVerifier()
+        .withCheck(new UnusedFieldCheck())
+        .onFile(
+            new DelphiTestUnitBuilder()
+                .appendDecl("type TFoo = class")
+                .appendDecl("public")
+                .appendDecl("  [Baz]")
+                .appendDecl("  Bar: Integer;")
+                .appendDecl("end;"))
+        .verifyNoIssues();
+  }
+
+  @Test
+  void testUnusedGroupedPublicFieldsWithAttributeShouldNotAddIssue() {
+    CheckVerifier.newVerifier()
+        .withCheck(new UnusedFieldCheck())
+        .onFile(
+            new DelphiTestUnitBuilder()
+                .appendDecl("type TFoo = class")
+                .appendDecl("public")
+                .appendDecl("  [Flarp]")
+                .appendDecl("  Bar, Baz: Integer;")
+                .appendDecl("end;"))
+        .verifyNoIssues();
+  }
+
+  @Test
   void testUsedInRoutineShouldNotAddIssue() {
     CheckVerifier.newVerifier()
         .withCheck(new UnusedFieldCheck())

--- a/delphi-checks/src/test/java/au/com/integradev/delphi/checks/UnusedPropertyCheckTest.java
+++ b/delphi-checks/src/test/java/au/com/integradev/delphi/checks/UnusedPropertyCheckTest.java
@@ -39,6 +39,22 @@ class UnusedPropertyCheckTest {
   }
 
   @Test
+  void testUnusedPropertyWithAttributeShouldNotAddIssue() {
+    CheckVerifier.newVerifier()
+        .withCheck(new UnusedPropertyCheck())
+        .onFile(
+            new DelphiTestUnitBuilder()
+                .appendDecl("type TFoo = class")
+                .appendDecl("private")
+                .appendDecl("  FBar: Integer;")
+                .appendDecl("public")
+                .appendDecl("  [Flarp]")
+                .appendDecl("  property Bar: Integer read FBar;")
+                .appendDecl("end;"))
+        .verifyNoIssues();
+  }
+
+  @Test
   void testUsedInRoutineShouldNotAddIssue() {
     CheckVerifier.newVerifier()
         .withCheck(new UnusedPropertyCheck())

--- a/delphi-checks/src/test/java/au/com/integradev/delphi/checks/UnusedRoutineCheckTest.java
+++ b/delphi-checks/src/test/java/au/com/integradev/delphi/checks/UnusedRoutineCheckTest.java
@@ -50,6 +50,21 @@ class UnusedRoutineCheckTest {
   }
 
   @Test
+  void testUnusedRoutineWithAttributeShouldAddIssue() {
+    CheckVerifier.newVerifier()
+        .withCheck(new UnusedRoutineCheck())
+        .onFile(
+            new DelphiTestUnitBuilder()
+                .appendDecl("[Bar]")
+                .appendDecl("procedure Foo; // Noncompliant")
+                .appendImpl("procedure Foo;")
+                .appendImpl("begin")
+                .appendImpl("  // do nothing")
+                .appendImpl("end;"))
+        .verifyIssues();
+  }
+
+  @Test
   void testUsedRoutineShouldNotAddIssue() {
     CheckVerifier.newVerifier()
         .withCheck(new UnusedRoutineCheck())
@@ -108,6 +123,25 @@ class UnusedRoutineCheckTest {
                 .appendImpl("  // do nothing")
                 .appendImpl("end;"))
         .verifyIssues();
+  }
+
+  @Test
+  void testUnusedMemberRoutineWithAttributeShouldNotAddIssue() {
+    CheckVerifier.newVerifier()
+        .withCheck(new UnusedRoutineCheck())
+        .onFile(
+            new DelphiTestUnitBuilder()
+                .appendDecl("type")
+                .appendDecl("  TFoo = class")
+                .appendDecl("  public")
+                .appendDecl("    [MyAttr]")
+                .appendDecl("    procedure Foo;")
+                .appendDecl("  end;")
+                .appendImpl("procedure TFoo.Foo;")
+                .appendImpl("begin")
+                .appendImpl("  // do nothing")
+                .appendImpl("end;"))
+        .verifyNoIssues();
   }
 
   @Test

--- a/delphi-frontend/src/main/antlr3/au/com/integradev/delphi/antlr/Delphi.g
+++ b/delphi-frontend/src/main/antlr3/au/com/integradev/delphi/antlr/Delphi.g
@@ -372,7 +372,7 @@ fieldSection                 : 'class'? fieldSectionKey fieldDecl* -> ^(TkFieldS
                              | fieldDecl+ -> ^(TkFieldSection<FieldSectionNodeImpl> fieldDecl+)
                              ;
 fieldDecl                    : attributeList? nameDeclarationList ':' varType portabilityDirective* ';'?
-                             -> ^(TkFieldDeclaration<FieldDeclarationNodeImpl> nameDeclarationList varType portabilityDirective* ';'?)
+                             -> ^(TkFieldDeclaration<FieldDeclarationNodeImpl> nameDeclarationList varType portabilityDirective* attributeList? ';'?)
                              ;
 classHelperType              : 'class'<ClassHelperTypeNodeImpl>^ 'helper' classParent? 'for' typeReference visibilitySection* 'end'
                              ;

--- a/delphi-frontend/src/main/java/au/com/integradev/delphi/antlr/ast/node/AttributeListNodeImpl.java
+++ b/delphi-frontend/src/main/java/au/com/integradev/delphi/antlr/ast/node/AttributeListNodeImpl.java
@@ -20,10 +20,15 @@ package au.com.integradev.delphi.antlr.ast.node;
 
 import au.com.integradev.delphi.antlr.ast.visitors.DelphiParserVisitor;
 import java.util.List;
+import java.util.stream.Collectors;
 import org.antlr.runtime.Token;
 import org.sonar.plugins.communitydelphi.api.ast.AttributeGroupNode;
 import org.sonar.plugins.communitydelphi.api.ast.AttributeListNode;
 import org.sonar.plugins.communitydelphi.api.ast.AttributeNode;
+import org.sonar.plugins.communitydelphi.api.symbol.declaration.NameDeclaration;
+import org.sonar.plugins.communitydelphi.api.symbol.declaration.TypeNameDeclaration;
+import org.sonar.plugins.communitydelphi.api.type.Type;
+import org.sonar.plugins.communitydelphi.api.type.TypeFactory;
 
 public final class AttributeListNodeImpl extends DelphiNodeImpl implements AttributeListNode {
   public AttributeListNodeImpl(Token token) {
@@ -47,5 +52,25 @@ public final class AttributeListNodeImpl extends DelphiNodeImpl implements Attri
   @Override
   public List<AttributeNode> getAttributes() {
     return findDescendantsOfType(AttributeNode.class);
+  }
+
+  @Override
+  public List<Type> getAttributeTypes() {
+    return getAttributes().stream()
+        .map(AttributeNode::getTypeNameOccurrence)
+        .map(
+            occurrence -> {
+              if (occurrence == null) {
+                return TypeFactory.unknownType();
+              }
+
+              NameDeclaration declaration = occurrence.getNameDeclaration();
+              if (!(declaration instanceof TypeNameDeclaration)) {
+                return TypeFactory.unknownType();
+              }
+
+              return ((TypeNameDeclaration) declaration).getType();
+            })
+        .collect(Collectors.toList());
   }
 }

--- a/delphi-frontend/src/main/java/au/com/integradev/delphi/type/factory/TypeFactoryImpl.java
+++ b/delphi-frontend/src/main/java/au/com/integradev/delphi/type/factory/TypeFactoryImpl.java
@@ -36,7 +36,6 @@ import java.util.concurrent.atomic.AtomicLong;
 import java.util.stream.Collectors;
 import javax.annotation.Nullable;
 import org.sonar.plugins.communitydelphi.api.ast.AttributeListNode;
-import org.sonar.plugins.communitydelphi.api.ast.AttributeNode;
 import org.sonar.plugins.communitydelphi.api.ast.ClassHelperTypeNode;
 import org.sonar.plugins.communitydelphi.api.ast.DelphiNode;
 import org.sonar.plugins.communitydelphi.api.ast.GenericDefinitionNode.TypeParameter;
@@ -44,8 +43,6 @@ import org.sonar.plugins.communitydelphi.api.ast.HelperTypeNode;
 import org.sonar.plugins.communitydelphi.api.ast.Node;
 import org.sonar.plugins.communitydelphi.api.ast.TypeDeclarationNode;
 import org.sonar.plugins.communitydelphi.api.ast.TypeNode;
-import org.sonar.plugins.communitydelphi.api.symbol.declaration.NameDeclaration;
-import org.sonar.plugins.communitydelphi.api.symbol.declaration.TypeNameDeclaration;
 import org.sonar.plugins.communitydelphi.api.symbol.declaration.TypedDeclaration;
 import org.sonar.plugins.communitydelphi.api.symbol.scope.DelphiScope;
 import org.sonar.plugins.communitydelphi.api.symbol.scope.FileScope;
@@ -505,22 +502,7 @@ public class TypeFactoryImpl implements TypeFactory {
       return Collections.emptyList();
     }
 
-    return attributeList.getAttributes().stream()
-        .map(AttributeNode::getTypeNameOccurrence)
-        .map(
-            occurrence -> {
-              if (occurrence == null) {
-                return TypeFactory.unknownType();
-              }
-
-              NameDeclaration declaration = occurrence.getNameDeclaration();
-              if (!(declaration instanceof TypeNameDeclaration)) {
-                return TypeFactory.unknownType();
-              }
-
-              return ((TypeNameDeclaration) declaration).getType();
-            })
-        .collect(Collectors.toUnmodifiableList());
+    return attributeList.getAttributeTypes();
   }
 
   public HelperType helper(HelperTypeNode node) {

--- a/delphi-frontend/src/main/java/org/sonar/plugins/communitydelphi/api/ast/AttributeListNode.java
+++ b/delphi-frontend/src/main/java/org/sonar/plugins/communitydelphi/api/ast/AttributeListNode.java
@@ -19,9 +19,12 @@
 package org.sonar.plugins.communitydelphi.api.ast;
 
 import java.util.List;
+import org.sonar.plugins.communitydelphi.api.type.Type;
 
 public interface AttributeListNode extends DelphiNode {
   List<AttributeGroupNode> getAttributeGroups();
 
   List<AttributeNode> getAttributes();
+
+  List<Type> getAttributeTypes();
 }

--- a/delphi-frontend/src/main/java/org/sonar/plugins/communitydelphi/api/symbol/declaration/PropertyNameDeclaration.java
+++ b/delphi-frontend/src/main/java/org/sonar/plugins/communitydelphi/api/symbol/declaration/PropertyNameDeclaration.java
@@ -22,6 +22,7 @@ import java.util.List;
 import javax.annotation.Nullable;
 import org.sonar.plugins.communitydelphi.api.ast.Visibility;
 import org.sonar.plugins.communitydelphi.api.symbol.Invocable;
+import org.sonar.plugins.communitydelphi.api.type.Type;
 
 public interface PropertyNameDeclaration extends TypedDeclaration, Invocable, Visibility {
   String fullyQualifiedName();
@@ -37,4 +38,6 @@ public interface PropertyNameDeclaration extends TypedDeclaration, Invocable, Vi
   boolean isDefaultProperty();
 
   List<PropertyNameDeclaration> getRedeclarations();
+
+  List<Type> getAttributeTypes();
 }

--- a/delphi-frontend/src/main/java/org/sonar/plugins/communitydelphi/api/symbol/declaration/RoutineNameDeclaration.java
+++ b/delphi-frontend/src/main/java/org/sonar/plugins/communitydelphi/api/symbol/declaration/RoutineNameDeclaration.java
@@ -18,10 +18,12 @@
  */
 package org.sonar.plugins.communitydelphi.api.symbol.declaration;
 
+import java.util.List;
 import java.util.Set;
 import javax.annotation.Nullable;
 import org.sonar.plugins.communitydelphi.api.ast.Visibility;
 import org.sonar.plugins.communitydelphi.api.symbol.Invocable;
+import org.sonar.plugins.communitydelphi.api.type.Type;
 
 public interface RoutineNameDeclaration
     extends GenerifiableDeclaration, TypedDeclaration, Invocable, Visibility {
@@ -35,4 +37,6 @@ public interface RoutineNameDeclaration
 
   @Nullable
   TypeNameDeclaration getTypeDeclaration();
+
+  List<Type> getAttributeTypes();
 }

--- a/delphi-frontend/src/test/java/au/com/integradev/delphi/symbol/declaration/RoutineNameDeclarationTest.java
+++ b/delphi-frontend/src/test/java/au/com/integradev/delphi/symbol/declaration/RoutineNameDeclarationTest.java
@@ -61,6 +61,8 @@ class RoutineNameDeclarationTest {
   private static final List<TypedDeclaration> TYPE_PARAMETERS =
       List.of(mock(TypedDeclaration.class));
 
+  private static final List<Type> ATTRIBUTE_TYPES = Collections.emptyList();
+
   private static final RoutineNameDeclaration ROUTINE =
       new RoutineNameDeclarationImpl(
           LOCATION,
@@ -73,7 +75,8 @@ class RoutineNameDeclarationTest {
           ROUTINE_TYPE,
           TYPE_NAME_DECLARATION,
           VISIBILITY,
-          TYPE_PARAMETERS);
+          TYPE_PARAMETERS,
+          ATTRIBUTE_TYPES);
 
   @Test
   void testEquals() {
@@ -89,7 +92,8 @@ class RoutineNameDeclarationTest {
             ROUTINE_TYPE,
             TYPE_NAME_DECLARATION,
             VISIBILITY,
-            TYPE_PARAMETERS);
+            TYPE_PARAMETERS,
+            ATTRIBUTE_TYPES);
 
     RoutineNameDeclarationImpl forwardDeclaration =
         new RoutineNameDeclarationImpl(
@@ -103,7 +107,8 @@ class RoutineNameDeclarationTest {
             ROUTINE_TYPE,
             TYPE_NAME_DECLARATION,
             VISIBILITY,
-            TYPE_PARAMETERS);
+            TYPE_PARAMETERS,
+            ATTRIBUTE_TYPES);
     forwardDeclaration.setIsForwardDeclaration();
 
     RoutineNameDeclarationImpl implementationDeclaration =
@@ -118,7 +123,8 @@ class RoutineNameDeclarationTest {
             ROUTINE_TYPE,
             TYPE_NAME_DECLARATION,
             VISIBILITY,
-            TYPE_PARAMETERS);
+            TYPE_PARAMETERS,
+            ATTRIBUTE_TYPES);
     implementationDeclaration.setIsImplementationDeclaration();
 
     RoutineNameDeclaration differentLocation =
@@ -133,7 +139,8 @@ class RoutineNameDeclarationTest {
             ROUTINE_TYPE,
             TYPE_NAME_DECLARATION,
             VISIBILITY,
-            TYPE_PARAMETERS);
+            TYPE_PARAMETERS,
+            ATTRIBUTE_TYPES);
 
     RoutineNameDeclaration differentFullyQualifiedName =
         new RoutineNameDeclarationImpl(
@@ -147,7 +154,8 @@ class RoutineNameDeclarationTest {
             ROUTINE_TYPE,
             TYPE_NAME_DECLARATION,
             VISIBILITY,
-            TYPE_PARAMETERS);
+            TYPE_PARAMETERS,
+            ATTRIBUTE_TYPES);
 
     RoutineNameDeclaration differentReturnType =
         new RoutineNameDeclarationImpl(
@@ -161,7 +169,8 @@ class RoutineNameDeclarationTest {
             ROUTINE_TYPE,
             TYPE_NAME_DECLARATION,
             VISIBILITY,
-            TYPE_PARAMETERS);
+            TYPE_PARAMETERS,
+            ATTRIBUTE_TYPES);
 
     RoutineNameDeclaration differentDirectives =
         new RoutineNameDeclarationImpl(
@@ -175,7 +184,8 @@ class RoutineNameDeclarationTest {
             ROUTINE_TYPE,
             TYPE_NAME_DECLARATION,
             VISIBILITY,
-            TYPE_PARAMETERS);
+            TYPE_PARAMETERS,
+            ATTRIBUTE_TYPES);
 
     RoutineNameDeclaration differentIsClassInvocable =
         new RoutineNameDeclarationImpl(
@@ -189,7 +199,8 @@ class RoutineNameDeclarationTest {
             ROUTINE_TYPE,
             TYPE_NAME_DECLARATION,
             VISIBILITY,
-            TYPE_PARAMETERS);
+            TYPE_PARAMETERS,
+            ATTRIBUTE_TYPES);
 
     RoutineNameDeclaration differentIsCallable =
         new RoutineNameDeclarationImpl(
@@ -203,7 +214,8 @@ class RoutineNameDeclarationTest {
             ROUTINE_TYPE,
             TYPE_NAME_DECLARATION,
             VISIBILITY,
-            TYPE_PARAMETERS);
+            TYPE_PARAMETERS,
+            ATTRIBUTE_TYPES);
 
     RoutineNameDeclaration differentRoutineType =
         new RoutineNameDeclarationImpl(
@@ -217,7 +229,8 @@ class RoutineNameDeclarationTest {
             ((TypeFactoryImpl) FACTORY).routine(Collections.emptyList(), TypeFactory.untypedType()),
             TYPE_NAME_DECLARATION,
             VISIBILITY,
-            TYPE_PARAMETERS);
+            TYPE_PARAMETERS,
+            ATTRIBUTE_TYPES);
 
     RoutineNameDeclaration differentTypeParameters =
         new RoutineNameDeclarationImpl(
@@ -231,7 +244,8 @@ class RoutineNameDeclarationTest {
             ROUTINE_TYPE,
             TYPE_NAME_DECLARATION,
             VISIBILITY,
-            Collections.emptyList());
+            Collections.emptyList(),
+            ATTRIBUTE_TYPES);
 
     assertThat(ROUTINE)
         .isEqualTo(ROUTINE)

--- a/delphi-frontend/src/test/java/au/com/integradev/delphi/symbol/scope/RoutineScopeImplTest.java
+++ b/delphi-frontend/src/test/java/au/com/integradev/delphi/symbol/scope/RoutineScopeImplTest.java
@@ -50,6 +50,7 @@ class RoutineScopeImplTest {
             mock(ProceduralType.class),
             null,
             VisibilityType.PUBLIC,
+            Collections.emptyList(),
             Collections.emptyList()));
 
     assertThat(routineScope).hasToString("Foo <RoutineScope>");


### PR DESCRIPTION
Routines, properties, or fields that are annotated with an attribute are generally done so because they will be accessed at runtime via RTTI. This PR fixes #113 by excluding these members from UnusedRoutine, UnusedProperty, and UnusedField.

A couple of changes have been made to the API to facilitate this change:

- `AttributeListNode` now has a `getAttributeTypes` method that returns the list of attributes as their types
- `PropertyNameDeclaration` now has a `getAttributeTypes` method that returns a list of the types of each annotated attribute
- `RoutineNameDeclaration` now has a `getAttributeTypes` method that returns a list of the types of each annotated attribute