### PR TITLE
Add support Unicode identifiers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Support for unicode characters in identifiers.
 - Support for the NUnit 2.0 test results format (in addition to existing 3.0 support).
 - `ConsecutiveVarSection` analysis rule, which flags consecutive `var` sections that can be merged.
 - `ConsecutiveConstSection` analysis rule, which flags consecutive `const` sections that can be

--- a/delphi-frontend/src/test/resources/au/com/integradev/delphi/grammar/FullWidthNumeralBeforeIdentifier.pas
+++ b/delphi-frontend/src/test/resources/au/com/integradev/delphi/grammar/FullWidthNumeralBeforeIdentifier.pas
@@ -1,0 +1,10 @@
+unit FullWidthNumeralBeforeIdentifier;
+
+interface
+
+const
+  ０Ident = 0;
+
+implementation
+
+end.

--- a/delphi-frontend/src/test/resources/au/com/integradev/delphi/grammar/UnicodeIdentifiers.pas
+++ b/delphi-frontend/src/test/resources/au/com/integradev/delphi/grammar/UnicodeIdentifiers.pas
@@ -1,0 +1,29 @@
+unit UnicodeIdentifiers;
+
+interface
+
+const
+  // technically not valid Delphi, but there's no reason we shouldn't parse it properly
+  😎SurrogatePair😎 = 0;
+
+  Âçcèñtëd = 0;
+
+
+  Ĉ̵̮̓͊u̸̢̻̚ŕ̷̬͔s̴̯̰͈͗̎̾ê̷̗̚d̵̤͍͊̇͛ͅ = 0;
+
+
+  // Fullwidth numerals
+  A０ = 0;
+  A１ = 0;
+  A２ = 0;
+  A３ = 0;
+  A４ = 0;
+  A５ = 0;
+  A６ = 0;
+  A７ = 0;
+  A８ = 0;
+  A９ = 0;
+
+implementation
+
+end.


### PR DESCRIPTION
Fixes #125

The Unicode-aware case-insensitive identifier comparison that we are currently performing doesn't _perfectly_ match the Delphi compiler, but @Cirras and I decided it wasn't worth trying to match this unspecified behaviour. Instead, I documented the situation with some tests and comments in `DelphiScopeImplTest`