### PR TITLE
Highlight the whole hard cast expression when reporting issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Exclude properties annotated with attributes in `UnusedProperty`.
 - Exclude fields annotated with attributes in `UnusedField`.
 - Improve type modeling around integer subranges.
+- Issues raised on a hard cast expression now span the entire expression in `UnicodeToAnsiCast`,
+  `CharacterToCharacterPointerCast`, `NonLinearCast`, `RedundantCast`, and `PlatformDependentCast`.
 
 ### Fixed
 

--- a/delphi-checks/src/main/java/au/com/integradev/delphi/checks/AbstractCastCheck.java
+++ b/delphi-checks/src/main/java/au/com/integradev/delphi/checks/AbstractCastCheck.java
@@ -22,9 +22,11 @@ import au.com.integradev.delphi.utils.CastUtils;
 import au.com.integradev.delphi.utils.CastUtils.DelphiCast;
 import java.util.Optional;
 import org.sonar.plugins.communitydelphi.api.ast.BinaryExpressionNode;
+import org.sonar.plugins.communitydelphi.api.ast.DelphiNode;
 import org.sonar.plugins.communitydelphi.api.ast.PrimaryExpressionNode;
 import org.sonar.plugins.communitydelphi.api.check.DelphiCheck;
 import org.sonar.plugins.communitydelphi.api.check.DelphiCheckContext;
+import org.sonar.plugins.communitydelphi.api.check.FilePosition;
 import org.sonar.plugins.communitydelphi.api.type.Type;
 
 public abstract class AbstractCastCheck extends DelphiCheck {
@@ -61,7 +63,19 @@ public abstract class AbstractCastCheck extends DelphiCheck {
       Type castedType = cast.get().castedType();
 
       if (castedType != null && isViolation(originalType, castedType)) {
-        reportIssue(context, primaryExpression, getIssueMessage());
+        DelphiNode name = primaryExpression.getChild(0);
+        DelphiNode argumentList = primaryExpression.getChild(1);
+
+        context
+            .newIssue()
+            .onFilePosition(
+                FilePosition.from(
+                    name.getBeginLine(),
+                    name.getBeginColumn(),
+                    argumentList.getEndLine(),
+                    argumentList.getEndColumn()))
+            .withMessage(getIssueMessage())
+            .report();
       }
     }
 

--- a/delphi-checks/src/main/java/au/com/integradev/delphi/checks/PlatformDependentCastCheck.java
+++ b/delphi-checks/src/main/java/au/com/integradev/delphi/checks/PlatformDependentCastCheck.java
@@ -21,12 +21,14 @@ package au.com.integradev.delphi.checks;
 import java.util.List;
 import org.sonar.check.Rule;
 import org.sonar.plugins.communitydelphi.api.ast.ArgumentListNode;
+import org.sonar.plugins.communitydelphi.api.ast.DelphiNode;
 import org.sonar.plugins.communitydelphi.api.ast.ExpressionNode;
 import org.sonar.plugins.communitydelphi.api.ast.NameReferenceNode;
 import org.sonar.plugins.communitydelphi.api.ast.Node;
 import org.sonar.plugins.communitydelphi.api.ast.utils.ExpressionNodeUtils;
 import org.sonar.plugins.communitydelphi.api.check.DelphiCheck;
 import org.sonar.plugins.communitydelphi.api.check.DelphiCheckContext;
+import org.sonar.plugins.communitydelphi.api.check.FilePosition;
 import org.sonar.plugins.communitydelphi.api.symbol.declaration.NameDeclaration;
 import org.sonar.plugins.communitydelphi.api.symbol.declaration.TypeNameDeclaration;
 import org.sonar.plugins.communitydelphi.api.token.DelphiTokenType;
@@ -54,7 +56,18 @@ public class PlatformDependentCastCheck extends DelphiCheck {
         Type castedType = getHardCastedType(argumentList, context);
 
         if (isPlatformDependentCast(originalType, castedType)) {
-          reportIssue(context, argumentList, MESSAGE);
+          DelphiNode name = argumentList.getParent().getChild(argumentList.getChildIndex() - 1);
+
+          context
+              .newIssue()
+              .onFilePosition(
+                  FilePosition.from(
+                      name.getBeginLine(),
+                      name.getBeginColumn(),
+                      argumentList.getEndLine(),
+                      argumentList.getEndColumn()))
+              .withMessage(MESSAGE)
+              .report();
         }
       }
     }


### PR DESCRIPTION
The current standard behavior around flagging hard casts is to highlight the argument list in the issue.
```
ShortInt(123);
        ^^^^^
```

This can be very confusing in the case of nested hard casts, and you might erroneously think the issue applies to the inner cast.
 Consistently highlighting the whole cast expression would make this clearer:
```
ShortInt(123);
^^^^^^^^^^^^^
```

This PR changes the behavior to highlight the whole hard cast expression in the following rules:
- `UnicodeToAnsiCast`
- `CharacterToCharacterPointerCastCheck`
- `NonLinearCastCheck`
- `RedundantCastCheck`
- `PlatformDependentCast`