### PR TITLE
Add `excludeApi` property to the `Unused*` rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,8 +18,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   merged.
 - `ConsecutiveVisibilitySection` analysis rule, which flags consecutive visibility sections that can
   be merged.
-- `VarSectionNode::isThreadVarSection` API method.
-- `ConstSectionNode::isResourceStringSection` API method.
+- `excludeApi` rule property to most of the `Unused*` rules:
+  - Available for `UnusedConstant`, `UnusedField`, `UnusedGlobalVariable`, `UnusedProperty`,
+    `UnusedRoutine`, and `UnusedType`.
+  - Excludes public API (declared with public visibility in the interface section).
+- **API**: `VarSectionNode::isThreadVarSection` method.
+- **API**: `ConstSectionNode::isResourceStringSection` method.
 
 ### Changed
 
@@ -31,6 +35,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Improve type modeling around integer subranges.
 - Issues raised on a hard cast expression now span the entire expression in `UnicodeToAnsiCast`,
   `CharacterToCharacterPointerCast`, `NonLinearCast`, `RedundantCast`, and `PlatformDependentCast`.
+- **API:** `TypeSectionNode` now implements `Visibility`.
+- **API:** `TypeDeclarationNode` now implements `Visibility`.
 
 ### Fixed
 

--- a/delphi-checks/src/main/java/au/com/integradev/delphi/checks/UnusedRoutineCheck.java
+++ b/delphi-checks/src/main/java/au/com/integradev/delphi/checks/UnusedRoutineCheck.java
@@ -24,7 +24,9 @@ import au.com.integradev.delphi.utils.InterfaceUtils;
 import java.util.HashSet;
 import java.util.Set;
 import org.sonar.check.Rule;
+import org.sonar.check.RuleProperty;
 import org.sonar.plugins.communitydelphi.api.ast.DelphiAst;
+import org.sonar.plugins.communitydelphi.api.ast.InterfaceSectionNode;
 import org.sonar.plugins.communitydelphi.api.ast.RoutineDeclarationNode;
 import org.sonar.plugins.communitydelphi.api.ast.RoutineImplementationNode;
 import org.sonar.plugins.communitydelphi.api.ast.RoutineNode;
@@ -45,6 +47,11 @@ import org.sonarsource.analyzer.commons.annotations.DeprecatedRuleKey;
 @Rule(key = "UnusedRoutine")
 public class UnusedRoutineCheck extends DelphiCheck {
   private static final String MESSAGE = "Remove this unused routine.";
+
+  @RuleProperty(
+      key = "excludeApi",
+      description = "Exclude routines declared in the interface section with public visibility.")
+  public boolean excludeApi = false;
 
   private final Set<RoutineNameDeclaration> seenRoutines = new HashSet<>();
 
@@ -67,8 +74,14 @@ public class UnusedRoutineCheck extends DelphiCheck {
     return super.visit(routine, context);
   }
 
-  private static boolean isViolation(RoutineNode routine) {
+  private boolean isViolation(RoutineNode routine) {
     if (routine.isPublished()) {
+      return false;
+    }
+
+    if (excludeApi
+        && routine.isPublic()
+        && routine.getFirstParentOfType(InterfaceSectionNode.class) != null) {
       return false;
     }
 

--- a/delphi-checks/src/test/java/au/com/integradev/delphi/checks/UnusedConstantCheckTest.java
+++ b/delphi-checks/src/test/java/au/com/integradev/delphi/checks/UnusedConstantCheckTest.java
@@ -158,4 +158,64 @@ class UnusedConstantCheckTest {
                 .appendImpl("end;"))
         .verifyNoIssues();
   }
+
+  @Test
+  void testUnusedApiConstantWithExcludeApiShouldNotAddIssue() {
+    var check = new UnusedConstantCheck();
+    check.excludeApi = true;
+
+    CheckVerifier.newVerifier()
+        .withCheck(check)
+        .onFile(
+            new DelphiTestUnitBuilder()
+                .appendDecl("const")
+                .appendDecl("  CFoo = 'Foo';")
+                .appendDecl("")
+                .appendDecl("type TFoo = class")
+                .appendDecl("public const")
+                .appendDecl("  CBar = 'Bar';")
+                .appendDecl("published const")
+                .appendDecl("  CBaz = 'Baz';")
+                .appendDecl("end;"))
+        .verifyNoIssues();
+  }
+
+  @Test
+  void testUnusedNonPublicConstantWithExcludeApiShouldAddIssue() {
+    var check = new UnusedConstantCheck();
+    check.excludeApi = true;
+
+    CheckVerifier.newVerifier()
+        .withCheck(check)
+        .onFile(
+            new DelphiTestUnitBuilder()
+                .appendDecl("type TFoo = class")
+                .appendDecl("private const")
+                .appendDecl("  CBar = 'Bar'; // Noncompliant")
+                .appendDecl("protected const")
+                .appendDecl("  CBaz = 'Baz'; // Noncompliant")
+                .appendDecl("end;"))
+        .verifyIssues();
+  }
+
+  @Test
+  void testUnusedImplementationConstantWithExcludeApiShouldAddIssue() {
+    var check = new UnusedConstantCheck();
+    check.excludeApi = true;
+
+    CheckVerifier.newVerifier()
+        .withCheck(check)
+        .onFile(
+            new DelphiTestUnitBuilder()
+                .appendImpl("const")
+                .appendImpl("  CFoo = 'Foo'; // Noncompliant")
+                .appendImpl("")
+                .appendImpl("type TFoo = class")
+                .appendImpl("public const")
+                .appendImpl("  CBar = 'Bar'; // Noncompliant")
+                .appendImpl("published const")
+                .appendImpl("  CBaz = 'Baz'; // Noncompliant")
+                .appendImpl("end;"))
+        .verifyIssues();
+  }
 }

--- a/delphi-checks/src/test/java/au/com/integradev/delphi/checks/UnusedFieldCheckTest.java
+++ b/delphi-checks/src/test/java/au/com/integradev/delphi/checks/UnusedFieldCheckTest.java
@@ -96,4 +96,54 @@ class UnusedFieldCheckTest {
                 .appendImpl("end;"))
         .verifyNoIssues();
   }
+
+  @Test
+  void testUnusedApiFieldWithExcludeApiShouldNotAddIssue() {
+    var check = new UnusedFieldCheck();
+    check.excludeApi = true;
+
+    CheckVerifier.newVerifier()
+        .withCheck(check)
+        .onFile(
+            new DelphiTestUnitBuilder()
+                .appendDecl("type TFoo = class")
+                .appendDecl("public")
+                .appendDecl("  Bar: Integer;")
+                .appendDecl("end;"))
+        .verifyNoIssues();
+  }
+
+  @Test
+  void testUnusedNonPublicFieldWithExcludeApiShouldAddIssue() {
+    var check = new UnusedFieldCheck();
+    check.excludeApi = true;
+
+    CheckVerifier.newVerifier()
+        .withCheck(check)
+        .onFile(
+            new DelphiTestUnitBuilder()
+                .appendDecl("type TFoo = class")
+                .appendDecl("private")
+                .appendDecl("  Bar: Integer; // Noncompliant")
+                .appendDecl("protected")
+                .appendDecl("  Baz: Integer; // Noncompliant")
+                .appendDecl("end;"))
+        .verifyIssues();
+  }
+
+  @Test
+  void testUnusedImplementationFieldWithExcludeApiShouldAddIssue() {
+    var check = new UnusedFieldCheck();
+    check.excludeApi = true;
+
+    CheckVerifier.newVerifier()
+        .withCheck(check)
+        .onFile(
+            new DelphiTestUnitBuilder()
+                .appendImpl("type TFoo = class")
+                .appendImpl("public")
+                .appendImpl("  Bar: Integer; // Noncompliant")
+                .appendImpl("end;"))
+        .verifyIssues();
+  }
 }

--- a/delphi-checks/src/test/java/au/com/integradev/delphi/checks/UnusedGlobalVariableCheckTest.java
+++ b/delphi-checks/src/test/java/au/com/integradev/delphi/checks/UnusedGlobalVariableCheckTest.java
@@ -24,7 +24,7 @@ import org.junit.jupiter.api.Test;
 
 class UnusedGlobalVariableCheckTest {
   @Test
-  void testUsedGlobalConstantShouldNotAddIssue() {
+  void testUsedGlobalVariableShouldNotAddIssue() {
     CheckVerifier.newVerifier()
         .withCheck(new UnusedGlobalVariableCheck())
         .onFile(
@@ -39,7 +39,7 @@ class UnusedGlobalVariableCheckTest {
   }
 
   @Test
-  void testUnusedGlobalConstantShouldAddIssue() {
+  void testUnusedGlobalVariableShouldAddIssue() {
     CheckVerifier.newVerifier()
         .withCheck(new UnusedGlobalVariableCheck())
         .onFile(
@@ -74,5 +74,33 @@ class UnusedGlobalVariableCheckTest {
         .appendDecl("type")
         .appendDecl("TForm = class(TComponent)")
         .appendDecl("end;");
+  }
+
+  @Test
+  void testUnusedApiGlobalVariableWithExcludeApiShouldNotAddIssue() {
+    var check = new UnusedGlobalVariableCheck();
+    check.excludeApi = true;
+
+    CheckVerifier.newVerifier()
+        .withCheck(check)
+        .onFile(
+            new DelphiTestUnitBuilder() //
+                .appendDecl("var")
+                .appendDecl("  Foo: Integer;"))
+        .verifyNoIssues();
+  }
+
+  @Test
+  void testUnusedImplementationGlobalVariableWithExcludeApiShouldAddIssue() {
+    var check = new UnusedGlobalVariableCheck();
+    check.excludeApi = true;
+
+    CheckVerifier.newVerifier()
+        .withCheck(check)
+        .onFile(
+            new DelphiTestUnitBuilder() //
+                .appendImpl("var")
+                .appendImpl("  Foo: Integer; // Noncompliant"))
+        .verifyIssues();
   }
 }

--- a/delphi-checks/src/test/java/au/com/integradev/delphi/checks/UnusedPropertyCheckTest.java
+++ b/delphi-checks/src/test/java/au/com/integradev/delphi/checks/UnusedPropertyCheckTest.java
@@ -188,4 +188,59 @@ class UnusedPropertyCheckTest {
                 .appendImpl("end;"))
         .verifyIssues();
   }
+
+  @Test
+  void testUnusedApiPropertyWithExcludeApiShouldNotAddIssue() {
+    var check = new UnusedPropertyCheck();
+    check.excludeApi = true;
+
+    CheckVerifier.newVerifier()
+        .withCheck(check)
+        .onFile(
+            new DelphiTestUnitBuilder()
+                .appendDecl("type TFoo = class")
+                .appendDecl("private")
+                .appendDecl("  FBar: Integer;")
+                .appendDecl("public")
+                .appendDecl("  property Bar: Integer read FBar;")
+                .appendDecl("end;"))
+        .verifyNoIssues();
+  }
+
+  @Test
+  void testUnusedNonPublicPropertyWithExcludeApiShouldAddIssue() {
+    var check = new UnusedPropertyCheck();
+    check.excludeApi = true;
+
+    CheckVerifier.newVerifier()
+        .withCheck(check)
+        .onFile(
+            new DelphiTestUnitBuilder()
+                .appendDecl("type TFoo = class")
+                .appendDecl("private")
+                .appendDecl("  FBar: Integer;")
+                .appendDecl("  property Bar: Integer read FBar; // Noncompliant")
+                .appendDecl("protected")
+                .appendDecl("  property Bar: Integer read FBar; // Noncompliant")
+                .appendDecl("end;"))
+        .verifyIssues();
+  }
+
+  @Test
+  void testUnusedImplementationPropertyWithExcludeApiShouldAddIssue() {
+    var check = new UnusedPropertyCheck();
+    check.excludeApi = true;
+
+    CheckVerifier.newVerifier()
+        .withCheck(check)
+        .onFile(
+            new DelphiTestUnitBuilder()
+                .appendImpl("type TFoo = class")
+                .appendImpl("private")
+                .appendImpl("  FBar: Integer;")
+                .appendImpl("public")
+                .appendImpl("  property Bar: Integer read FBar; //Noncompliant")
+                .appendImpl("end;"))
+        .verifyIssues();
+  }
 }

--- a/delphi-checks/src/test/java/au/com/integradev/delphi/checks/UnusedRoutineCheckTest.java
+++ b/delphi-checks/src/test/java/au/com/integradev/delphi/checks/UnusedRoutineCheckTest.java
@@ -352,4 +352,61 @@ class UnusedRoutineCheckTest {
                 .appendDecl("  end;"))
         .verifyIssues();
   }
+
+  @Test
+  void testUnusedApiPropertyWithExcludeApiShouldNotAddIssue() {
+    var check = new UnusedRoutineCheck();
+    check.excludeApi = true;
+
+    CheckVerifier.newVerifier()
+        .withCheck(check)
+        .onFile(
+            new DelphiTestUnitBuilder()
+                .appendDecl("type TFoo = class")
+                .appendDecl("public")
+                .appendDecl("  procedure Bar;")
+                .appendDecl("end;")
+                .appendDecl("")
+                .appendDecl("procedure Baz;"))
+        .verifyNoIssues();
+  }
+
+  @Test
+  void testUnusedNonPublicRoutineWithExcludeApiShouldAddIssue() {
+    var check = new UnusedRoutineCheck();
+    check.excludeApi = true;
+
+    CheckVerifier.newVerifier()
+        .withCheck(check)
+        .onFile(
+            new DelphiTestUnitBuilder()
+                .appendDecl("type TFoo = class")
+                .appendDecl("private")
+                .appendDecl("  procedure Bar; // Noncompliant")
+                .appendDecl("protected")
+                .appendDecl("  procedure Baz; // Noncompliant")
+                .appendDecl("end;"))
+        .verifyIssues();
+  }
+
+  @Test
+  void testUnusedImplementationRoutineWithExcludeApiShouldAddIssue() {
+    var check = new UnusedRoutineCheck();
+    check.excludeApi = true;
+
+    CheckVerifier.newVerifier()
+        .withCheck(check)
+        .onFile(
+            new DelphiTestUnitBuilder()
+                .appendImpl("type TFoo = class")
+                .appendImpl("public")
+                .appendImpl("  procedure Bar; // Noncompliant")
+                .appendImpl("end;")
+                .appendImpl("")
+                .appendImpl("procedure Baz; // Noncompliant")
+                .appendImpl("begin")
+                .appendImpl("  // do nothing")
+                .appendImpl("end;"))
+        .verifyIssues();
+  }
 }

--- a/delphi-checks/src/test/java/au/com/integradev/delphi/checks/UnusedTypeCheckTest.java
+++ b/delphi-checks/src/test/java/au/com/integradev/delphi/checks/UnusedTypeCheckTest.java
@@ -127,4 +127,76 @@ class UnusedTypeCheckTest {
                 .appendDecl("  end;"))
         .verifyNoIssues();
   }
+
+  @Test
+  void testUnusedApiTypeWithExcludeApiShouldNotAddIssue() {
+    var check = new UnusedTypeCheck();
+    check.excludeApi = true;
+
+    CheckVerifier.newVerifier()
+        .withCheck(check)
+        .onFile(
+            new DelphiTestUnitBuilder() //
+                .appendDecl("type TFoo = class")
+                .appendDecl("end;"))
+        .verifyNoIssues();
+  }
+
+  @Test
+  void testUnusedNestedApiTypeWithExcludeApiShouldNotAddIssue() {
+    var check = new UnusedTypeCheck();
+    check.excludeApi = true;
+
+    CheckVerifier.newVerifier()
+        .withCheck(check)
+        .onFile(
+            new DelphiTestUnitBuilder()
+                .appendDecl("type TFoo = class")
+                .appendDecl("  public type")
+                .appendDecl("    TBar = class")
+                .appendDecl("    end;")
+                .appendDecl("  published type")
+                .appendDecl("    TBaz = class")
+                .appendDecl("    end;")
+                .appendDecl("end;"))
+        .verifyNoIssues();
+  }
+
+  @Test
+  void testUnusedNonPublicTypeWithExcludeApiShouldAddIssue() {
+    var check = new UnusedTypeCheck();
+    check.excludeApi = true;
+
+    CheckVerifier.newVerifier()
+        .withCheck(check)
+        .onFile(
+            new DelphiTestUnitBuilder()
+                .appendDecl("type TFoo = class")
+                .appendDecl("private type")
+                .appendDecl("  TBar = class end; // Noncompliant")
+                .appendDecl("protected type")
+                .appendDecl("  TBaz = class end; // Noncompliant")
+                .appendDecl("end;"))
+        .verifyIssues();
+  }
+
+  @Test
+  void testUnusedImplementationTypeWithExcludeApiShouldAddIssue() {
+    var check = new UnusedTypeCheck();
+    check.excludeApi = true;
+
+    CheckVerifier.newVerifier()
+        .withCheck(check)
+        .onFile(
+            new DelphiTestUnitBuilder()
+                .appendImpl("type TFoo = class // Noncompliant")
+                .appendImpl("  public type")
+                .appendImpl("    TBar = class // Noncompliant")
+                .appendImpl("    end;")
+                .appendImpl("  published type")
+                .appendImpl("    TBaz = class // Noncompliant")
+                .appendImpl("    end;")
+                .appendImpl("end;"))
+        .verifyIssues();
+  }
 }

--- a/delphi-frontend/src/main/java/au/com/integradev/delphi/antlr/ast/node/TypeDeclarationNodeImpl.java
+++ b/delphi-frontend/src/main/java/au/com/integradev/delphi/antlr/ast/node/TypeDeclarationNodeImpl.java
@@ -29,6 +29,7 @@ import org.sonar.plugins.communitydelphi.api.ast.AttributeListNode;
 import org.sonar.plugins.communitydelphi.api.ast.ClassHelperTypeNode;
 import org.sonar.plugins.communitydelphi.api.ast.ClassReferenceTypeNode;
 import org.sonar.plugins.communitydelphi.api.ast.ClassTypeNode;
+import org.sonar.plugins.communitydelphi.api.ast.DelphiNode;
 import org.sonar.plugins.communitydelphi.api.ast.EnumTypeNode;
 import org.sonar.plugins.communitydelphi.api.ast.InterfaceTypeNode;
 import org.sonar.plugins.communitydelphi.api.ast.ObjectTypeNode;
@@ -39,6 +40,7 @@ import org.sonar.plugins.communitydelphi.api.ast.SimpleNameDeclarationNode;
 import org.sonar.plugins.communitydelphi.api.ast.StrongAliasTypeNode;
 import org.sonar.plugins.communitydelphi.api.ast.TypeDeclarationNode;
 import org.sonar.plugins.communitydelphi.api.ast.TypeNode;
+import org.sonar.plugins.communitydelphi.api.ast.TypeSectionNode;
 import org.sonar.plugins.communitydelphi.api.ast.WeakAliasTypeNode;
 import org.sonar.plugins.communitydelphi.api.symbol.QualifiedName;
 import org.sonar.plugins.communitydelphi.api.symbol.declaration.TypeNameDeclaration;
@@ -206,6 +208,15 @@ public final class TypeDeclarationNodeImpl extends DelphiNodeImpl implements Typ
   public boolean isForwardDeclaration() {
     TypeNameDeclaration declaration = getTypeNameDeclaration();
     return declaration != null && declaration.isForwardDeclaration();
+  }
+
+  @Override
+  public VisibilityType getVisibility() {
+    DelphiNode parent = getParent();
+    if (parent instanceof TypeSectionNode) {
+      return ((TypeSectionNode) parent).getVisibility();
+    }
+    return VisibilityType.PUBLIC;
   }
 
   @Override

--- a/delphi-frontend/src/main/java/au/com/integradev/delphi/antlr/ast/node/TypeSectionNodeImpl.java
+++ b/delphi-frontend/src/main/java/au/com/integradev/delphi/antlr/ast/node/TypeSectionNodeImpl.java
@@ -21,8 +21,10 @@ package au.com.integradev.delphi.antlr.ast.node;
 import au.com.integradev.delphi.antlr.ast.visitors.DelphiParserVisitor;
 import java.util.List;
 import org.antlr.runtime.Token;
+import org.sonar.plugins.communitydelphi.api.ast.DelphiNode;
 import org.sonar.plugins.communitydelphi.api.ast.TypeDeclarationNode;
 import org.sonar.plugins.communitydelphi.api.ast.TypeSectionNode;
+import org.sonar.plugins.communitydelphi.api.ast.VisibilitySectionNode;
 
 public final class TypeSectionNodeImpl extends DelphiNodeImpl implements TypeSectionNode {
   public TypeSectionNodeImpl(Token token) {
@@ -37,5 +39,14 @@ public final class TypeSectionNodeImpl extends DelphiNodeImpl implements TypeSec
   @Override
   public List<TypeDeclarationNode> getDeclarations() {
     return findChildrenOfType(TypeDeclarationNode.class);
+  }
+
+  @Override
+  public VisibilityType getVisibility() {
+    DelphiNode parent = getParent();
+    if (parent instanceof VisibilitySectionNode) {
+      return ((VisibilitySectionNode) parent).getVisibility();
+    }
+    return VisibilityType.PUBLIC;
   }
 }

--- a/delphi-frontend/src/main/java/org/sonar/plugins/communitydelphi/api/ast/TypeDeclarationNode.java
+++ b/delphi-frontend/src/main/java/org/sonar/plugins/communitydelphi/api/ast/TypeDeclarationNode.java
@@ -24,7 +24,7 @@ import org.sonar.plugins.communitydelphi.api.symbol.Qualifiable;
 import org.sonar.plugins.communitydelphi.api.symbol.declaration.TypeNameDeclaration;
 import org.sonar.plugins.communitydelphi.api.type.Typed;
 
-public interface TypeDeclarationNode extends DelphiNode, Typed, Qualifiable {
+public interface TypeDeclarationNode extends DelphiNode, Typed, Qualifiable, Visibility {
   SimpleNameDeclarationNode getTypeNameNode();
 
   TypeNode getTypeNode();

--- a/delphi-frontend/src/main/java/org/sonar/plugins/communitydelphi/api/ast/TypeSectionNode.java
+++ b/delphi-frontend/src/main/java/org/sonar/plugins/communitydelphi/api/ast/TypeSectionNode.java
@@ -20,6 +20,6 @@ package org.sonar.plugins.communitydelphi.api.ast;
 
 import java.util.List;
 
-public interface TypeSectionNode extends DelphiNode {
+public interface TypeSectionNode extends DelphiNode, Visibility {
   List<TypeDeclarationNode> getDeclarations();
 }


### PR DESCRIPTION
This new property excludes public API (declared in the interface section with public visibility).

This primarily caters to libraries, which have large public API surfaces that are intended for consumers of the library.

Closes #106