### PR TITLE
Reference new attribute-related API methods in changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Excludes public API (declared with public visibility in the interface section).
 - **API**: `VarSectionNode::isThreadVarSection` method.
 - **API**: `ConstSectionNode::isResourceStringSection` method.
+- **API**: `AttributeListNode::getAttributeTypes` method.
+- **API**: `RoutineNameDeclaration::getAttributeTypes` method.
+- **API**: `PropertyNameDeclaration::getAttributeTypes` method.
 
 ### Changed
 


### PR DESCRIPTION
Changelog entries describing the API methods introduced in #121 were accidentally removed in a5d88a010ac62f6c22e2d66c5bba56d1111977ee. This PR re-adds those entries. 