### PR TITLE
Provide default value of `excludeApi` properties to SonarQube

### DIFF
--- a/delphi-checks/src/main/java/au/com/integradev/delphi/checks/UnusedConstantCheck.java
+++ b/delphi-checks/src/main/java/au/com/integradev/delphi/checks/UnusedConstantCheck.java
@@ -34,11 +34,13 @@ import org.sonarsource.analyzer.commons.annotations.DeprecatedRuleKey;
 @Rule(key = "UnusedConstant")
 public class UnusedConstantCheck extends DelphiCheck {
   private static final String MESSAGE = "Remove this unused constant.";
+  private static final boolean EXCLUDE_API_DEFAULT = false;
 
   @RuleProperty(
       key = "excludeApi",
-      description = "Exclude constants declared in the interface section with public visibility.")
-  public boolean excludeApi = false;
+      description = "Exclude constants declared in the interface section with public visibility.",
+      defaultValue = EXCLUDE_API_DEFAULT + "")
+  public boolean excludeApi = EXCLUDE_API_DEFAULT;
 
   @Override
   public DelphiCheckContext visit(ConstDeclarationNode declaration, DelphiCheckContext context) {

--- a/delphi-checks/src/main/java/au/com/integradev/delphi/checks/UnusedFieldCheck.java
+++ b/delphi-checks/src/main/java/au/com/integradev/delphi/checks/UnusedFieldCheck.java
@@ -33,11 +33,13 @@ import org.sonarsource.analyzer.commons.annotations.DeprecatedRuleKey;
 @Rule(key = "UnusedField")
 public class UnusedFieldCheck extends DelphiCheck {
   private static final String MESSAGE = "Remove this unused field.";
+  private static final boolean EXCLUDE_API_DEFAULT = false;
 
   @RuleProperty(
       key = "excludeApi",
-      description = "Exclude fields declared in the interface section with public visibility.")
-  public boolean excludeApi = false;
+      description = "Exclude fields declared in the interface section with public visibility.",
+      defaultValue = EXCLUDE_API_DEFAULT + "")
+  public boolean excludeApi = EXCLUDE_API_DEFAULT;
 
   @Override
   public DelphiCheckContext visit(FieldDeclarationNode field, DelphiCheckContext context) {

--- a/delphi-checks/src/main/java/au/com/integradev/delphi/checks/UnusedGlobalVariableCheck.java
+++ b/delphi-checks/src/main/java/au/com/integradev/delphi/checks/UnusedGlobalVariableCheck.java
@@ -35,11 +35,13 @@ import org.sonarsource.analyzer.commons.annotations.DeprecatedRuleKey;
 @Rule(key = "UnusedGlobalVariable")
 public class UnusedGlobalVariableCheck extends DelphiCheck {
   private static final String MESSAGE = "Remove this unused global variable.";
+  private static final boolean EXCLUDE_API_DEFAULT = false;
 
   @RuleProperty(
       key = "excludeApi",
-      description = "Exclude global variables declared in the interface section.")
-  public boolean excludeApi = false;
+      description = "Exclude global variables declared in the interface section.",
+      defaultValue = EXCLUDE_API_DEFAULT + "")
+  public boolean excludeApi = EXCLUDE_API_DEFAULT;
 
   @Override
   public DelphiCheckContext visit(VarDeclarationNode varDeclaration, DelphiCheckContext context) {

--- a/delphi-checks/src/main/java/au/com/integradev/delphi/checks/UnusedPropertyCheck.java
+++ b/delphi-checks/src/main/java/au/com/integradev/delphi/checks/UnusedPropertyCheck.java
@@ -33,11 +33,13 @@ import org.sonarsource.analyzer.commons.annotations.DeprecatedRuleKey;
 @Rule(key = "UnusedProperty")
 public class UnusedPropertyCheck extends DelphiCheck {
   private static final String MESSAGE = "Remove this unused property.";
+  private static final boolean EXCLUDE_API_DEFAULT = false;
 
   @RuleProperty(
       key = "excludeApi",
-      description = "Exclude properties declared in the interface section with public visibility.")
-  public boolean excludeApi = false;
+      description = "Exclude properties declared in the interface section with public visibility.",
+      defaultValue = EXCLUDE_API_DEFAULT + "")
+  public boolean excludeApi = EXCLUDE_API_DEFAULT;
 
   @Override
   public DelphiCheckContext visit(PropertyNode property, DelphiCheckContext context) {

--- a/delphi-checks/src/main/java/au/com/integradev/delphi/checks/UnusedRoutineCheck.java
+++ b/delphi-checks/src/main/java/au/com/integradev/delphi/checks/UnusedRoutineCheck.java
@@ -47,11 +47,13 @@ import org.sonarsource.analyzer.commons.annotations.DeprecatedRuleKey;
 @Rule(key = "UnusedRoutine")
 public class UnusedRoutineCheck extends DelphiCheck {
   private static final String MESSAGE = "Remove this unused routine.";
+  private static final boolean EXCLUDE_API_DEFAULT = false;
 
   @RuleProperty(
       key = "excludeApi",
-      description = "Exclude routines declared in the interface section with public visibility.")
-  public boolean excludeApi = false;
+      description = "Exclude routines declared in the interface section with public visibility.",
+      defaultValue = EXCLUDE_API_DEFAULT + "")
+  public boolean excludeApi = EXCLUDE_API_DEFAULT;
 
   private final Set<RoutineNameDeclaration> seenRoutines = new HashSet<>();
 

--- a/delphi-checks/src/main/java/au/com/integradev/delphi/checks/UnusedTypeCheck.java
+++ b/delphi-checks/src/main/java/au/com/integradev/delphi/checks/UnusedTypeCheck.java
@@ -39,13 +39,15 @@ import org.sonarsource.analyzer.commons.annotations.DeprecatedRuleKey;
 @Rule(key = "UnusedType")
 public class UnusedTypeCheck extends DelphiCheck {
   private static final String MESSAGE = "Remove this unused type.";
+  private static final boolean EXCLUDE_API_DEFAULT = false;
 
   @RuleProperty(
       key = "excludeApi",
       description =
           "Exclude types declared in the interface section, "
-              + "including any nested types with public visibility.")
-  public boolean excludeApi = false;
+              + "including any nested types with public visibility.",
+      defaultValue = EXCLUDE_API_DEFAULT + "")
+  public boolean excludeApi = EXCLUDE_API_DEFAULT;
 
   @Override
   public DelphiCheckContext visit(TypeDeclarationNode type, DelphiCheckContext context) {


### PR DESCRIPTION
A minor oversight in #137 - we didn't provide a default value to SonarQube for the new `excludeApi` properties.

This PR provides a default value of "false" for all `excludeApi` rule properties, making that default value explicit in the SonarQube UI and also making it clearer that the property is a boolean value.