### PR TITLE
Fix name resolution failures around type helpers for weak aliases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Scan failures on redundant unit aliases in .dproj files.
 - Incorrect file position calculation for multiline compiler directives.
 - Incorrect detection of method calls as hard casts in `CastAndFree`.
+- Name resolution failures around helpers extending weak alias types.
 
 ## [1.0.0] - 2023-11-14
 

--- a/delphi-frontend/src/main/java/au/com/integradev/delphi/symbol/scope/DelphiScopeImpl.java
+++ b/delphi-frontend/src/main/java/au/com/integradev/delphi/symbol/scope/DelphiScopeImpl.java
@@ -26,11 +26,11 @@ import com.google.common.collect.Ordering;
 import com.google.common.collect.SetMultimap;
 import com.google.common.collect.TreeMultimap;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.TreeMap;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import org.sonar.plugins.communitydelphi.api.symbol.Invocable;
@@ -60,7 +60,7 @@ public class DelphiScopeImpl implements DelphiScope {
   private final Set<PropertyNameDeclaration> propertyDeclarations;
   private final Set<RoutineNameDeclaration> routineDeclarations;
   private final Set<VariableNameDeclaration> variableDeclarations;
-  private final Map<Type, HelperType> helpersByType;
+  private final Map<String, HelperType> helpersByType;
 
   private DelphiScope parent;
 
@@ -74,7 +74,7 @@ public class DelphiScopeImpl implements DelphiScope {
     propertyDeclarations = new HashSet<>();
     routineDeclarations = new HashSet<>();
     variableDeclarations = new HashSet<>();
-    helpersByType = new HashMap<>();
+    helpersByType = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
   }
 
   public Set<NameDeclaration> addNameOccurrence(@Nonnull NameOccurrence occurrence) {
@@ -194,7 +194,7 @@ public class DelphiScopeImpl implements DelphiScope {
       Type type = typeDeclaration.getType();
       if (type.isHelper()) {
         HelperType helper = (HelperType) type;
-        helpersByType.put(helper.extendedType(), helper);
+        helpersByType.put(helper.extendedType().getImage(), helper);
       }
     }
   }
@@ -362,7 +362,7 @@ public class DelphiScopeImpl implements DelphiScope {
   }
 
   protected HelperType findHelper(Type type) {
-    return helpersByType.get(type);
+    return helpersByType.get(type.getImage());
   }
 
   private static NameDeclaration getDeclaration(NameDeclaration declaration) {

--- a/delphi-frontend/src/test/java/au/com/integradev/delphi/executor/DelphiSymbolTableExecutorTest.java
+++ b/delphi-frontend/src/test/java/au/com/integradev/delphi/executor/DelphiSymbolTableExecutorTest.java
@@ -1251,6 +1251,12 @@ class DelphiSymbolTableExecutorTest {
   }
 
   @Test
+  void testWeakAliasHelpers() {
+    execute("helpers/WeakAliasHelper.pas");
+    verifyUsages(13, 14, reference(24, 21), reference(31, 6));
+  }
+
+  @Test
   void testDependencyReferencedImplicitly() {
     execute("dependencies/Implicit.pas");
     verifyDependencies("System.SysUtils");

--- a/delphi-frontend/src/test/resources/au/com/integradev/delphi/symbol/helpers/WeakAliasHelper.pas
+++ b/delphi-frontend/src/test/resources/au/com/integradev/delphi/symbol/helpers/WeakAliasHelper.pas
@@ -1,0 +1,34 @@
+unit WeakAliasHelper;
+
+interface
+
+type
+  TFoo = record
+    procedure Bar;
+  end;
+
+  TFooAlias = TFoo;
+
+  TFooHelper = record helper for TFooAlias
+    procedure Bar;
+  end;
+
+implementation
+
+procedure TFoo.Bar;
+begin
+  // Do nothing
+end;
+
+
+procedure TFooHelper.Bar;
+begin
+  // Do nothing
+end;
+
+procedure Test(Foo: TFoo);
+begin
+  Foo.Bar;
+end;
+
+end.


### PR DESCRIPTION
Internally, we map `Type` -> `HelperType` when doing helper lookups in a given scope.

The analyzer models weak alias types by generating a transparent wrapper around the aliased type. It looks and behaves exactly like the aliased type, but the two type objects are not **equal** to each other.

The source of truth about a type's identity is the image, so the solution here is to simply map `<type image>` -> `HelperType` instead.

Fixes #104 and #108.