### PR TITLE
Fix name resolution failures when `Inc`/`Dec` are invoked on pointers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Incorrect file position calculation for multiline compiler directives.
 - Incorrect detection of method calls as hard casts in `CastAndFree`.
 - Name resolution failures around helpers extending weak alias types.
+- Name resolution failures when `Inc`/`Dec` are invoked on pointer types.
 
 ## [1.0.0] - 2023-11-14
 

--- a/delphi-checks/src/test/java/au/com/integradev/delphi/checks/UnusedLocalVariableCheckTest.java
+++ b/delphi-checks/src/test/java/au/com/integradev/delphi/checks/UnusedLocalVariableCheckTest.java
@@ -21,6 +21,8 @@ package au.com.integradev.delphi.checks;
 import au.com.integradev.delphi.builders.DelphiTestUnitBuilder;
 import au.com.integradev.delphi.checks.verifier.CheckVerifier;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 class UnusedLocalVariableCheckTest {
   @Test
@@ -208,6 +210,26 @@ class UnusedLocalVariableCheckTest {
                 .appendImpl("procedure Test(Foo: Integer);")
                 .appendImpl("begin")
                 .appendImpl("  // Do nothing")
+                .appendImpl("end;"))
+        .verifyNoIssues();
+  }
+
+  // See: https://github.com/integrated-application-development/sonar-delphi/issues/141
+  @ParameterizedTest
+  @ValueSource(strings = {"Inc", "Dec"})
+  void testIssue141ShouldNotAddIssue(String routine) {
+    CheckVerifier.newVerifier()
+        .withCheck(new UnusedLocalVariableCheck())
+        .onFile(
+            new DelphiTestUnitBuilder()
+                .appendDecl("type")
+                .appendDecl("  PByte = ^Byte;")
+                .appendImpl("procedure Test(P: PByte);")
+                .appendImpl("var")
+                .appendImpl("  I: Integer;")
+                .appendImpl("begin")
+                .appendImpl("  I := 5;")
+                .appendImpl(String.format("  %s(P, I);", routine))
                 .appendImpl("end;"))
         .verifyNoIssues();
   }

--- a/delphi-frontend/src/main/java/au/com/integradev/delphi/type/intrinsic/IntrinsicArgumentMatcher.java
+++ b/delphi-frontend/src/main/java/au/com/integradev/delphi/type/intrinsic/IntrinsicArgumentMatcher.java
@@ -41,6 +41,14 @@ public final class IntrinsicArgumentMatcher extends TypeImpl {
           "<ordinal>",
           type -> type.isInteger() || type.isBoolean() || type.isEnum() || type.isChar());
 
+  public static final Type ANY_TYPED_POINTER =
+      new IntrinsicArgumentMatcher(
+          "<typed pointer>",
+          type ->
+              type.isPointer()
+                  && !((PointerType) type).dereferencedType().isUntyped()
+                  && !((PointerType) type).dereferencedType().isVoid());
+
   public static final Type ANY_CLASS_REFERENCE =
       new IntrinsicArgumentMatcher("<class reference>", Type::isClassReference);
 

--- a/delphi-frontend/src/main/java/au/com/integradev/delphi/type/intrinsic/IntrinsicsInjector.java
+++ b/delphi-frontend/src/main/java/au/com/integradev/delphi/type/intrinsic/IntrinsicsInjector.java
@@ -24,6 +24,7 @@ import static au.com.integradev.delphi.type.intrinsic.IntrinsicArgumentMatcher.A
 import static au.com.integradev.delphi.type.intrinsic.IntrinsicArgumentMatcher.ANY_OBJECT;
 import static au.com.integradev.delphi.type.intrinsic.IntrinsicArgumentMatcher.ANY_ORDINAL;
 import static au.com.integradev.delphi.type.intrinsic.IntrinsicArgumentMatcher.ANY_SET;
+import static au.com.integradev.delphi.type.intrinsic.IntrinsicArgumentMatcher.ANY_TYPED_POINTER;
 import static org.sonar.plugins.communitydelphi.api.type.IntrinsicType.ANSISTRING;
 import static org.sonar.plugins.communitydelphi.api.type.IntrinsicType.BOOLEAN;
 import static org.sonar.plugins.communitydelphi.api.type.IntrinsicType.BYTE;
@@ -184,7 +185,8 @@ public final class IntrinsicsInjector {
         .param(type(INTEGER))
         .required(1)
         .returns(type(UNICODESTRING));
-    routine("Dec").varParam(ANY_ORDINAL).param(type(INTEGER)).required(1).returns(type(INTEGER));
+    routine("Dec").varParam(ANY_ORDINAL).param(type(INTEGER)).required(1);
+    routine("Dec").varParam(ANY_TYPED_POINTER).param(type(INTEGER)).required(1);
     routine("Default")
         .param(ANY_CLASS_REFERENCE)
         .returns(IntrinsicReturnType.classReferenceValue());
@@ -211,6 +213,7 @@ public final class IntrinsicsInjector {
         .varParam(TypeFactory.untypedType())
         .returns(IntrinsicReturnType.high(typeFactory));
     routine("Inc").varParam(ANY_ORDINAL).param(type(INTEGER)).required(1);
+    routine("Inc").varParam(ANY_TYPED_POINTER).param(type(INTEGER)).required(1);
     routine("Include").varParam(ANY_SET).param(ANY_ORDINAL);
     routine("Initialize").varParam(TypeFactory.untypedType()).param(type(NATIVEINT)).required(1);
     routine("Insert").param(type(UNICODESTRING)).varParam(type(UNICODESTRING)).param(type(INTEGER));

--- a/delphi-frontend/src/test/java/au/com/integradev/delphi/type/intrinsic/IntrinsicArgumentMatcherTest.java
+++ b/delphi-frontend/src/test/java/au/com/integradev/delphi/type/intrinsic/IntrinsicArgumentMatcherTest.java
@@ -23,6 +23,7 @@ import static au.com.integradev.delphi.type.intrinsic.IntrinsicArgumentMatcher.A
 import static au.com.integradev.delphi.type.intrinsic.IntrinsicArgumentMatcher.ANY_OBJECT;
 import static au.com.integradev.delphi.type.intrinsic.IntrinsicArgumentMatcher.ANY_ORDINAL;
 import static au.com.integradev.delphi.type.intrinsic.IntrinsicArgumentMatcher.ANY_SET;
+import static au.com.integradev.delphi.type.intrinsic.IntrinsicArgumentMatcher.ANY_TYPED_POINTER;
 import static au.com.integradev.delphi.type.intrinsic.IntrinsicArgumentMatcher.POINTER_MATH_OPERAND;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -81,6 +82,14 @@ class IntrinsicArgumentMatcherTest {
     assertThat(matches(ANY_ORDINAL, FACTORY.enumeration("TFoo", null))).isTrue();
     assertThat(matches(ANY_ORDINAL, FACTORY.getIntrinsic(IntrinsicType.CHAR))).isTrue();
     assertThat(matches(ANY_ORDINAL, FACTORY.getIntrinsic(IntrinsicType.STRING))).isFalse();
+  }
+
+  @Test
+  void testAnyTypedPointer() {
+    Type typedPointer = FACTORY.pointerTo("PInteger", FACTORY.getIntrinsic(IntrinsicType.INTEGER));
+    assertThat(matches(ANY_TYPED_POINTER, typedPointer)).isTrue();
+    assertThat(matches(ANY_TYPED_POINTER, FACTORY.untypedPointer())).isFalse();
+    assertThat(matches(ANY_TYPED_POINTER, FACTORY.nilPointer())).isFalse();
   }
 
   @Test


### PR DESCRIPTION
This PR adds a new `TYPED_POINTER` overload to the `Inc` and `Dec` intrinsic signatures.

Fixes #141.