### PR TITLE
Clarify wording of VariableName description

### DIFF
--- a/delphi-checks/src/main/resources/org/sonar/l10n/delphi/rules/community-delphi/VariableName.html
+++ b/delphi-checks/src/main/resources/org/sonar/l10n/delphi/rules/community-delphi/VariableName.html
@@ -1,12 +1,16 @@
 <h2>Why is this an issue?</h2>
 <p>
   Code that follows a consistent naming convention is self-documenting. In Delphi, all variable
-  names should be in PascalCase. Global variables should have a consistent prefix.
+  names should be in PascalCase. This rule enforces that variables follow the following conventions:
 </p>
+<ul>
+  <li>Variable names (both local and global) should be in PascalCase</li>
+  <li>Global variable names should have a consistent prefix</li>
+</ul>
 <p>
-  The default prefix for global variables is <code>G</code>, but some projects may use another
-  prefix to separate their global variables from those of other projects. This can make code
-  spanning several projects more easily understandable.
+  The required prefix for global variables defaults to <code>G</code>, although some projects may
+  use another prefix to separate their global variables from those of other projects.
+  This can make code spanning several projects more easily understandable.
 </p>
 <h2>How to fix it</h2>
 <p>Rename the variable name to follow the convention.</p>


### PR DESCRIPTION
Fixes #96 by rephrasing the VariableName description, emphasising that the rule enforces naming conventions for both local and global variables.