### PR TITLE
Fix missing information in "ambiguous declarations" warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Test sources were erroneously excluded from analysis.
+- Key information was missing from "ambiguous declarations" warnings.
 - Stack overflow on class reference types that reference their containing type.
 - Scan failures on redundant unit aliases in .dproj files.
 - Incorrect file position calculation for multiline compiler directives.

--- a/delphi-frontend/src/main/java/au/com/integradev/delphi/symbol/resolve/NameResolver.java
+++ b/delphi-frontend/src/main/java/au/com/integradev/delphi/symbol/resolve/NameResolver.java
@@ -198,11 +198,14 @@ public class NameResolver {
 
   public void checkAmbiguity() {
     if (declarations.size() > 1) {
-      LOG.warn(
-          "Ambiguous declarations could not be resolved\n[Occurrence] {}{}",
-          Iterables.getLast(names),
-          declarations.stream().map(declaration -> "\n[Declaration] " + declaration));
-
+      if (LOG.isWarnEnabled()) {
+        LOG.warn(
+            "Ambiguous declarations could not be resolved\n[Occurrence] {}\n{}",
+            Iterables.getLast(names),
+            declarations.stream()
+                .map(declaration -> "[Declaration] " + declaration)
+                .collect(Collectors.joining("\n")));
+      }
       declarations.clear();
     }
   }


### PR DESCRIPTION
This PR restores the declaration information in "ambiguous declarations" warnings.

Example output:
```
WARN: Ambiguous declarations could not be resolved
[Occurrence] Length [11399,16] <Data.DBXCommon>
[Declaration] Routine Length, line 0, params = 1 <System>
[Declaration] Routine Length, line 0, params = 1 <System>
```