### PR TITLE
Improve behavior of various intrinsic routines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Return type of the array `Copy` intrinsic was not specified correctly.
 - Dynamic array literals were not accepted as arguments to `Copy`.
 - Strong aliases to `System.Text` were not accepted as arguments to `Append`.
+- Implicit conversions to `Boolean` were not accepted as arguments to `Assert`.
 
 ## [1.0.0] - 2023-11-14
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Strong aliases were not accepted as arguments to `VarArrayRedim`, `VarCast`, `VarClear`, or
   `VarCopy`.
 - Parameter of the `Int64` overload of `Sqr` was erroneously specified as `Real`.
+- Return type of the `Succ` intrinsic was not specified correctly.
 
 ## [1.0.0] - 2023-11-14
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Dynamic array literals were not accepted as arguments to `Concat`.
 - Return type of the array `Copy` intrinsic was not specified correctly.
 - Dynamic array literals were not accepted as arguments to `Copy`.
+- Strong aliases to `System.Text` were not accepted as arguments to `Append`.
 
 ## [1.0.0] - 2023-11-14
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Strong aliases were not accepted as arguments to `Delete`, `Insert`, or `SetLength`.
 - Strong aliases and typed pointers were not accepted as arguments to `Dispose`, `FreeMem`,
   `GetMem`, `New`, or `ReallocMem`.
+- Strong aliases and specialized string types were not accepted as arguments to `Str`, `GetDir`,
+  `SetString`, or `Val`.
 
 ## [1.0.0] - 2023-11-14
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Improve type resolution on binary and unary expressions.
 - Improve type comparisons between signed and unsigned integer types.
+- Improve type comparisons between text types.
 - Exclude routines annotated with attributes in `UnusedRoutine`.
 - Exclude properties annotated with attributes in `UnusedProperty`.
 - Exclude fields annotated with attributes in `UnusedField`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Dynamic array literals were not accepted as arguments to `Copy`.
 - Strong aliases to `System.Text` were not accepted as arguments to `Append`.
 - Implicit conversions to `Boolean` were not accepted as arguments to `Assert`.
+- Strong aliases and typed files were not accepted as arguments to `Assign`.
 
 ## [1.0.0] - 2023-11-14
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,9 +57,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Dynamic array literals were not accepted as arguments to `Concat`.
 - Return type of the array `Copy` intrinsic was not specified correctly.
 - Dynamic array literals were not accepted as arguments to `Copy`.
-- Strong aliases to `System.Text` were not accepted as arguments to `Append`.
 - Implicit conversions to `Boolean` were not accepted as arguments to `Assert`.
-- Strong aliases and typed files were not accepted as arguments to `Assign`.
+- Strong aliases were not accepted as arguments to `Append`, `SeekEof`, `SeekEoln`, or `SetTextBuf`.
+- Strong aliases and typed files were not accepted as arguments to `Assign`, `BlockRead`,
+  `BlockWrite`, `Close`, `CloseFile`, `Eof`, `Eoln`, `Erase`, `FilePos`, `FileSize`, `Read`,
+  `ReadLn`, `Rename`, `Reset`, `Rewrite`, `Seek`, `Truncate`, `Write`, or `WriteLn`.
 
 ## [1.0.0] - 2023-11-14
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Strong aliases and typed files were not accepted as arguments to `Assign`, `BlockRead`,
   `BlockWrite`, `Close`, `CloseFile`, `Eof`, `Eoln`, `Erase`, `FilePos`, `FileSize`, `Read`,
   `ReadLn`, `Rename`, `Reset`, `Rewrite`, `Seek`, `Truncate`, `Write`, or `WriteLn`.
+- Strong aliases were not accepted as arguments to `Delete`, `Insert`, or `SetLength`.
 
 ## [1.0.0] - 2023-11-14
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `VarCopy`.
 - Parameter of the `Int64` overload of `Sqr` was erroneously specified as `Real`.
 - Return type of the `Succ` intrinsic was not specified correctly.
+- Return type of the `Slice` intrinsic was not inferred correctly.
 
 ## [1.0.0] - 2023-11-14
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,27 +53,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Incorrect file position calculation for multiline compiler directives.
 - Incorrect detection of method calls as hard casts in `CastAndFree`.
 - Name resolution failures around helpers extending weak alias types.
-- Name resolution failures when `Inc`/`Dec` are invoked on pointer types.
-- Return type of the array `Concat` intrinsic was not inferred correctly.
-- Dynamic array literals were not accepted as arguments to `Concat`.
-- Return type of the array `Copy` intrinsic was not specified correctly.
-- Dynamic array literals were not accepted as arguments to `Copy`.
-- Implicit conversions to `Boolean` were not accepted as arguments to `Assert`.
-- Return type of the `Length` intrinsic was incorrect for `ShortString`.
-- Strong aliases were not accepted as arguments to `Append`, `SeekEof`, `SeekEoln`, or `SetTextBuf`.
-- Strong aliases and typed files were not accepted as arguments to `Assign`, `BlockRead`,
-  `BlockWrite`, `Close`, `CloseFile`, `Eof`, `Eoln`, `Erase`, `FilePos`, `FileSize`, `Read`,
-  `ReadLn`, `Rename`, `Reset`, `Rewrite`, `Seek`, `Truncate`, `Write`, or `WriteLn`.
-- Strong aliases were not accepted as arguments to `Delete`, `Insert`, or `SetLength`.
-- Strong aliases and typed pointers were not accepted as arguments to `Dispose`, `FreeMem`,
-  `GetMem`, `New`, or `ReallocMem`.
-- Strong aliases and specialized string types were not accepted as arguments to `Str`, `GetDir`,
-  `SetString`, or `Val`.
-- Strong aliases were not accepted as arguments to `VarArrayRedim`, `VarCast`, `VarClear`, or
-  `VarCopy`.
-- Parameter of the `Int64` overload of `Sqr` was erroneously specified as `Real`.
-- Return type of the `Succ` intrinsic was not specified correctly.
-- Return type of the `Slice` intrinsic was not inferred correctly.
+- Various intrinsic routine signatures had incorrect return types.
+- Various intrinsic routine signatures had incorrect or overly-restrictive parameter types.
 
 ## [1.0.0] - 2023-11-14
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `GetMem`, `New`, or `ReallocMem`.
 - Strong aliases and specialized string types were not accepted as arguments to `Str`, `GetDir`,
   `SetString`, or `Val`.
+- Strong aliases were not accepted as arguments to `VarArrayRedim`, `VarCast`, `VarClear`, or
+  `VarCopy`.
 
 ## [1.0.0] - 2023-11-14
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Name resolution failures when `Inc`/`Dec` are invoked on pointer types.
 - Return type of the array `Concat` intrinsic was not inferred correctly.
 - Dynamic array literals were not accepted as arguments to `Concat`.
+- Return type of the array `Copy` intrinsic was not specified correctly.
+- Dynamic array literals were not accepted as arguments to `Copy`.
 
 ## [1.0.0] - 2023-11-14
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `BlockWrite`, `Close`, `CloseFile`, `Eof`, `Eoln`, `Erase`, `FilePos`, `FileSize`, `Read`,
   `ReadLn`, `Rename`, `Reset`, `Rewrite`, `Seek`, `Truncate`, `Write`, or `WriteLn`.
 - Strong aliases were not accepted as arguments to `Delete`, `Insert`, or `SetLength`.
+- Strong aliases and typed pointers were not accepted as arguments to `Dispose`, `FreeMem`,
+  `GetMem`, `New`, or `ReallocMem`.
 
 ## [1.0.0] - 2023-11-14
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Return type of the array `Copy` intrinsic was not specified correctly.
 - Dynamic array literals were not accepted as arguments to `Copy`.
 - Implicit conversions to `Boolean` were not accepted as arguments to `Assert`.
+- Return type of the `Length` intrinsic was incorrect for `ShortString`.
 - Strong aliases were not accepted as arguments to `Append`, `SeekEof`, `SeekEoln`, or `SetTextBuf`.
 - Strong aliases and typed files were not accepted as arguments to `Assign`, `BlockRead`,
   `BlockWrite`, `Close`, `CloseFile`, `Eof`, `Eoln`, `Erase`, `FilePos`, `FileSize`, `Read`,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `SetString`, or `Val`.
 - Strong aliases were not accepted as arguments to `VarArrayRedim`, `VarCast`, `VarClear`, or
   `VarCopy`.
+- Parameter of the `Int64` overload of `Sqr` was erroneously specified as `Real`.
 
 ## [1.0.0] - 2023-11-14
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Improve type resolution on binary and unary expressions.
 - Improve type comparisons between signed and unsigned integer types.
 - Improve type comparisons between text types.
+- Improve type conversions from character pointers to strings.
 - Exclude routines annotated with attributes in `UnusedRoutine`.
 - Exclude properties annotated with attributes in `UnusedProperty`.
 - Exclude fields annotated with attributes in `UnusedField`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Incorrect detection of method calls as hard casts in `CastAndFree`.
 - Name resolution failures around helpers extending weak alias types.
 - Name resolution failures when `Inc`/`Dec` are invoked on pointer types.
+- Return type of the array `Concat` intrinsic was not inferred correctly.
+- Dynamic array literals were not accepted as arguments to `Concat`.
 
 ## [1.0.0] - 2023-11-14
 

--- a/delphi-frontend/src/main/java/au/com/integradev/delphi/symbol/resolve/InvocationCandidate.java
+++ b/delphi-frontend/src/main/java/au/com/integradev/delphi/symbol/resolve/InvocationCandidate.java
@@ -54,6 +54,7 @@ public final class InvocationCandidate {
   private int numericMismatchCount;
   private int structMismatchCount;
   private int proceduralDistance;
+  private int codePageDistance;
   private final List<VariantConversionType> variantConversions;
   private boolean invalid;
 
@@ -145,6 +146,14 @@ public final class InvocationCandidate {
 
   public int getProceduralDistance() {
     return proceduralDistance;
+  }
+
+  public void increaseCodePageDistance(int codePageDistance) {
+    this.codePageDistance += codePageDistance;
+  }
+
+  public int getCodePageDistance() {
+    return codePageDistance;
   }
 
   public void addVariantConversion(VariantConversionType variantConversionType) {

--- a/delphi-frontend/src/main/java/au/com/integradev/delphi/symbol/resolve/InvocationResolver.java
+++ b/delphi-frontend/src/main/java/au/com/integradev/delphi/symbol/resolve/InvocationResolver.java
@@ -56,6 +56,7 @@ import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 import org.sonar.plugins.communitydelphi.api.type.CodePages;
+import org.sonar.plugins.communitydelphi.api.type.IntrinsicType;
 import org.sonar.plugins.communitydelphi.api.type.Parameter;
 import org.sonar.plugins.communitydelphi.api.type.Type;
 import org.sonar.plugins.communitydelphi.api.type.Type.AnsiStringType;
@@ -317,13 +318,24 @@ public class InvocationResolver {
 
   private static void checkCodePageDistance(
       InvocationCandidate candidate, Type argumentType, Type parameterType) {
-    if (!argumentType.isAnsiString() || !parameterType.isAnsiString()) {
+    if (!parameterType.isAnsiString()) {
       return;
     }
 
-    AnsiStringType from = (AnsiStringType) argumentType;
+    Integer codePage = null;
+
+    if (argumentType.isAnsiString()) {
+      codePage = ((AnsiStringType) argumentType).codePage();
+    } else if (TypeUtils.findBaseType(argumentType).is(IntrinsicType.PANSICHAR)) {
+      codePage = CodePages.CP_ACP;
+    }
+
+    if (codePage == null) {
+      return;
+    }
+
     AnsiStringType to = (AnsiStringType) parameterType;
-    if (from.codePage() == to.codePage() || to.codePage() == CodePages.CP_NONE) {
+    if (codePage == to.codePage() || to.codePage() == CodePages.CP_NONE) {
       return;
     }
 

--- a/delphi-frontend/src/main/java/au/com/integradev/delphi/symbol/resolve/TypeComparer.java
+++ b/delphi-frontend/src/main/java/au/com/integradev/delphi/symbol/resolve/TypeComparer.java
@@ -410,11 +410,24 @@ final class TypeComparer {
   }
 
   private static EqualityType comparePointerToString(PointerType from, StringType to) {
-    if (from.dereferencedType().isChar()) {
-      if (from.dereferencedType().is(to.characterType())) {
+    if (from.is(IntrinsicType.PANSICHAR)) {
+      if (to.isAnsiString()) {
         return CONVERT_LEVEL_3;
-      } else {
+      } else if (to.is(IntrinsicType.UNICODESTRING)) {
         return CONVERT_LEVEL_4;
+      } else if (to.is(IntrinsicType.WIDESTRING)) {
+        return CONVERT_LEVEL_5;
+      } else if (to.is(IntrinsicType.SHORTSTRING)) {
+        return CONVERT_LEVEL_6;
+      }
+    } else if (from.is(IntrinsicType.PWIDECHAR)) {
+      if (to.is(IntrinsicType.UNICODESTRING)) {
+        return CONVERT_LEVEL_3;
+      } else if (to.is(IntrinsicType.WIDESTRING)) {
+        return CONVERT_LEVEL_4;
+      } else if (to.isAnsiString()) {
+        // Penalty for bad type conversion
+        return CONVERT_LEVEL_7;
       }
     }
     return INCOMPATIBLE_TYPES;

--- a/delphi-frontend/src/main/java/au/com/integradev/delphi/symbol/resolve/TypeComparer.java
+++ b/delphi-frontend/src/main/java/au/com/integradev/delphi/symbol/resolve/TypeComparer.java
@@ -35,12 +35,10 @@ import au.com.integradev.delphi.type.intrinsic.IntrinsicArgumentMatcher;
 import com.google.common.annotations.VisibleForTesting;
 import java.util.Comparator;
 import java.util.List;
-import org.sonar.plugins.communitydelphi.api.type.CodePages;
 import org.sonar.plugins.communitydelphi.api.type.IntrinsicType;
 import org.sonar.plugins.communitydelphi.api.type.Parameter;
 import org.sonar.plugins.communitydelphi.api.type.Type;
 import org.sonar.plugins.communitydelphi.api.type.Type.AliasType;
-import org.sonar.plugins.communitydelphi.api.type.Type.AnsiStringType;
 import org.sonar.plugins.communitydelphi.api.type.Type.ArrayConstructorType;
 import org.sonar.plugins.communitydelphi.api.type.Type.BooleanType;
 import org.sonar.plugins.communitydelphi.api.type.Type.ClassReferenceType;
@@ -299,7 +297,7 @@ final class TypeComparer {
     } else if (from.is(IntrinsicType.SHORTSTRING)) {
       return compareShortStringToString(to);
     } else if (from.isAnsiString()) {
-      return compareAnsiStringToString((AnsiStringType) from, to);
+      return compareAnsiStringToString(to);
     }
 
     throw new AssertionError("Unhandled string type");
@@ -309,9 +307,9 @@ final class TypeComparer {
     if (to.is(IntrinsicType.UNICODESTRING)) {
       return CONVERT_LEVEL_1;
     } else if (to.isAnsiString()) {
-      return CONVERT_LEVEL_2;
+      return CONVERT_LEVEL_4;
     } else {
-      return CONVERT_LEVEL_3;
+      return CONVERT_LEVEL_5;
     }
   }
 
@@ -319,9 +317,9 @@ final class TypeComparer {
     if (to.is(IntrinsicType.WIDESTRING)) {
       return CONVERT_LEVEL_1;
     } else if (to.isAnsiString()) {
-      return CONVERT_LEVEL_2;
+      return CONVERT_LEVEL_4;
     } else {
-      return CONVERT_LEVEL_3;
+      return CONVERT_LEVEL_5;
     }
   }
 
@@ -335,25 +333,15 @@ final class TypeComparer {
     }
   }
 
-  private static EqualityType compareAnsiStringToString(AnsiStringType from, Type to) {
+  private static EqualityType compareAnsiStringToString(Type to) {
     if (to.isAnsiString()) {
-      AnsiStringType toAnsiString = (AnsiStringType) to;
-      if (from.codePage() == toAnsiString.codePage()
-          || toAnsiString.codePage() == CodePages.CP_NONE) {
-        return EQUAL;
-      } else if (toAnsiString.codePage() == CodePages.CP_UTF8) {
-        return CONVERT_LEVEL_1;
-      } else if (toAnsiString.codePage() == CodePages.CP_ACP) {
-        return CONVERT_LEVEL_2;
-      } else {
-        return CONVERT_LEVEL_3;
-      }
+      return EQUAL;
     } else if (to.is(IntrinsicType.UNICODESTRING)) {
-      return CONVERT_LEVEL_4;
+      return CONVERT_LEVEL_1;
     } else if (to.is(IntrinsicType.WIDESTRING)) {
-      return CONVERT_LEVEL_5;
+      return CONVERT_LEVEL_2;
     } else {
-      return CONVERT_LEVEL_6;
+      return CONVERT_LEVEL_3;
     }
   }
 

--- a/delphi-frontend/src/main/java/au/com/integradev/delphi/type/intrinsic/IntrinsicArgumentMatcher.java
+++ b/delphi-frontend/src/main/java/au/com/integradev/delphi/type/intrinsic/IntrinsicArgumentMatcher.java
@@ -60,6 +60,8 @@ public final class IntrinsicArgumentMatcher extends TypeImpl {
       new IntrinsicArgumentMatcher(
           "<32-bit integer>", type -> type.isInteger() && type.size() == 4);
 
+  public static final Type ANY_POINTER = new IntrinsicArgumentMatcher("<pointer>", Type::isPointer);
+
   public static final Type ANY_TYPED_POINTER =
       new IntrinsicArgumentMatcher(
           "<typed pointer>",

--- a/delphi-frontend/src/main/java/au/com/integradev/delphi/type/intrinsic/IntrinsicArgumentMatcher.java
+++ b/delphi-frontend/src/main/java/au/com/integradev/delphi/type/intrinsic/IntrinsicArgumentMatcher.java
@@ -59,6 +59,10 @@ public final class IntrinsicArgumentMatcher extends TypeImpl {
           "<ordinal>",
           type -> type.isInteger() || type.isBoolean() || type.isEnum() || type.isChar());
 
+  public static final Type ANY_32_BIT_INTEGER =
+      new IntrinsicArgumentMatcher(
+          "<32-bit integer>", type -> type.isInteger() && type.size() == 4);
+
   public static final Type ANY_TYPED_POINTER =
       new IntrinsicArgumentMatcher(
           "<typed pointer>",

--- a/delphi-frontend/src/main/java/au/com/integradev/delphi/type/intrinsic/IntrinsicArgumentMatcher.java
+++ b/delphi-frontend/src/main/java/au/com/integradev/delphi/type/intrinsic/IntrinsicArgumentMatcher.java
@@ -40,6 +40,8 @@ public final class IntrinsicArgumentMatcher extends TypeImpl {
   public static final Type ANY_STRING =
       new IntrinsicArgumentMatcher("<string or char>", type -> type.isString() || type.isChar());
 
+  public static final Type ANY_FILE = new IntrinsicArgumentMatcher("<file>", Type::isFile);
+
   public static final Type ANY_TEXT_FILE =
       new IntrinsicArgumentMatcher("<text file>", type -> type.is(IntrinsicType.TEXT));
 

--- a/delphi-frontend/src/main/java/au/com/integradev/delphi/type/intrinsic/IntrinsicArgumentMatcher.java
+++ b/delphi-frontend/src/main/java/au/com/integradev/delphi/type/intrinsic/IntrinsicArgumentMatcher.java
@@ -42,6 +42,8 @@ public final class IntrinsicArgumentMatcher extends TypeImpl {
   public static final Type ANY_TEXT_FILE =
       new IntrinsicArgumentMatcher("<text file>", type -> type.is(IntrinsicType.TEXT));
 
+  public static final Type ANY_VARIANT = new IntrinsicArgumentMatcher("<variant>", Type::isVariant);
+
   public static final Type ANY_ARRAY = new IntrinsicArgumentMatcher("<array>", Type::isArray);
 
   public static final Type ANY_SET =

--- a/delphi-frontend/src/main/java/au/com/integradev/delphi/type/intrinsic/IntrinsicArgumentMatcher.java
+++ b/delphi-frontend/src/main/java/au/com/integradev/delphi/type/intrinsic/IntrinsicArgumentMatcher.java
@@ -37,6 +37,9 @@ public final class IntrinsicArgumentMatcher extends TypeImpl {
                   || type.isString()
                   || type.isChar());
 
+  public static final Type ANY_STRING =
+      new IntrinsicArgumentMatcher("<string or char>", type -> type.isString() || type.isChar());
+
   public static final Type ANY_TEXT_FILE =
       new IntrinsicArgumentMatcher("<text file>", type -> type.is(IntrinsicType.TEXT));
 

--- a/delphi-frontend/src/main/java/au/com/integradev/delphi/type/intrinsic/IntrinsicArgumentMatcher.java
+++ b/delphi-frontend/src/main/java/au/com/integradev/delphi/type/intrinsic/IntrinsicArgumentMatcher.java
@@ -27,6 +27,15 @@ public final class IntrinsicArgumentMatcher extends TypeImpl {
   public static final Type ANY_DYNAMIC_ARRAY =
       new IntrinsicArgumentMatcher("<dynamic array>", Type::isDynamicArray);
 
+  public static final Type LIKE_DYNAMIC_ARRAY =
+      new IntrinsicArgumentMatcher(
+          "<dynamic array, array constructor, string, or char>",
+          type ->
+              type.isDynamicArray()
+                  || type.isArrayConstructor()
+                  || type.isString()
+                  || type.isChar());
+
   public static final Type ANY_ARRAY = new IntrinsicArgumentMatcher("<array>", Type::isArray);
 
   public static final Type ANY_SET =

--- a/delphi-frontend/src/main/java/au/com/integradev/delphi/type/intrinsic/IntrinsicArgumentMatcher.java
+++ b/delphi-frontend/src/main/java/au/com/integradev/delphi/type/intrinsic/IntrinsicArgumentMatcher.java
@@ -20,6 +20,7 @@ package au.com.integradev.delphi.type.intrinsic;
 
 import au.com.integradev.delphi.type.TypeImpl;
 import au.com.integradev.delphi.type.TypeUtils;
+import org.sonar.plugins.communitydelphi.api.type.IntrinsicType;
 import org.sonar.plugins.communitydelphi.api.type.StructKind;
 import org.sonar.plugins.communitydelphi.api.type.Type;
 
@@ -35,6 +36,9 @@ public final class IntrinsicArgumentMatcher extends TypeImpl {
                   || type.isArrayConstructor()
                   || type.isString()
                   || type.isChar());
+
+  public static final Type ANY_TEXT_FILE =
+      new IntrinsicArgumentMatcher("<text file>", type -> type.is(IntrinsicType.TEXT));
 
   public static final Type ANY_ARRAY = new IntrinsicArgumentMatcher("<array>", Type::isArray);
 

--- a/delphi-frontend/src/main/java/au/com/integradev/delphi/type/intrinsic/IntrinsicArgumentMatcher.java
+++ b/delphi-frontend/src/main/java/au/com/integradev/delphi/type/intrinsic/IntrinsicArgumentMatcher.java
@@ -25,9 +25,6 @@ import org.sonar.plugins.communitydelphi.api.type.StructKind;
 import org.sonar.plugins.communitydelphi.api.type.Type;
 
 public final class IntrinsicArgumentMatcher extends TypeImpl {
-  public static final Type ANY_DYNAMIC_ARRAY =
-      new IntrinsicArgumentMatcher("<dynamic array>", Type::isDynamicArray);
-
   public static final Type LIKE_DYNAMIC_ARRAY =
       new IntrinsicArgumentMatcher(
           "<dynamic array, array constructor, string, or char>",

--- a/delphi-frontend/src/main/java/au/com/integradev/delphi/type/intrinsic/IntrinsicReturnType.java
+++ b/delphi-frontend/src/main/java/au/com/integradev/delphi/type/intrinsic/IntrinsicReturnType.java
@@ -67,6 +67,10 @@ public abstract class IntrinsicReturnType extends TypeImpl {
     return new ConcatReturnType(typeFactory);
   }
 
+  public static Type copy(TypeFactory typeFactory) {
+    return new CopyReturnType(typeFactory);
+  }
+
   public static Type classReferenceValue() {
     return new ClassReferenceValueType();
   }
@@ -180,6 +184,23 @@ public abstract class IntrinsicReturnType extends TypeImpl {
       }
 
       return currentType;
+    }
+  }
+
+  private static final class CopyReturnType extends IntrinsicReturnType {
+    private final TypeFactory typeFactory;
+
+    public CopyReturnType(TypeFactory typeFactory) {
+      this.typeFactory = typeFactory;
+    }
+
+    @Override
+    public Type getReturnType(List<Type> arguments) {
+      Type result = arguments.get(0);
+      if (result.isChar()) {
+        result = typeFactory.getIntrinsic(result.size() == 1 ? ANSISTRING : UNICODESTRING);
+      }
+      return result;
     }
   }
 }

--- a/delphi-frontend/src/main/java/au/com/integradev/delphi/type/intrinsic/IntrinsicReturnType.java
+++ b/delphi-frontend/src/main/java/au/com/integradev/delphi/type/intrinsic/IntrinsicReturnType.java
@@ -24,8 +24,11 @@ import static org.sonar.plugins.communitydelphi.api.type.IntrinsicType.UNICODEST
 import static org.sonar.plugins.communitydelphi.api.type.IntrinsicType.WIDECHAR;
 
 import au.com.integradev.delphi.type.TypeImpl;
+import au.com.integradev.delphi.type.factory.ArrayOption;
+import au.com.integradev.delphi.type.factory.TypeFactoryImpl;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Set;
 import javax.annotation.Nullable;
 import org.sonar.plugins.communitydelphi.api.symbol.declaration.RoutineKind;
 import org.sonar.plugins.communitydelphi.api.symbol.declaration.RoutineNameDeclaration;
@@ -69,6 +72,10 @@ public abstract class IntrinsicReturnType extends TypeImpl {
 
   public static Type copy(TypeFactory typeFactory) {
     return new CopyReturnType(typeFactory);
+  }
+
+  public static Type slice(TypeFactory typeFactory) {
+    return new SliceReturnType(typeFactory);
   }
 
   public static Type classReferenceValue() {
@@ -205,6 +212,24 @@ public abstract class IntrinsicReturnType extends TypeImpl {
         result = typeFactory.getIntrinsic(result.size() == 1 ? ANSISTRING : UNICODESTRING);
       }
       return result;
+    }
+  }
+
+  private static final class SliceReturnType extends IntrinsicReturnType {
+    private final TypeFactory typeFactory;
+
+    public SliceReturnType(TypeFactory typeFactory) {
+      this.typeFactory = typeFactory;
+    }
+
+    @Override
+    public Type getReturnType(List<Type> arguments) {
+      Type array = arguments.get(0);
+      if (array.isArray()) {
+        Type elementType = ((CollectionType) array).elementType();
+        return ((TypeFactoryImpl) typeFactory).array(null, elementType, Set.of(ArrayOption.OPEN));
+      }
+      return TypeFactory.unknownType();
     }
   }
 

--- a/delphi-frontend/src/main/java/au/com/integradev/delphi/type/intrinsic/IntrinsicReturnType.java
+++ b/delphi-frontend/src/main/java/au/com/integradev/delphi/type/intrinsic/IntrinsicReturnType.java
@@ -75,6 +75,10 @@ public abstract class IntrinsicReturnType extends TypeImpl {
     return new ClassReferenceValueType();
   }
 
+  public static Type argumentByIndex(int index) {
+    return new ArgumentByIndexReturnType(index);
+  }
+
   private static final class HighLowReturnType extends IntrinsicReturnType {
     private final Type integerType;
 
@@ -201,6 +205,19 @@ public abstract class IntrinsicReturnType extends TypeImpl {
         result = typeFactory.getIntrinsic(result.size() == 1 ? ANSISTRING : UNICODESTRING);
       }
       return result;
+    }
+  }
+
+  private static final class ArgumentByIndexReturnType extends IntrinsicReturnType {
+    private final int index;
+
+    private ArgumentByIndexReturnType(int index) {
+      this.index = index;
+    }
+
+    @Override
+    public Type getReturnType(List<Type> arguments) {
+      return arguments.get(index);
     }
   }
 }

--- a/delphi-frontend/src/main/java/au/com/integradev/delphi/type/intrinsic/IntrinsicsInjector.java
+++ b/delphi-frontend/src/main/java/au/com/integradev/delphi/type/intrinsic/IntrinsicsInjector.java
@@ -48,7 +48,6 @@ import static org.sonar.plugins.communitydelphi.api.type.IntrinsicType.REAL;
 import static org.sonar.plugins.communitydelphi.api.type.IntrinsicType.SHORTSTRING;
 import static org.sonar.plugins.communitydelphi.api.type.IntrinsicType.UNICODESTRING;
 import static org.sonar.plugins.communitydelphi.api.type.IntrinsicType.VARIANT;
-import static org.sonar.plugins.communitydelphi.api.type.IntrinsicType.WIDESTRING;
 import static org.sonar.plugins.communitydelphi.api.type.IntrinsicType.WORD;
 
 import au.com.integradev.delphi.symbol.SymbolicNode;
@@ -199,7 +198,7 @@ public final class IntrinsicsInjector {
     routine("FillChar").varParam(TypeFactory.untypedType()).param(type(INTEGER)).param(ANY_ORDINAL);
     routine("Finalize").varParam(TypeFactory.untypedType()).param(type(NATIVEUINT)).required(1);
     routine("FreeMem").varParam(ANY_POINTER).param(type(INTEGER)).required(1);
-    routine("GetDir").param(type(BYTE)).varParam(type(UNICODESTRING));
+    routine("GetDir").param(type(BYTE)).varParam(ANY_STRING);
     routine("GetMem").varParam(ANY_POINTER).param(type(INTEGER));
     routine("Halt").param(type(INTEGER)).required(0);
     routine("HasWeakRef").param(ANY_CLASS_REFERENCE).returns(type(BOOLEAN));
@@ -253,10 +252,8 @@ public final class IntrinsicsInjector {
     routine("SeekEof").varParam(ANY_TEXT_FILE).required(0).returns(type(BOOLEAN));
     routine("SeekEoln").varParam(ANY_TEXT_FILE).required(0).returns(type(BOOLEAN));
     routine("SetLength").varParam(LIKE_DYNAMIC_ARRAY).param(type(INTEGER)).variadic(type(INTEGER));
-    routine("SetString").varParam(type(SHORTSTRING)).param(type(PANSICHAR)).param(type(INTEGER));
-    routine("SetString").varParam(type(ANSISTRING)).param(type(PANSICHAR)).param(type(INTEGER));
-    routine("SetString").varParam(type(WIDESTRING)).param(type(PCHAR)).param(type(INTEGER));
-    routine("SetString").varParam(type(UNICODESTRING)).param(type(PCHAR)).param(type(INTEGER));
+    routine("SetString").varParam(ANY_STRING).param(type(PANSICHAR)).param(type(INTEGER));
+    routine("SetString").varParam(ANY_STRING).param(type(PWIDECHAR)).param(type(INTEGER));
     routine("SetTextBuf")
         .varParam(ANY_TEXT_FILE)
         .varParam(TypeFactory.untypedType())
@@ -267,7 +264,7 @@ public final class IntrinsicsInjector {
     routine("Sqr").param(type(EXTENDED)).returns(type(EXTENDED));
     routine("Sqr").param(type(INTEGER)).returns(type(INTEGER));
     routine("Sqr").param(type(REAL)).returns(type(INT64));
-    routine("Str").constParam(TypeFactory.untypedType()).varParam(type(UNICODESTRING));
+    routine("Str").constParam(TypeFactory.untypedType()).varParam(ANY_STRING);
     routine("Succ").param(ANY_ORDINAL).returns(type(INTEGER));
     routine("Swap").param(type(INTEGER)).returns(type(INTEGER));
     routine("Trunc")
@@ -278,9 +275,9 @@ public final class IntrinsicsInjector {
     routine("TypeInfo").param(TypeFactory.untypedType()).returns(typeFactory.untypedPointer());
     routine("TypeOf").param(ANY_OBJECT).returns(typeFactory.untypedPointer());
     routine("Val")
-        .param(type(UNICODESTRING))
+        .param(ANY_STRING)
         .varParam(TypeFactory.untypedType())
-        .varParam(type(INTEGER));
+        .varParam(ANY_32_BIT_INTEGER);
     routine("VarArrayRedim").varParam(type(VARIANT)).param(type(INTEGER));
     routine("VarArrayRedim").varParam(type(OLEVARIANT)).param(type(INTEGER));
     routine("VarCast").varParam(type(VARIANT)).param(type(VARIANT)).param(type(INTEGER));

--- a/delphi-frontend/src/main/java/au/com/integradev/delphi/type/intrinsic/IntrinsicsInjector.java
+++ b/delphi-frontend/src/main/java/au/com/integradev/delphi/type/intrinsic/IntrinsicsInjector.java
@@ -259,7 +259,10 @@ public final class IntrinsicsInjector {
         .param(type(INTEGER))
         .required(2);
     routine("SizeOf").param(TypeFactory.untypedType()).returns(type(INTEGER));
-    routine("Slice").varParam(ANY_ARRAY).param(type(INTEGER)).returns(typeFactory.untypedPointer());
+    routine("Slice")
+        .varParam(ANY_ARRAY)
+        .param(type(INTEGER))
+        .returns(IntrinsicReturnType.slice(typeFactory));
     routine("Sqr").param(type(EXTENDED)).returns(type(EXTENDED));
     routine("Sqr").param(type(INTEGER)).returns(type(INTEGER));
     routine("Sqr").param(type(INT64)).returns(type(INT64));

--- a/delphi-frontend/src/main/java/au/com/integradev/delphi/type/intrinsic/IntrinsicsInjector.java
+++ b/delphi-frontend/src/main/java/au/com/integradev/delphi/type/intrinsic/IntrinsicsInjector.java
@@ -18,6 +18,7 @@
  */
 package au.com.integradev.delphi.type.intrinsic;
 
+import static au.com.integradev.delphi.type.intrinsic.IntrinsicArgumentMatcher.ANY_32_BIT_INTEGER;
 import static au.com.integradev.delphi.type.intrinsic.IntrinsicArgumentMatcher.ANY_ARRAY;
 import static au.com.integradev.delphi.type.intrinsic.IntrinsicArgumentMatcher.ANY_CLASS_REFERENCE;
 import static au.com.integradev.delphi.type.intrinsic.IntrinsicArgumentMatcher.ANY_DYNAMIC_ARRAY;
@@ -45,7 +46,6 @@ import static org.sonar.plugins.communitydelphi.api.type.IntrinsicType.POINTER;
 import static org.sonar.plugins.communitydelphi.api.type.IntrinsicType.PWIDECHAR;
 import static org.sonar.plugins.communitydelphi.api.type.IntrinsicType.REAL;
 import static org.sonar.plugins.communitydelphi.api.type.IntrinsicType.SHORTSTRING;
-import static org.sonar.plugins.communitydelphi.api.type.IntrinsicType.TEXT;
 import static org.sonar.plugins.communitydelphi.api.type.IntrinsicType.UNICODESTRING;
 import static org.sonar.plugins.communitydelphi.api.type.IntrinsicType.VARIANT;
 import static org.sonar.plugins.communitydelphi.api.type.IntrinsicType.WIDESTRING;
@@ -132,17 +132,17 @@ public final class IntrinsicsInjector {
         .required(1)
         .returns(type(INTEGER));
     routine("BlockRead")
-        .varParam(typeFactory.untypedFile())
+        .varParam(ANY_FILE)
         .varParam(TypeFactory.untypedType())
         .param(type(INTEGER))
-        .varParam(type(INTEGER))
+        .varParam(ANY_32_BIT_INTEGER)
         .required(3)
         .returns(type(INTEGER));
     routine("BlockWrite")
-        .varParam(typeFactory.untypedFile())
+        .varParam(ANY_FILE)
         .constParam(TypeFactory.untypedType())
         .param(type(INTEGER))
-        .varParam(type(INTEGER))
+        .varParam(ANY_32_BIT_INTEGER)
         .required(3)
         .returns(type(INTEGER));
     routine("Break");
@@ -157,8 +157,8 @@ public final class IntrinsicsInjector {
     routine("BuiltInSqrt").param(type(REAL)).returns(type(EXTENDED));
     routine("BuiltInTan").param(type(REAL)).returns(type(EXTENDED));
     routine("Chr").param(type(BYTE)).returns(type(CHAR));
-    routine("Close").varParam(typeFactory.untypedFile()).returns(type(INTEGER));
-    routine("CloseFile").varParam(typeFactory.untypedFile());
+    routine("Close").varParam(ANY_FILE).returns(type(INTEGER));
+    routine("CloseFile").varParam(ANY_FILE);
     routine("Concat")
         .param(LIKE_DYNAMIC_ARRAY)
         .param(LIKE_DYNAMIC_ARRAY)
@@ -189,14 +189,14 @@ public final class IntrinsicsInjector {
     routine("Delete").varParam(type(UNICODESTRING)).param(type(INTEGER)).param(type(INTEGER));
     routine("Delete").varParam(ANY_DYNAMIC_ARRAY).param(type(INTEGER)).param(type(INTEGER));
     routine("Dispose").varParam(typeFactory.untypedPointer());
-    routine("Eof").varParam(typeFactory.untypedFile()).required(0).returns(type(BOOLEAN));
-    routine("Eoln").varParam(typeFactory.untypedFile()).required(0).returns(type(BOOLEAN));
-    routine("Erase").varParam(typeFactory.untypedFile());
+    routine("Eof").varParam(ANY_FILE).required(0).returns(type(BOOLEAN));
+    routine("Eoln").varParam(ANY_FILE).required(0).returns(type(BOOLEAN));
+    routine("Erase").varParam(ANY_FILE);
     routine("Exclude").varParam(ANY_SET).param(ANY_ORDINAL);
     routine("Exit").varParam(TypeFactory.untypedType()).required(0);
     routine("Fail");
-    routine("FilePos").varParam(typeFactory.untypedFile()).returns(type(INTEGER));
-    routine("FileSize").varParam(typeFactory.untypedFile()).returns(type(INTEGER));
+    routine("FilePos").varParam(ANY_FILE).returns(type(INTEGER));
+    routine("FileSize").varParam(ANY_FILE).returns(type(INTEGER));
     routine("FillChar").varParam(TypeFactory.untypedType()).param(type(INTEGER)).param(ANY_ORDINAL);
     routine("Finalize").varParam(TypeFactory.untypedType()).param(type(NATIVEUINT)).required(1);
     routine("FreeMem").varParam(typeFactory.untypedPointer()).param(type(INTEGER)).required(1);
@@ -237,21 +237,21 @@ public final class IntrinsicsInjector {
     routine("Pred").param(ANY_ORDINAL).returns(type(INTEGER));
     routine("Ptr").param(type(INTEGER)).returns(typeFactory.untypedPointer());
     routine("Read")
-        .varParam(typeFactory.untypedFile())
+        .varParam(ANY_FILE)
         .param(TypeFactory.untypedType())
         .variadic(TypeFactory.untypedType());
-    routine("ReadLn").varParam(typeFactory.untypedFile()).variadic(TypeFactory.untypedType());
+    routine("ReadLn").varParam(ANY_FILE).variadic(TypeFactory.untypedType());
     routine("ReallocMem").varParam(typeFactory.untypedPointer()).param(type(INTEGER));
-    routine("Rename").varParam(typeFactory.untypedFile()).param(type(UNICODESTRING));
-    routine("Reset").varParam(typeFactory.untypedFile()).param(type(INTEGER)).required(1);
-    routine("Rewrite").varParam(typeFactory.untypedFile()).param(type(INTEGER)).required(1);
+    routine("Rename").varParam(ANY_FILE).param(ANY_STRING);
+    routine("Reset").varParam(ANY_FILE).param(type(INTEGER)).required(1);
+    routine("Rewrite").varParam(ANY_FILE).param(type(INTEGER)).required(1);
     routine("Round")
         .param(TypeFactory.untypedType())
         .returns(IntrinsicReturnType.round(typeFactory));
     routine("RunError").param(type(BYTE)).required(0);
-    routine("Seek").varParam(typeFactory.untypedFile()).param(type(INTEGER));
-    routine("SeekEof").varParam(type(TEXT)).required(0).returns(type(BOOLEAN));
-    routine("SeekEoln").varParam(type(TEXT)).required(0).returns(type(BOOLEAN));
+    routine("Seek").varParam(ANY_FILE).param(type(INTEGER));
+    routine("SeekEof").varParam(ANY_TEXT_FILE).required(0).returns(type(BOOLEAN));
+    routine("SeekEoln").varParam(ANY_TEXT_FILE).required(0).returns(type(BOOLEAN));
     routine("SetLength").varParam(type(UNICODESTRING)).param(type(INTEGER));
     routine("SetLength").varParam(type(ANSISTRING)).param(type(INTEGER));
     routine("SetLength").varParam(ANY_DYNAMIC_ARRAY).param(type(INTEGER)).variadic(type(INTEGER));
@@ -260,7 +260,7 @@ public final class IntrinsicsInjector {
     routine("SetString").varParam(type(WIDESTRING)).param(type(PCHAR)).param(type(INTEGER));
     routine("SetString").varParam(type(UNICODESTRING)).param(type(PCHAR)).param(type(INTEGER));
     routine("SetTextBuf")
-        .varParam(type(TEXT))
+        .varParam(ANY_TEXT_FILE)
         .varParam(TypeFactory.untypedType())
         .param(type(INTEGER))
         .required(2);
@@ -275,7 +275,7 @@ public final class IntrinsicsInjector {
     routine("Trunc")
         .param(TypeFactory.untypedType())
         .returns(IntrinsicReturnType.trunc(typeFactory));
-    routine("Truncate").varParam(typeFactory.untypedFile());
+    routine("Truncate").varParam(ANY_FILE);
     routine("TypeHandle").param(TypeFactory.untypedType()).returns(typeFactory.untypedPointer());
     routine("TypeInfo").param(TypeFactory.untypedType()).returns(typeFactory.untypedPointer());
     routine("TypeOf").param(ANY_OBJECT).returns(typeFactory.untypedPointer());
@@ -290,11 +290,11 @@ public final class IntrinsicsInjector {
     routine("VarClear").varParam(type(OLEVARIANT));
     routine("VarCopy").varParam(type(VARIANT)).param(type(VARIANT));
     routine("Write")
-        .varParam(typeFactory.untypedFile())
+        .varParam(ANY_FILE)
         .param(TypeFactory.untypedType())
         .variadic(TypeFactory.untypedType());
     routine("Write").varParam(TypeFactory.untypedType()).variadic(TypeFactory.untypedType());
-    routine("WriteLn").varParam(typeFactory.untypedFile()).variadic(TypeFactory.untypedType());
+    routine("WriteLn").varParam(ANY_FILE).variadic(TypeFactory.untypedType());
     routine("WriteLn").variadic(TypeFactory.untypedType());
   }
 

--- a/delphi-frontend/src/main/java/au/com/integradev/delphi/type/intrinsic/IntrinsicsInjector.java
+++ b/delphi-frontend/src/main/java/au/com/integradev/delphi/type/intrinsic/IntrinsicsInjector.java
@@ -29,6 +29,7 @@ import static au.com.integradev.delphi.type.intrinsic.IntrinsicArgumentMatcher.A
 import static au.com.integradev.delphi.type.intrinsic.IntrinsicArgumentMatcher.ANY_STRING;
 import static au.com.integradev.delphi.type.intrinsic.IntrinsicArgumentMatcher.ANY_TEXT_FILE;
 import static au.com.integradev.delphi.type.intrinsic.IntrinsicArgumentMatcher.ANY_TYPED_POINTER;
+import static au.com.integradev.delphi.type.intrinsic.IntrinsicArgumentMatcher.ANY_VARIANT;
 import static au.com.integradev.delphi.type.intrinsic.IntrinsicArgumentMatcher.LIKE_DYNAMIC_ARRAY;
 import static org.sonar.plugins.communitydelphi.api.type.IntrinsicType.ANSISTRING;
 import static org.sonar.plugins.communitydelphi.api.type.IntrinsicType.BOOLEAN;
@@ -40,14 +41,12 @@ import static org.sonar.plugins.communitydelphi.api.type.IntrinsicType.INTEGER;
 import static org.sonar.plugins.communitydelphi.api.type.IntrinsicType.LONGINT;
 import static org.sonar.plugins.communitydelphi.api.type.IntrinsicType.NATIVEINT;
 import static org.sonar.plugins.communitydelphi.api.type.IntrinsicType.NATIVEUINT;
-import static org.sonar.plugins.communitydelphi.api.type.IntrinsicType.OLEVARIANT;
 import static org.sonar.plugins.communitydelphi.api.type.IntrinsicType.PANSICHAR;
 import static org.sonar.plugins.communitydelphi.api.type.IntrinsicType.POINTER;
 import static org.sonar.plugins.communitydelphi.api.type.IntrinsicType.PWIDECHAR;
 import static org.sonar.plugins.communitydelphi.api.type.IntrinsicType.REAL;
 import static org.sonar.plugins.communitydelphi.api.type.IntrinsicType.SHORTSTRING;
 import static org.sonar.plugins.communitydelphi.api.type.IntrinsicType.UNICODESTRING;
-import static org.sonar.plugins.communitydelphi.api.type.IntrinsicType.VARIANT;
 import static org.sonar.plugins.communitydelphi.api.type.IntrinsicType.WORD;
 
 import au.com.integradev.delphi.symbol.SymbolicNode;
@@ -278,12 +277,10 @@ public final class IntrinsicsInjector {
         .param(ANY_STRING)
         .varParam(TypeFactory.untypedType())
         .varParam(ANY_32_BIT_INTEGER);
-    routine("VarArrayRedim").varParam(type(VARIANT)).param(type(INTEGER));
-    routine("VarArrayRedim").varParam(type(OLEVARIANT)).param(type(INTEGER));
-    routine("VarCast").varParam(type(VARIANT)).param(type(VARIANT)).param(type(INTEGER));
-    routine("VarClear").varParam(type(VARIANT));
-    routine("VarClear").varParam(type(OLEVARIANT));
-    routine("VarCopy").varParam(type(VARIANT)).param(type(VARIANT));
+    routine("VarArrayRedim").varParam(ANY_VARIANT).param(type(INTEGER));
+    routine("VarCast").varParam(ANY_VARIANT).param(ANY_VARIANT).param(type(INTEGER));
+    routine("VarClear").varParam(ANY_VARIANT);
+    routine("VarCopy").varParam(ANY_VARIANT).param(ANY_VARIANT);
     routine("Write")
         .varParam(ANY_FILE)
         .param(TypeFactory.untypedType())

--- a/delphi-frontend/src/main/java/au/com/integradev/delphi/type/intrinsic/IntrinsicsInjector.java
+++ b/delphi-frontend/src/main/java/au/com/integradev/delphi/type/intrinsic/IntrinsicsInjector.java
@@ -21,6 +21,7 @@ package au.com.integradev.delphi.type.intrinsic;
 import static au.com.integradev.delphi.type.intrinsic.IntrinsicArgumentMatcher.ANY_ARRAY;
 import static au.com.integradev.delphi.type.intrinsic.IntrinsicArgumentMatcher.ANY_CLASS_REFERENCE;
 import static au.com.integradev.delphi.type.intrinsic.IntrinsicArgumentMatcher.ANY_DYNAMIC_ARRAY;
+import static au.com.integradev.delphi.type.intrinsic.IntrinsicArgumentMatcher.ANY_FILE;
 import static au.com.integradev.delphi.type.intrinsic.IntrinsicArgumentMatcher.ANY_OBJECT;
 import static au.com.integradev.delphi.type.intrinsic.IntrinsicArgumentMatcher.ANY_ORDINAL;
 import static au.com.integradev.delphi.type.intrinsic.IntrinsicArgumentMatcher.ANY_SET;
@@ -95,11 +96,7 @@ public final class IntrinsicsInjector {
     routine("Addr").varParam(TypeFactory.untypedType()).returns(typeFactory.untypedPointer());
     routine("Append").varParam(ANY_TEXT_FILE).returns(type(INTEGER));
     routine("Assert").param(type(BOOLEAN)).param(ANY_STRING).required(1);
-    routine("Assign")
-        .varParam(typeFactory.untypedFile())
-        .param(type(UNICODESTRING))
-        .param(type(WORD))
-        .required(2);
+    routine("Assign").varParam(ANY_FILE).param(ANY_STRING).param(type(WORD)).required(2);
     routine("Assigned").varParam(TypeFactory.untypedType()).returns(type(BOOLEAN));
     routine("AssignFile")
         .varParam(typeFactory.untypedFile())

--- a/delphi-frontend/src/main/java/au/com/integradev/delphi/type/intrinsic/IntrinsicsInjector.java
+++ b/delphi-frontend/src/main/java/au/com/integradev/delphi/type/intrinsic/IntrinsicsInjector.java
@@ -24,6 +24,7 @@ import static au.com.integradev.delphi.type.intrinsic.IntrinsicArgumentMatcher.A
 import static au.com.integradev.delphi.type.intrinsic.IntrinsicArgumentMatcher.ANY_OBJECT;
 import static au.com.integradev.delphi.type.intrinsic.IntrinsicArgumentMatcher.ANY_ORDINAL;
 import static au.com.integradev.delphi.type.intrinsic.IntrinsicArgumentMatcher.ANY_SET;
+import static au.com.integradev.delphi.type.intrinsic.IntrinsicArgumentMatcher.ANY_STRING;
 import static au.com.integradev.delphi.type.intrinsic.IntrinsicArgumentMatcher.ANY_TEXT_FILE;
 import static au.com.integradev.delphi.type.intrinsic.IntrinsicArgumentMatcher.ANY_TYPED_POINTER;
 import static au.com.integradev.delphi.type.intrinsic.IntrinsicArgumentMatcher.LIKE_DYNAMIC_ARRAY;
@@ -93,7 +94,7 @@ public final class IntrinsicsInjector {
     routine("Abs").param(type(INT64)).returns(type(INT64));
     routine("Addr").varParam(TypeFactory.untypedType()).returns(typeFactory.untypedPointer());
     routine("Append").varParam(ANY_TEXT_FILE).returns(type(INTEGER));
-    routine("Assert").varParam(type(BOOLEAN)).param(type(UNICODESTRING)).required(1);
+    routine("Assert").param(type(BOOLEAN)).param(ANY_STRING).required(1);
     routine("Assign")
         .varParam(typeFactory.untypedFile())
         .param(type(UNICODESTRING))

--- a/delphi-frontend/src/main/java/au/com/integradev/delphi/type/intrinsic/IntrinsicsInjector.java
+++ b/delphi-frontend/src/main/java/au/com/integradev/delphi/type/intrinsic/IntrinsicsInjector.java
@@ -262,7 +262,7 @@ public final class IntrinsicsInjector {
     routine("Slice").varParam(ANY_ARRAY).param(type(INTEGER)).returns(typeFactory.untypedPointer());
     routine("Sqr").param(type(EXTENDED)).returns(type(EXTENDED));
     routine("Sqr").param(type(INTEGER)).returns(type(INTEGER));
-    routine("Sqr").param(type(REAL)).returns(type(INT64));
+    routine("Sqr").param(type(INT64)).returns(type(INT64));
     routine("Str").constParam(TypeFactory.untypedType()).varParam(ANY_STRING);
     routine("Succ").param(ANY_ORDINAL).returns(type(INTEGER));
     routine("Swap").param(type(INTEGER)).returns(type(INTEGER));

--- a/delphi-frontend/src/main/java/au/com/integradev/delphi/type/intrinsic/IntrinsicsInjector.java
+++ b/delphi-frontend/src/main/java/au/com/integradev/delphi/type/intrinsic/IntrinsicsInjector.java
@@ -24,6 +24,7 @@ import static au.com.integradev.delphi.type.intrinsic.IntrinsicArgumentMatcher.A
 import static au.com.integradev.delphi.type.intrinsic.IntrinsicArgumentMatcher.ANY_FILE;
 import static au.com.integradev.delphi.type.intrinsic.IntrinsicArgumentMatcher.ANY_OBJECT;
 import static au.com.integradev.delphi.type.intrinsic.IntrinsicArgumentMatcher.ANY_ORDINAL;
+import static au.com.integradev.delphi.type.intrinsic.IntrinsicArgumentMatcher.ANY_POINTER;
 import static au.com.integradev.delphi.type.intrinsic.IntrinsicArgumentMatcher.ANY_SET;
 import static au.com.integradev.delphi.type.intrinsic.IntrinsicArgumentMatcher.ANY_STRING;
 import static au.com.integradev.delphi.type.intrinsic.IntrinsicArgumentMatcher.ANY_TEXT_FILE;
@@ -186,7 +187,7 @@ public final class IntrinsicsInjector {
         .param(ANY_CLASS_REFERENCE)
         .returns(IntrinsicReturnType.classReferenceValue());
     routine("Delete").varParam(LIKE_DYNAMIC_ARRAY).param(type(INTEGER)).param(type(INTEGER));
-    routine("Dispose").varParam(typeFactory.untypedPointer());
+    routine("Dispose").varParam(ANY_POINTER);
     routine("Eof").varParam(ANY_FILE).required(0).returns(type(BOOLEAN));
     routine("Eoln").varParam(ANY_FILE).required(0).returns(type(BOOLEAN));
     routine("Erase").varParam(ANY_FILE);
@@ -197,9 +198,9 @@ public final class IntrinsicsInjector {
     routine("FileSize").varParam(ANY_FILE).returns(type(INTEGER));
     routine("FillChar").varParam(TypeFactory.untypedType()).param(type(INTEGER)).param(ANY_ORDINAL);
     routine("Finalize").varParam(TypeFactory.untypedType()).param(type(NATIVEUINT)).required(1);
-    routine("FreeMem").varParam(typeFactory.untypedPointer()).param(type(INTEGER)).required(1);
+    routine("FreeMem").varParam(ANY_POINTER).param(type(INTEGER)).required(1);
     routine("GetDir").param(type(BYTE)).varParam(type(UNICODESTRING));
-    routine("GetMem").varParam(typeFactory.untypedPointer()).param(type(INTEGER));
+    routine("GetMem").varParam(ANY_POINTER).param(type(INTEGER));
     routine("Halt").param(type(INTEGER)).required(0);
     routine("HasWeakRef").param(ANY_CLASS_REFERENCE).returns(type(BOOLEAN));
     routine("Hi").param(type(INTEGER)).returns(type(BYTE));
@@ -229,7 +230,7 @@ public final class IntrinsicsInjector {
         .outParam(type(INT64))
         .required(3)
         .returns(type(INT64));
-    routine("New").varParam(typeFactory.untypedPointer());
+    routine("New").varParam(ANY_POINTER);
     routine("Odd").param(type(INTEGER)).returns(type(BOOLEAN));
     routine("Ord").param(ANY_ORDINAL).returns(type(BYTE));
     routine("Pi").returns(type(EXTENDED));
@@ -240,7 +241,7 @@ public final class IntrinsicsInjector {
         .param(TypeFactory.untypedType())
         .variadic(TypeFactory.untypedType());
     routine("ReadLn").varParam(ANY_FILE).variadic(TypeFactory.untypedType());
-    routine("ReallocMem").varParam(typeFactory.untypedPointer()).param(type(INTEGER));
+    routine("ReallocMem").varParam(ANY_POINTER).param(type(INTEGER));
     routine("Rename").varParam(ANY_FILE).param(ANY_STRING);
     routine("Reset").varParam(ANY_FILE).param(type(INTEGER)).required(1);
     routine("Rewrite").varParam(ANY_FILE).param(type(INTEGER)).required(1);

--- a/delphi-frontend/src/main/java/au/com/integradev/delphi/type/intrinsic/IntrinsicsInjector.java
+++ b/delphi-frontend/src/main/java/au/com/integradev/delphi/type/intrinsic/IntrinsicsInjector.java
@@ -24,6 +24,7 @@ import static au.com.integradev.delphi.type.intrinsic.IntrinsicArgumentMatcher.A
 import static au.com.integradev.delphi.type.intrinsic.IntrinsicArgumentMatcher.ANY_OBJECT;
 import static au.com.integradev.delphi.type.intrinsic.IntrinsicArgumentMatcher.ANY_ORDINAL;
 import static au.com.integradev.delphi.type.intrinsic.IntrinsicArgumentMatcher.ANY_SET;
+import static au.com.integradev.delphi.type.intrinsic.IntrinsicArgumentMatcher.ANY_TEXT_FILE;
 import static au.com.integradev.delphi.type.intrinsic.IntrinsicArgumentMatcher.ANY_TYPED_POINTER;
 import static au.com.integradev.delphi.type.intrinsic.IntrinsicArgumentMatcher.LIKE_DYNAMIC_ARRAY;
 import static org.sonar.plugins.communitydelphi.api.type.IntrinsicType.ANSISTRING;
@@ -91,7 +92,7 @@ public final class IntrinsicsInjector {
     routine("Abs").param(type(INTEGER)).returns(type(INTEGER));
     routine("Abs").param(type(INT64)).returns(type(INT64));
     routine("Addr").varParam(TypeFactory.untypedType()).returns(typeFactory.untypedPointer());
-    routine("Append").varParam(type(TEXT)).returns(type(INTEGER));
+    routine("Append").varParam(ANY_TEXT_FILE).returns(type(INTEGER));
     routine("Assert").varParam(type(BOOLEAN)).param(type(UNICODESTRING)).required(1);
     routine("Assign")
         .varParam(typeFactory.untypedFile())

--- a/delphi-frontend/src/main/java/au/com/integradev/delphi/type/intrinsic/IntrinsicsInjector.java
+++ b/delphi-frontend/src/main/java/au/com/integradev/delphi/type/intrinsic/IntrinsicsInjector.java
@@ -25,6 +25,7 @@ import static au.com.integradev.delphi.type.intrinsic.IntrinsicArgumentMatcher.A
 import static au.com.integradev.delphi.type.intrinsic.IntrinsicArgumentMatcher.ANY_ORDINAL;
 import static au.com.integradev.delphi.type.intrinsic.IntrinsicArgumentMatcher.ANY_SET;
 import static au.com.integradev.delphi.type.intrinsic.IntrinsicArgumentMatcher.ANY_TYPED_POINTER;
+import static au.com.integradev.delphi.type.intrinsic.IntrinsicArgumentMatcher.LIKE_DYNAMIC_ARRAY;
 import static org.sonar.plugins.communitydelphi.api.type.IntrinsicType.ANSISTRING;
 import static org.sonar.plugins.communitydelphi.api.type.IntrinsicType.BOOLEAN;
 import static org.sonar.plugins.communitydelphi.api.type.IntrinsicType.BYTE;
@@ -164,15 +165,10 @@ public final class IntrinsicsInjector {
     routine("Close").varParam(typeFactory.untypedFile()).returns(type(INTEGER));
     routine("CloseFile").varParam(typeFactory.untypedFile());
     routine("Concat")
-        .param(type(UNICODESTRING))
-        .param(type(UNICODESTRING))
-        .variadic(type(UNICODESTRING))
-        .returns(type(UNICODESTRING));
-    routine("Concat")
-        .param(ANY_DYNAMIC_ARRAY)
-        .param(ANY_DYNAMIC_ARRAY)
-        .variadic(ANY_DYNAMIC_ARRAY)
-        .returns(ANY_DYNAMIC_ARRAY);
+        .param(LIKE_DYNAMIC_ARRAY)
+        .param(LIKE_DYNAMIC_ARRAY)
+        .variadic(LIKE_DYNAMIC_ARRAY)
+        .returns(IntrinsicReturnType.concat(typeFactory));
     routine("Continue");
     routine("Copy")
         .param(type(UNICODESTRING))

--- a/delphi-frontend/src/main/java/au/com/integradev/delphi/type/intrinsic/IntrinsicsInjector.java
+++ b/delphi-frontend/src/main/java/au/com/integradev/delphi/type/intrinsic/IntrinsicsInjector.java
@@ -216,6 +216,8 @@ public final class IntrinsicsInjector {
     routine("Insert").param(ANY_DYNAMIC_ARRAY).varParam(ANY_DYNAMIC_ARRAY).param(type(INTEGER));
     routine("IsConstValue").param(TypeFactory.untypedType()).returns(type(BOOLEAN));
     routine("IsManagedType").param(ANY_CLASS_REFERENCE).returns(type(BOOLEAN));
+    routine("Length").param(type(SHORTSTRING)).returns(type(BYTE));
+    routine("Length").param(type(ANSISTRING)).returns(type(INTEGER));
     routine("Length").param(type(UNICODESTRING)).returns(type(INTEGER));
     routine("Length").param(ANY_ARRAY).returns(type(INTEGER));
     routine("Lo").param(type(INTEGER)).returns(type(BYTE));

--- a/delphi-frontend/src/main/java/au/com/integradev/delphi/type/intrinsic/IntrinsicsInjector.java
+++ b/delphi-frontend/src/main/java/au/com/integradev/delphi/type/intrinsic/IntrinsicsInjector.java
@@ -21,7 +21,6 @@ package au.com.integradev.delphi.type.intrinsic;
 import static au.com.integradev.delphi.type.intrinsic.IntrinsicArgumentMatcher.ANY_32_BIT_INTEGER;
 import static au.com.integradev.delphi.type.intrinsic.IntrinsicArgumentMatcher.ANY_ARRAY;
 import static au.com.integradev.delphi.type.intrinsic.IntrinsicArgumentMatcher.ANY_CLASS_REFERENCE;
-import static au.com.integradev.delphi.type.intrinsic.IntrinsicArgumentMatcher.ANY_DYNAMIC_ARRAY;
 import static au.com.integradev.delphi.type.intrinsic.IntrinsicArgumentMatcher.ANY_FILE;
 import static au.com.integradev.delphi.type.intrinsic.IntrinsicArgumentMatcher.ANY_OBJECT;
 import static au.com.integradev.delphi.type.intrinsic.IntrinsicArgumentMatcher.ANY_ORDINAL;
@@ -186,8 +185,7 @@ public final class IntrinsicsInjector {
     routine("Default")
         .param(ANY_CLASS_REFERENCE)
         .returns(IntrinsicReturnType.classReferenceValue());
-    routine("Delete").varParam(type(UNICODESTRING)).param(type(INTEGER)).param(type(INTEGER));
-    routine("Delete").varParam(ANY_DYNAMIC_ARRAY).param(type(INTEGER)).param(type(INTEGER));
+    routine("Delete").varParam(LIKE_DYNAMIC_ARRAY).param(type(INTEGER)).param(type(INTEGER));
     routine("Dispose").varParam(typeFactory.untypedPointer());
     routine("Eof").varParam(ANY_FILE).required(0).returns(type(BOOLEAN));
     routine("Eoln").varParam(ANY_FILE).required(0).returns(type(BOOLEAN));
@@ -212,8 +210,7 @@ public final class IntrinsicsInjector {
     routine("Inc").varParam(ANY_TYPED_POINTER).param(type(INTEGER)).required(1);
     routine("Include").varParam(ANY_SET).param(ANY_ORDINAL);
     routine("Initialize").varParam(TypeFactory.untypedType()).param(type(NATIVEINT)).required(1);
-    routine("Insert").param(type(UNICODESTRING)).varParam(type(UNICODESTRING)).param(type(INTEGER));
-    routine("Insert").param(ANY_DYNAMIC_ARRAY).varParam(ANY_DYNAMIC_ARRAY).param(type(INTEGER));
+    routine("Insert").param(LIKE_DYNAMIC_ARRAY).varParam(LIKE_DYNAMIC_ARRAY).param(type(INTEGER));
     routine("IsConstValue").param(TypeFactory.untypedType()).returns(type(BOOLEAN));
     routine("IsManagedType").param(ANY_CLASS_REFERENCE).returns(type(BOOLEAN));
     routine("Length").param(type(SHORTSTRING)).returns(type(BYTE));
@@ -254,9 +251,7 @@ public final class IntrinsicsInjector {
     routine("Seek").varParam(ANY_FILE).param(type(INTEGER));
     routine("SeekEof").varParam(ANY_TEXT_FILE).required(0).returns(type(BOOLEAN));
     routine("SeekEoln").varParam(ANY_TEXT_FILE).required(0).returns(type(BOOLEAN));
-    routine("SetLength").varParam(type(UNICODESTRING)).param(type(INTEGER));
-    routine("SetLength").varParam(type(ANSISTRING)).param(type(INTEGER));
-    routine("SetLength").varParam(ANY_DYNAMIC_ARRAY).param(type(INTEGER)).variadic(type(INTEGER));
+    routine("SetLength").varParam(LIKE_DYNAMIC_ARRAY).param(type(INTEGER)).variadic(type(INTEGER));
     routine("SetString").varParam(type(SHORTSTRING)).param(type(PANSICHAR)).param(type(INTEGER));
     routine("SetString").varParam(type(ANSISTRING)).param(type(PANSICHAR)).param(type(INTEGER));
     routine("SetString").varParam(type(WIDESTRING)).param(type(PCHAR)).param(type(INTEGER));

--- a/delphi-frontend/src/main/java/au/com/integradev/delphi/type/intrinsic/IntrinsicsInjector.java
+++ b/delphi-frontend/src/main/java/au/com/integradev/delphi/type/intrinsic/IntrinsicsInjector.java
@@ -98,11 +98,7 @@ public final class IntrinsicsInjector {
     routine("Assert").param(type(BOOLEAN)).param(ANY_STRING).required(1);
     routine("Assign").varParam(ANY_FILE).param(ANY_STRING).param(type(WORD)).required(2);
     routine("Assigned").varParam(TypeFactory.untypedType()).returns(type(BOOLEAN));
-    routine("AssignFile")
-        .varParam(typeFactory.untypedFile())
-        .param(type(UNICODESTRING))
-        .param(type(WORD))
-        .required(2);
+    routine("AssignFile").varParam(ANY_FILE).param(ANY_STRING).param(type(WORD)).required(2);
     routine("AtomicCmpExchange")
         .varParam(TypeFactory.untypedType())
         .param(type(INTEGER))

--- a/delphi-frontend/src/main/java/au/com/integradev/delphi/type/intrinsic/IntrinsicsInjector.java
+++ b/delphi-frontend/src/main/java/au/com/integradev/delphi/type/intrinsic/IntrinsicsInjector.java
@@ -264,7 +264,7 @@ public final class IntrinsicsInjector {
     routine("Sqr").param(type(INTEGER)).returns(type(INTEGER));
     routine("Sqr").param(type(INT64)).returns(type(INT64));
     routine("Str").constParam(TypeFactory.untypedType()).varParam(ANY_STRING);
-    routine("Succ").param(ANY_ORDINAL).returns(type(INTEGER));
+    routine("Succ").param(ANY_ORDINAL).returns(IntrinsicReturnType.argumentByIndex(0));
     routine("Swap").param(type(INTEGER)).returns(type(INTEGER));
     routine("Trunc")
         .param(TypeFactory.untypedType())

--- a/delphi-frontend/src/main/java/au/com/integradev/delphi/type/intrinsic/IntrinsicsInjector.java
+++ b/delphi-frontend/src/main/java/au/com/integradev/delphi/type/intrinsic/IntrinsicsInjector.java
@@ -38,8 +38,8 @@ import static org.sonar.plugins.communitydelphi.api.type.IntrinsicType.NATIVEINT
 import static org.sonar.plugins.communitydelphi.api.type.IntrinsicType.NATIVEUINT;
 import static org.sonar.plugins.communitydelphi.api.type.IntrinsicType.OLEVARIANT;
 import static org.sonar.plugins.communitydelphi.api.type.IntrinsicType.PANSICHAR;
-import static org.sonar.plugins.communitydelphi.api.type.IntrinsicType.PCHAR;
 import static org.sonar.plugins.communitydelphi.api.type.IntrinsicType.POINTER;
+import static org.sonar.plugins.communitydelphi.api.type.IntrinsicType.PWIDECHAR;
 import static org.sonar.plugins.communitydelphi.api.type.IntrinsicType.REAL;
 import static org.sonar.plugins.communitydelphi.api.type.IntrinsicType.SHORTSTRING;
 import static org.sonar.plugins.communitydelphi.api.type.IntrinsicType.TEXT;
@@ -171,16 +171,21 @@ public final class IntrinsicsInjector {
         .returns(IntrinsicReturnType.concat(typeFactory));
     routine("Continue");
     routine("Copy")
-        .param(type(UNICODESTRING))
+        .param(type(PANSICHAR))
         .param(type(INTEGER))
         .param(type(INTEGER))
-        .returns(type(UNICODESTRING));
+        .returns(IntrinsicReturnType.copy(typeFactory));
     routine("Copy")
-        .param(ANY_DYNAMIC_ARRAY)
+        .param(type(PWIDECHAR))
+        .param(type(INTEGER))
+        .param(type(INTEGER))
+        .returns(IntrinsicReturnType.copy(typeFactory));
+    routine("Copy")
+        .param(LIKE_DYNAMIC_ARRAY)
         .param(type(INTEGER))
         .param(type(INTEGER))
         .required(1)
-        .returns(type(UNICODESTRING));
+        .returns(IntrinsicReturnType.copy(typeFactory));
     routine("Dec").varParam(ANY_ORDINAL).param(type(INTEGER)).required(1);
     routine("Dec").varParam(ANY_TYPED_POINTER).param(type(INTEGER)).required(1);
     routine("Default")

--- a/delphi-frontend/src/test/java/au/com/integradev/delphi/symbol/resolve/InvocationResolverTest.java
+++ b/delphi-frontend/src/test/java/au/com/integradev/delphi/symbol/resolve/InvocationResolverTest.java
@@ -37,6 +37,8 @@ import static org.sonar.plugins.communitydelphi.api.type.IntrinsicType.LONGINT;
 import static org.sonar.plugins.communitydelphi.api.type.IntrinsicType.LONGWORD;
 import static org.sonar.plugins.communitydelphi.api.type.IntrinsicType.NATIVEINT;
 import static org.sonar.plugins.communitydelphi.api.type.IntrinsicType.NATIVEUINT;
+import static org.sonar.plugins.communitydelphi.api.type.IntrinsicType.PANSICHAR;
+import static org.sonar.plugins.communitydelphi.api.type.IntrinsicType.PWIDECHAR;
 import static org.sonar.plugins.communitydelphi.api.type.IntrinsicType.REAL;
 import static org.sonar.plugins.communitydelphi.api.type.IntrinsicType.SHORTINT;
 import static org.sonar.plugins.communitydelphi.api.type.IntrinsicType.SHORTSTRING;
@@ -266,6 +268,16 @@ class InvocationResolverTest {
         List.of(type(CHAR), type(CHAR)),
         List.of(type(UNICODESTRING), type(UNICODESTRING)),
         List.of(type(ANSISTRING), type(ANSISTRING)));
+
+    assertResolved(type(PANSICHAR), type(ANSISTRING), FACTORY.ansiString(CodePages.CP_1252));
+    assertResolved(type(PANSICHAR), FACTORY.ansiString(CodePages.CP_1252), type(UNICODESTRING));
+    assertResolved(type(PANSICHAR), type(UNICODESTRING), type(WIDESTRING));
+    assertResolved(type(PANSICHAR), type(WIDESTRING), type(SHORTSTRING));
+
+    assertResolved(type(PWIDECHAR), type(UNICODESTRING), type(WIDESTRING));
+    assertResolved(type(PWIDECHAR), type(WIDESTRING), type(ANSISTRING));
+    assertResolved(type(PWIDECHAR), type(ANSISTRING), type(SHORTSTRING));
+    assertIncompatible(type(PWIDECHAR), type(SHORTSTRING));
   }
 
   @Test

--- a/delphi-frontend/src/test/java/au/com/integradev/delphi/symbol/resolve/InvocationResolverTest.java
+++ b/delphi-frontend/src/test/java/au/com/integradev/delphi/symbol/resolve/InvocationResolverTest.java
@@ -22,6 +22,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
+import static org.sonar.plugins.communitydelphi.api.type.IntrinsicType.ANSICHAR;
 import static org.sonar.plugins.communitydelphi.api.type.IntrinsicType.ANSISTRING;
 import static org.sonar.plugins.communitydelphi.api.type.IntrinsicType.BOOLEAN;
 import static org.sonar.plugins.communitydelphi.api.type.IntrinsicType.BYTE;
@@ -66,6 +67,7 @@ import org.junit.jupiter.api.Test;
 import org.sonar.plugins.communitydelphi.api.ast.FormalParameterNode.FormalParameterData;
 import org.sonar.plugins.communitydelphi.api.symbol.Invocable;
 import org.sonar.plugins.communitydelphi.api.symbol.scope.DelphiScope;
+import org.sonar.plugins.communitydelphi.api.type.CodePages;
 import org.sonar.plugins.communitydelphi.api.type.IntrinsicType;
 import org.sonar.plugins.communitydelphi.api.type.Parameter;
 import org.sonar.plugins.communitydelphi.api.type.Type;
@@ -224,6 +226,46 @@ class InvocationResolverTest {
         type(UNICODESTRING),
         FACTORY.strongAlias("MyString", type(UNICODESTRING)),
         type(SHORTSTRING));
+    assertResolved(
+        List.of(type(ANSICHAR), type(ANSICHAR)),
+        List.of(type(ANSISTRING), type(ANSISTRING)),
+        List.of(type(UNICODESTRING), type(UNICODESTRING)));
+    assertResolved(
+        List.of(type(ANSISTRING), type(ANSISTRING)),
+        List.of(type(ANSISTRING), type(ANSISTRING)),
+        List.of(type(UNICODESTRING), type(UNICODESTRING)));
+    assertResolved(
+        List.of(type(ANSICHAR), type(SHORTSTRING)),
+        List.of(type(ANSISTRING), type(ANSISTRING)),
+        List.of(type(UNICODESTRING), type(UNICODESTRING)));
+    assertResolved(
+        List.of(type(ANSISTRING), type(SHORTSTRING)),
+        List.of(type(ANSISTRING), type(ANSISTRING)),
+        List.of(type(UNICODESTRING), type(UNICODESTRING)));
+    assertResolved(
+        List.of(type(SHORTSTRING), type(SHORTSTRING)),
+        List.of(type(ANSISTRING), type(ANSISTRING)),
+        List.of(type(UNICODESTRING), type(UNICODESTRING)));
+    assertResolved(
+        List.of(type(ANSICHAR), type(CHAR)),
+        List.of(type(UNICODESTRING), type(UNICODESTRING)),
+        List.of(type(ANSISTRING), type(ANSISTRING)));
+    assertResolved(
+        List.of(type(ANSISTRING), type(UNICODESTRING)),
+        List.of(type(UNICODESTRING), type(UNICODESTRING)),
+        List.of(type(ANSISTRING), type(ANSISTRING)));
+    assertResolved(
+        List.of(type(SHORTSTRING), type(CHAR)),
+        List.of(type(UNICODESTRING), type(UNICODESTRING)),
+        List.of(type(ANSISTRING), type(ANSISTRING)));
+    assertResolved(
+        List.of(type(SHORTSTRING), type(UNICODESTRING)),
+        List.of(type(UNICODESTRING), type(UNICODESTRING)),
+        List.of(type(ANSISTRING), type(ANSISTRING)));
+    assertResolved(
+        List.of(type(CHAR), type(CHAR)),
+        List.of(type(UNICODESTRING), type(UNICODESTRING)),
+        List.of(type(ANSISTRING), type(ANSISTRING)));
   }
 
   @Test
@@ -233,6 +275,14 @@ class InvocationResolverTest {
         List.of(type(UNICODESTRING), variantIncompatibleType, type(BOOLEAN)),
         List.of(type(UNICODESTRING), variantIncompatibleType, type(VARIANT), type(BOOLEAN)),
         List.of(type(UNICODESTRING), type(VARIANT), type(BOOLEAN)));
+    assertResolved(type(UNICODESTRING), type(VARIANT), type(ANSISTRING));
+    assertResolved(type(UNICODESTRING), type(VARIANT), type(SHORTSTRING));
+    assertResolved(type(SHORTSTRING), type(ANSISTRING), type(VARIANT));
+    assertResolved(type(ANSISTRING), type(VARIANT), type(SHORTSTRING));
+    assertResolved(type(ANSISTRING), type(UNICODESTRING), type(VARIANT));
+    assertResolved(type(ANSISTRING), FACTORY.ansiString(CodePages.CP_UTF8), type(VARIANT));
+    assertResolved(type(ANSISTRING), FACTORY.ansiString(CodePages.CP_1252), type(VARIANT));
+    assertResolved(FACTORY.ansiString(1251), FACTORY.ansiString(1252), type(VARIANT));
     assertResolved(
         List.of(type(VARIANT), type(BYTE)),
         List.of(type(UNICODESTRING), type(INTEGER)),

--- a/delphi-frontend/src/test/java/au/com/integradev/delphi/symbol/resolve/TypeComparerTest.java
+++ b/delphi-frontend/src/test/java/au/com/integradev/delphi/symbol/resolve/TypeComparerTest.java
@@ -30,10 +30,10 @@ import static au.com.integradev.delphi.symbol.resolve.EqualityType.EQUAL;
 import static au.com.integradev.delphi.symbol.resolve.EqualityType.EXACT;
 import static au.com.integradev.delphi.symbol.resolve.EqualityType.INCOMPATIBLE_TYPES;
 import static au.com.integradev.delphi.type.intrinsic.IntrinsicArgumentMatcher.ANY_ARRAY;
-import static au.com.integradev.delphi.type.intrinsic.IntrinsicArgumentMatcher.ANY_DYNAMIC_ARRAY;
 import static au.com.integradev.delphi.type.intrinsic.IntrinsicArgumentMatcher.ANY_OBJECT;
 import static au.com.integradev.delphi.type.intrinsic.IntrinsicArgumentMatcher.ANY_ORDINAL;
 import static au.com.integradev.delphi.type.intrinsic.IntrinsicArgumentMatcher.ANY_SET;
+import static au.com.integradev.delphi.type.intrinsic.IntrinsicArgumentMatcher.LIKE_DYNAMIC_ARRAY;
 import static java.util.Collections.emptyList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -644,9 +644,9 @@ class TypeComparerTest {
     compare(dynamicArray, ANY_ARRAY, EQUAL);
     compare(openArray, ANY_ARRAY, EQUAL);
 
-    compare(fixedArray, ANY_DYNAMIC_ARRAY, INCOMPATIBLE_TYPES);
-    compare(dynamicArray, ANY_DYNAMIC_ARRAY, EQUAL);
-    compare(openArray, ANY_DYNAMIC_ARRAY, INCOMPATIBLE_TYPES);
+    compare(fixedArray, LIKE_DYNAMIC_ARRAY, INCOMPATIBLE_TYPES);
+    compare(dynamicArray, LIKE_DYNAMIC_ARRAY, EQUAL);
+    compare(openArray, LIKE_DYNAMIC_ARRAY, INCOMPATIBLE_TYPES);
 
     compare(set, ANY_SET, EQUAL);
 

--- a/delphi-frontend/src/test/java/au/com/integradev/delphi/symbol/resolve/TypeComparerTest.java
+++ b/delphi-frontend/src/test/java/au/com/integradev/delphi/symbol/resolve/TypeComparerTest.java
@@ -189,13 +189,13 @@ class TypeComparerTest {
   @Test
   void testStringToString() {
     compare(IntrinsicType.WIDESTRING, IntrinsicType.UNICODESTRING, CONVERT_LEVEL_1);
-    compare(IntrinsicType.WIDESTRING, IntrinsicType.ANSISTRING, CONVERT_LEVEL_2);
-    compare(IntrinsicType.WIDESTRING, IntrinsicType.SHORTSTRING, CONVERT_LEVEL_3);
+    compare(IntrinsicType.WIDESTRING, IntrinsicType.ANSISTRING, CONVERT_LEVEL_4);
+    compare(IntrinsicType.WIDESTRING, IntrinsicType.SHORTSTRING, CONVERT_LEVEL_5);
     compare(IntrinsicType.WIDESTRING, IntrinsicType.CHAR, INCOMPATIBLE_TYPES);
 
     compare(IntrinsicType.UNICODESTRING, IntrinsicType.WIDESTRING, CONVERT_LEVEL_1);
-    compare(IntrinsicType.UNICODESTRING, IntrinsicType.ANSISTRING, CONVERT_LEVEL_2);
-    compare(IntrinsicType.UNICODESTRING, IntrinsicType.SHORTSTRING, CONVERT_LEVEL_3);
+    compare(IntrinsicType.UNICODESTRING, IntrinsicType.ANSISTRING, CONVERT_LEVEL_4);
+    compare(IntrinsicType.UNICODESTRING, IntrinsicType.SHORTSTRING, CONVERT_LEVEL_5);
     compare(IntrinsicType.UNICODESTRING, IntrinsicType.CHAR, INCOMPATIBLE_TYPES);
 
     compare(IntrinsicType.SHORTSTRING, IntrinsicType.ANSISTRING, CONVERT_LEVEL_1);
@@ -207,13 +207,13 @@ class TypeComparerTest {
     compare(strongAlias("_", IntrinsicType.ANSISTRING), IntrinsicType.ANSISTRING, EQUAL);
     compare(IntrinsicType.ANSISTRING, ansiString(CodePages.CP_NONE), EQUAL);
     compare(ansiString(CodePages.CP_NONE), strongAlias("_", ansiString(CodePages.CP_NONE)), EQUAL);
-    compare(IntrinsicType.ANSISTRING, ansiString(CodePages.CP_UTF8), CONVERT_LEVEL_1);
-    compare(ansiString(CodePages.CP_1252), IntrinsicType.ANSISTRING, CONVERT_LEVEL_2);
-    compare(ansiString(CodePages.CP_NONE), IntrinsicType.ANSISTRING, CONVERT_LEVEL_2);
-    compare(ansiString(CodePages.CP_1252), ansiString(50937), CONVERT_LEVEL_3);
-    compare(IntrinsicType.ANSISTRING, IntrinsicType.UNICODESTRING, CONVERT_LEVEL_4);
-    compare(IntrinsicType.ANSISTRING, IntrinsicType.WIDESTRING, CONVERT_LEVEL_5);
-    compare(IntrinsicType.ANSISTRING, IntrinsicType.SHORTSTRING, CONVERT_LEVEL_6);
+    compare(IntrinsicType.ANSISTRING, ansiString(CodePages.CP_UTF8), EQUAL);
+    compare(ansiString(CodePages.CP_1252), IntrinsicType.ANSISTRING, EQUAL);
+    compare(ansiString(CodePages.CP_NONE), IntrinsicType.ANSISTRING, EQUAL);
+    compare(ansiString(CodePages.CP_1252), ansiString(50937), EQUAL);
+    compare(IntrinsicType.ANSISTRING, IntrinsicType.UNICODESTRING, CONVERT_LEVEL_1);
+    compare(IntrinsicType.ANSISTRING, IntrinsicType.WIDESTRING, CONVERT_LEVEL_2);
+    compare(IntrinsicType.ANSISTRING, IntrinsicType.SHORTSTRING, CONVERT_LEVEL_3);
     compare(IntrinsicType.ANSISTRING, IntrinsicType.CHAR, INCOMPATIBLE_TYPES);
 
     compare(strongAlias("Test", IntrinsicType.UNICODESTRING), IntrinsicType.UNICODESTRING, EQUAL);

--- a/delphi-frontend/src/test/java/au/com/integradev/delphi/symbol/resolve/TypeComparerTest.java
+++ b/delphi-frontend/src/test/java/au/com/integradev/delphi/symbol/resolve/TypeComparerTest.java
@@ -258,9 +258,15 @@ class TypeComparerTest {
   @Test
   void testPointerToString() {
     compare(IntrinsicType.PANSICHAR, IntrinsicType.ANSISTRING, CONVERT_LEVEL_3);
-    compare(IntrinsicType.PCHAR, IntrinsicType.UNICODESTRING, CONVERT_LEVEL_3);
     compare(IntrinsicType.PANSICHAR, IntrinsicType.UNICODESTRING, CONVERT_LEVEL_4);
-    compare(IntrinsicType.PCHAR, IntrinsicType.ANSISTRING, CONVERT_LEVEL_4);
+    compare(IntrinsicType.PANSICHAR, IntrinsicType.WIDESTRING, CONVERT_LEVEL_5);
+    compare(IntrinsicType.PANSICHAR, IntrinsicType.SHORTSTRING, CONVERT_LEVEL_6);
+
+    compare(IntrinsicType.PCHAR, IntrinsicType.UNICODESTRING, CONVERT_LEVEL_3);
+    compare(IntrinsicType.PCHAR, IntrinsicType.WIDESTRING, CONVERT_LEVEL_4);
+    compare(IntrinsicType.PCHAR, IntrinsicType.ANSISTRING, CONVERT_LEVEL_7);
+    compare(IntrinsicType.PCHAR, IntrinsicType.SHORTSTRING, INCOMPATIBLE_TYPES);
+
     compare(pointerTo(IntrinsicType.INTEGER), IntrinsicType.UNICODESTRING, INCOMPATIBLE_TYPES);
   }
 

--- a/delphi-frontend/src/test/java/au/com/integradev/delphi/type/intrinsic/IntrinsicArgumentMatcherTest.java
+++ b/delphi-frontend/src/test/java/au/com/integradev/delphi/type/intrinsic/IntrinsicArgumentMatcherTest.java
@@ -23,6 +23,7 @@ import static au.com.integradev.delphi.type.intrinsic.IntrinsicArgumentMatcher.A
 import static au.com.integradev.delphi.type.intrinsic.IntrinsicArgumentMatcher.ANY_OBJECT;
 import static au.com.integradev.delphi.type.intrinsic.IntrinsicArgumentMatcher.ANY_ORDINAL;
 import static au.com.integradev.delphi.type.intrinsic.IntrinsicArgumentMatcher.ANY_SET;
+import static au.com.integradev.delphi.type.intrinsic.IntrinsicArgumentMatcher.ANY_TEXT_FILE;
 import static au.com.integradev.delphi.type.intrinsic.IntrinsicArgumentMatcher.ANY_TYPED_POINTER;
 import static au.com.integradev.delphi.type.intrinsic.IntrinsicArgumentMatcher.LIKE_DYNAMIC_ARRAY;
 import static au.com.integradev.delphi.type.intrinsic.IntrinsicArgumentMatcher.POINTER_MATH_OPERAND;
@@ -106,6 +107,15 @@ class IntrinsicArgumentMatcherTest {
     assertThat(matches(ANY_ORDINAL, FACTORY.enumeration("TFoo", null))).isTrue();
     assertThat(matches(ANY_ORDINAL, FACTORY.getIntrinsic(IntrinsicType.CHAR))).isTrue();
     assertThat(matches(ANY_ORDINAL, FACTORY.getIntrinsic(IntrinsicType.STRING))).isFalse();
+  }
+
+  @Test
+  void testAnyTextFile() {
+    assertThat(matches(ANY_TEXT_FILE, FACTORY.untypedFile())).isFalse();
+    assertThat(matches(ANY_TEXT_FILE, FACTORY.getIntrinsic(IntrinsicType.TEXT))).isTrue();
+    assertThat(matches(ANY_TEXT_FILE, FACTORY.fileOf(FACTORY.getIntrinsic(IntrinsicType.INTEGER))))
+        .isFalse();
+    assertThat(matches(ANY_TEXT_FILE, FACTORY.getIntrinsic(IntrinsicType.INTEGER))).isFalse();
   }
 
   @Test

--- a/delphi-frontend/src/test/java/au/com/integradev/delphi/type/intrinsic/IntrinsicArgumentMatcherTest.java
+++ b/delphi-frontend/src/test/java/au/com/integradev/delphi/type/intrinsic/IntrinsicArgumentMatcherTest.java
@@ -23,6 +23,7 @@ import static au.com.integradev.delphi.type.intrinsic.IntrinsicArgumentMatcher.A
 import static au.com.integradev.delphi.type.intrinsic.IntrinsicArgumentMatcher.ANY_OBJECT;
 import static au.com.integradev.delphi.type.intrinsic.IntrinsicArgumentMatcher.ANY_ORDINAL;
 import static au.com.integradev.delphi.type.intrinsic.IntrinsicArgumentMatcher.ANY_SET;
+import static au.com.integradev.delphi.type.intrinsic.IntrinsicArgumentMatcher.ANY_STRING;
 import static au.com.integradev.delphi.type.intrinsic.IntrinsicArgumentMatcher.ANY_TEXT_FILE;
 import static au.com.integradev.delphi.type.intrinsic.IntrinsicArgumentMatcher.ANY_TYPED_POINTER;
 import static au.com.integradev.delphi.type.intrinsic.IntrinsicArgumentMatcher.LIKE_DYNAMIC_ARRAY;
@@ -81,6 +82,18 @@ class IntrinsicArgumentMatcherTest {
                 FACTORY.array("TBar", TypeFactory.untypedType(), Set.of(ArrayOption.FIXED))))
         .isFalse();
     assertThat(matches(ANY_DYNAMIC_ARRAY, FACTORY.set(TypeFactory.untypedType()))).isFalse();
+  }
+
+  @Test
+  void testAnyString() {
+    assertThat(matches(ANY_STRING, FACTORY.getIntrinsic(IntrinsicType.ANSICHAR))).isTrue();
+    assertThat(matches(ANY_STRING, FACTORY.getIntrinsic(IntrinsicType.WIDECHAR))).isTrue();
+    assertThat(matches(ANY_STRING, FACTORY.getIntrinsic(IntrinsicType.SHORTSTRING))).isTrue();
+    assertThat(matches(ANY_STRING, FACTORY.getIntrinsic(IntrinsicType.ANSISTRING))).isTrue();
+    assertThat(matches(ANY_STRING, FACTORY.getIntrinsic(IntrinsicType.UNICODESTRING))).isTrue();
+    assertThat(matches(ANY_STRING, FACTORY.getIntrinsic(IntrinsicType.PANSICHAR))).isFalse();
+    assertThat(matches(ANY_STRING, FACTORY.getIntrinsic(IntrinsicType.PCHAR))).isFalse();
+    assertThat(matches(ANY_STRING, FACTORY.getIntrinsic(IntrinsicType.INTEGER))).isFalse();
   }
 
   @Test

--- a/delphi-frontend/src/test/java/au/com/integradev/delphi/type/intrinsic/IntrinsicArgumentMatcherTest.java
+++ b/delphi-frontend/src/test/java/au/com/integradev/delphi/type/intrinsic/IntrinsicArgumentMatcherTest.java
@@ -19,8 +19,8 @@
 package au.com.integradev.delphi.type.intrinsic;
 
 import static au.com.integradev.delphi.type.intrinsic.IntrinsicArgumentMatcher.ANY_32_BIT_INTEGER;
+import static au.com.integradev.delphi.type.intrinsic.IntrinsicArgumentMatcher.ANY_ARRAY;
 import static au.com.integradev.delphi.type.intrinsic.IntrinsicArgumentMatcher.ANY_CLASS_REFERENCE;
-import static au.com.integradev.delphi.type.intrinsic.IntrinsicArgumentMatcher.ANY_DYNAMIC_ARRAY;
 import static au.com.integradev.delphi.type.intrinsic.IntrinsicArgumentMatcher.ANY_FILE;
 import static au.com.integradev.delphi.type.intrinsic.IntrinsicArgumentMatcher.ANY_OBJECT;
 import static au.com.integradev.delphi.type.intrinsic.IntrinsicArgumentMatcher.ANY_ORDINAL;
@@ -74,21 +74,6 @@ class IntrinsicArgumentMatcherTest {
   }
 
   @Test
-  void testAnyDynamicArray() {
-    assertThat(
-            matches(
-                ANY_DYNAMIC_ARRAY,
-                FACTORY.array("TFoo", TypeFactory.untypedType(), Set.of(ArrayOption.DYNAMIC))))
-        .isTrue();
-    assertThat(
-            matches(
-                ANY_DYNAMIC_ARRAY,
-                FACTORY.array("TBar", TypeFactory.untypedType(), Set.of(ArrayOption.FIXED))))
-        .isFalse();
-    assertThat(matches(ANY_DYNAMIC_ARRAY, FACTORY.set(TypeFactory.untypedType()))).isFalse();
-  }
-
-  @Test
   void testAnyString() {
     assertThat(matches(ANY_STRING, FACTORY.getIntrinsic(IntrinsicType.ANSICHAR))).isTrue();
     assertThat(matches(ANY_STRING, FACTORY.getIntrinsic(IntrinsicType.WIDECHAR))).isTrue();
@@ -119,14 +104,31 @@ class IntrinsicArgumentMatcherTest {
   }
 
   @Test
+  void testAnyArray() {
+    Type elementType = FACTORY.getIntrinsic(IntrinsicType.INTEGER);
+
+    Type fixedArray = FACTORY.array(null, elementType, Set.of(ArrayOption.FIXED));
+    Type dynamicArray = FACTORY.array(null, elementType, Set.of(ArrayOption.DYNAMIC));
+    Type openArray = FACTORY.array(null, elementType, Set.of(ArrayOption.OPEN));
+    Type arrayOfConst =
+        FACTORY.array(null, elementType, Set.of(ArrayOption.OPEN, ArrayOption.ARRAY_OF_CONST));
+
+    assertThat(matches(ANY_ARRAY, fixedArray)).isTrue();
+    assertThat(matches(ANY_ARRAY, dynamicArray)).isTrue();
+    assertThat(matches(ANY_ARRAY, openArray)).isTrue();
+    assertThat(matches(ANY_ARRAY, arrayOfConst)).isTrue();
+    assertThat(matches(ANY_ARRAY, FACTORY.emptySet())).isFalse();
+    assertThat(matches(ANY_ARRAY, FACTORY.getIntrinsic(IntrinsicType.INTEGER))).isFalse();
+    assertThat(matches(ANY_ARRAY, FACTORY.getIntrinsic(IntrinsicType.ANSISTRING))).isFalse();
+  }
+
+  @Test
   void testAnySet() {
+    Type dynamicArray = FACTORY.array(null, TypeFactory.untypedType(), Set.of(ArrayOption.DYNAMIC));
+
     assertThat(matches(ANY_SET, FACTORY.emptySet())).isTrue();
     assertThat(matches(ANY_SET, FACTORY.arrayConstructor(Collections.emptyList()))).isTrue();
-    assertThat(
-            matches(
-                ANY_SET,
-                FACTORY.array("TFoo", TypeFactory.untypedType(), Set.of(ArrayOption.DYNAMIC))))
-        .isFalse();
+    assertThat(matches(ANY_SET, dynamicArray)).isFalse();
   }
 
   @Test

--- a/delphi-frontend/src/test/java/au/com/integradev/delphi/type/intrinsic/IntrinsicArgumentMatcherTest.java
+++ b/delphi-frontend/src/test/java/au/com/integradev/delphi/type/intrinsic/IntrinsicArgumentMatcherTest.java
@@ -24,6 +24,7 @@ import static au.com.integradev.delphi.type.intrinsic.IntrinsicArgumentMatcher.A
 import static au.com.integradev.delphi.type.intrinsic.IntrinsicArgumentMatcher.ANY_FILE;
 import static au.com.integradev.delphi.type.intrinsic.IntrinsicArgumentMatcher.ANY_OBJECT;
 import static au.com.integradev.delphi.type.intrinsic.IntrinsicArgumentMatcher.ANY_ORDINAL;
+import static au.com.integradev.delphi.type.intrinsic.IntrinsicArgumentMatcher.ANY_POINTER;
 import static au.com.integradev.delphi.type.intrinsic.IntrinsicArgumentMatcher.ANY_SET;
 import static au.com.integradev.delphi.type.intrinsic.IntrinsicArgumentMatcher.ANY_STRING;
 import static au.com.integradev.delphi.type.intrinsic.IntrinsicArgumentMatcher.ANY_TEXT_FILE;
@@ -157,6 +158,15 @@ class IntrinsicArgumentMatcherTest {
     assertThat(matches(ANY_32_BIT_INTEGER, subrange32)).isTrue();
     assertThat(matches(ANY_32_BIT_INTEGER, subrange16)).isFalse();
     assertThat(matches(ANY_32_BIT_INTEGER, FACTORY.getIntrinsic(IntrinsicType.STRING))).isFalse();
+  }
+
+  @Test
+  void testAnyPointer() {
+    Type typedPointer = FACTORY.pointerTo("PInteger", FACTORY.getIntrinsic(IntrinsicType.INTEGER));
+    assertThat(matches(ANY_POINTER, typedPointer)).isTrue();
+    assertThat(matches(ANY_POINTER, FACTORY.untypedPointer())).isTrue();
+    assertThat(matches(ANY_POINTER, FACTORY.nilPointer())).isTrue();
+    assertThat(matches(ANY_POINTER, FACTORY.getIntrinsic(IntrinsicType.INTEGER))).isFalse();
   }
 
   @Test

--- a/delphi-frontend/src/test/java/au/com/integradev/delphi/type/intrinsic/IntrinsicArgumentMatcherTest.java
+++ b/delphi-frontend/src/test/java/au/com/integradev/delphi/type/intrinsic/IntrinsicArgumentMatcherTest.java
@@ -29,6 +29,7 @@ import static au.com.integradev.delphi.type.intrinsic.IntrinsicArgumentMatcher.A
 import static au.com.integradev.delphi.type.intrinsic.IntrinsicArgumentMatcher.ANY_STRING;
 import static au.com.integradev.delphi.type.intrinsic.IntrinsicArgumentMatcher.ANY_TEXT_FILE;
 import static au.com.integradev.delphi.type.intrinsic.IntrinsicArgumentMatcher.ANY_TYPED_POINTER;
+import static au.com.integradev.delphi.type.intrinsic.IntrinsicArgumentMatcher.ANY_VARIANT;
 import static au.com.integradev.delphi.type.intrinsic.IntrinsicArgumentMatcher.LIKE_DYNAMIC_ARRAY;
 import static au.com.integradev.delphi.type.intrinsic.IntrinsicArgumentMatcher.POINTER_MATH_OPERAND;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -102,6 +103,14 @@ class IntrinsicArgumentMatcherTest {
     assertThat(matches(ANY_TEXT_FILE, FACTORY.fileOf(FACTORY.getIntrinsic(IntrinsicType.INTEGER))))
         .isFalse();
     assertThat(matches(ANY_TEXT_FILE, FACTORY.getIntrinsic(IntrinsicType.INTEGER))).isFalse();
+  }
+
+  @Test
+  void testAnyVariant() {
+    assertThat(matches(ANY_VARIANT, FACTORY.getIntrinsic(IntrinsicType.VARIANT))).isTrue();
+    assertThat(matches(ANY_VARIANT, FACTORY.getIntrinsic(IntrinsicType.OLEVARIANT))).isTrue();
+    assertThat(matches(ANY_VARIANT, FACTORY.getIntrinsic(IntrinsicType.ANSISTRING))).isFalse();
+    assertThat(matches(ANY_VARIANT, FACTORY.getIntrinsic(IntrinsicType.INTEGER))).isFalse();
   }
 
   @Test

--- a/delphi-frontend/src/test/java/au/com/integradev/delphi/type/intrinsic/IntrinsicArgumentMatcherTest.java
+++ b/delphi-frontend/src/test/java/au/com/integradev/delphi/type/intrinsic/IntrinsicArgumentMatcherTest.java
@@ -20,6 +20,7 @@ package au.com.integradev.delphi.type.intrinsic;
 
 import static au.com.integradev.delphi.type.intrinsic.IntrinsicArgumentMatcher.ANY_CLASS_REFERENCE;
 import static au.com.integradev.delphi.type.intrinsic.IntrinsicArgumentMatcher.ANY_DYNAMIC_ARRAY;
+import static au.com.integradev.delphi.type.intrinsic.IntrinsicArgumentMatcher.ANY_FILE;
 import static au.com.integradev.delphi.type.intrinsic.IntrinsicArgumentMatcher.ANY_OBJECT;
 import static au.com.integradev.delphi.type.intrinsic.IntrinsicArgumentMatcher.ANY_ORDINAL;
 import static au.com.integradev.delphi.type.intrinsic.IntrinsicArgumentMatcher.ANY_SET;
@@ -97,6 +98,24 @@ class IntrinsicArgumentMatcherTest {
   }
 
   @Test
+  void testAnyFile() {
+    assertThat(matches(ANY_FILE, FACTORY.untypedFile())).isTrue();
+    assertThat(matches(ANY_FILE, FACTORY.getIntrinsic(IntrinsicType.TEXT))).isTrue();
+    assertThat(matches(ANY_FILE, FACTORY.fileOf(FACTORY.getIntrinsic(IntrinsicType.INTEGER))))
+        .isTrue();
+    assertThat(matches(ANY_FILE, FACTORY.getIntrinsic(IntrinsicType.INTEGER))).isFalse();
+  }
+
+  @Test
+  void testAnyTextFile() {
+    assertThat(matches(ANY_TEXT_FILE, FACTORY.untypedFile())).isFalse();
+    assertThat(matches(ANY_TEXT_FILE, FACTORY.getIntrinsic(IntrinsicType.TEXT))).isTrue();
+    assertThat(matches(ANY_TEXT_FILE, FACTORY.fileOf(FACTORY.getIntrinsic(IntrinsicType.INTEGER))))
+        .isFalse();
+    assertThat(matches(ANY_TEXT_FILE, FACTORY.getIntrinsic(IntrinsicType.INTEGER))).isFalse();
+  }
+
+  @Test
   void testAnySet() {
     assertThat(matches(ANY_SET, FACTORY.emptySet())).isTrue();
     assertThat(matches(ANY_SET, FACTORY.arrayConstructor(Collections.emptyList()))).isTrue();
@@ -120,15 +139,6 @@ class IntrinsicArgumentMatcherTest {
     assertThat(matches(ANY_ORDINAL, FACTORY.enumeration("TFoo", null))).isTrue();
     assertThat(matches(ANY_ORDINAL, FACTORY.getIntrinsic(IntrinsicType.CHAR))).isTrue();
     assertThat(matches(ANY_ORDINAL, FACTORY.getIntrinsic(IntrinsicType.STRING))).isFalse();
-  }
-
-  @Test
-  void testAnyTextFile() {
-    assertThat(matches(ANY_TEXT_FILE, FACTORY.untypedFile())).isFalse();
-    assertThat(matches(ANY_TEXT_FILE, FACTORY.getIntrinsic(IntrinsicType.TEXT))).isTrue();
-    assertThat(matches(ANY_TEXT_FILE, FACTORY.fileOf(FACTORY.getIntrinsic(IntrinsicType.INTEGER))))
-        .isFalse();
-    assertThat(matches(ANY_TEXT_FILE, FACTORY.getIntrinsic(IntrinsicType.INTEGER))).isFalse();
   }
 
   @Test

--- a/delphi-frontend/src/test/java/au/com/integradev/delphi/type/intrinsic/IntrinsicArgumentMatcherTest.java
+++ b/delphi-frontend/src/test/java/au/com/integradev/delphi/type/intrinsic/IntrinsicArgumentMatcherTest.java
@@ -24,6 +24,7 @@ import static au.com.integradev.delphi.type.intrinsic.IntrinsicArgumentMatcher.A
 import static au.com.integradev.delphi.type.intrinsic.IntrinsicArgumentMatcher.ANY_ORDINAL;
 import static au.com.integradev.delphi.type.intrinsic.IntrinsicArgumentMatcher.ANY_SET;
 import static au.com.integradev.delphi.type.intrinsic.IntrinsicArgumentMatcher.ANY_TYPED_POINTER;
+import static au.com.integradev.delphi.type.intrinsic.IntrinsicArgumentMatcher.LIKE_DYNAMIC_ARRAY;
 import static au.com.integradev.delphi.type.intrinsic.IntrinsicArgumentMatcher.POINTER_MATH_OPERAND;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -32,6 +33,7 @@ import au.com.integradev.delphi.type.factory.TypeFactoryImpl;
 import au.com.integradev.delphi.utils.types.TypeFactoryUtils;
 import au.com.integradev.delphi.utils.types.TypeMocker;
 import java.util.Collections;
+import java.util.List;
 import java.util.Set;
 import org.junit.jupiter.api.Test;
 import org.sonar.plugins.communitydelphi.api.type.IntrinsicType;
@@ -42,6 +44,28 @@ import org.sonar.plugins.communitydelphi.api.type.TypeFactory;
 class IntrinsicArgumentMatcherTest {
   private static final TypeFactoryImpl FACTORY =
       (TypeFactoryImpl) TypeFactoryUtils.defaultFactory();
+
+  @Test
+  void testLikeDynamicArray() {
+    Type dynamicArray =
+        FACTORY.array("TFoo", TypeFactory.untypedType(), Set.of(ArrayOption.DYNAMIC));
+    Type fixedArray = FACTORY.array("TBar", TypeFactory.untypedType(), Set.of(ArrayOption.FIXED));
+    Type arrayConstructor =
+        FACTORY.arrayConstructor(List.of(FACTORY.getIntrinsic(IntrinsicType.INTEGER)));
+
+    assertThat(matches(LIKE_DYNAMIC_ARRAY, dynamicArray)).isTrue();
+    assertThat(matches(LIKE_DYNAMIC_ARRAY, arrayConstructor)).isTrue();
+    assertThat(matches(LIKE_DYNAMIC_ARRAY, FACTORY.getIntrinsic(IntrinsicType.ANSICHAR))).isTrue();
+    assertThat(matches(LIKE_DYNAMIC_ARRAY, FACTORY.getIntrinsic(IntrinsicType.WIDECHAR))).isTrue();
+    assertThat(matches(LIKE_DYNAMIC_ARRAY, FACTORY.getIntrinsic(IntrinsicType.SHORTSTRING)))
+        .isTrue();
+    assertThat(matches(LIKE_DYNAMIC_ARRAY, FACTORY.getIntrinsic(IntrinsicType.ANSISTRING)))
+        .isTrue();
+    assertThat(matches(LIKE_DYNAMIC_ARRAY, FACTORY.getIntrinsic(IntrinsicType.UNICODESTRING)))
+        .isTrue();
+    assertThat(matches(LIKE_DYNAMIC_ARRAY, fixedArray)).isFalse();
+    assertThat(matches(LIKE_DYNAMIC_ARRAY, FACTORY.emptySet())).isFalse();
+  }
 
   @Test
   void testAnyDynamicArray() {

--- a/delphi-frontend/src/test/java/au/com/integradev/delphi/type/intrinsic/IntrinsicArgumentMatcherTest.java
+++ b/delphi-frontend/src/test/java/au/com/integradev/delphi/type/intrinsic/IntrinsicArgumentMatcherTest.java
@@ -18,6 +18,7 @@
  */
 package au.com.integradev.delphi.type.intrinsic;
 
+import static au.com.integradev.delphi.type.intrinsic.IntrinsicArgumentMatcher.ANY_32_BIT_INTEGER;
 import static au.com.integradev.delphi.type.intrinsic.IntrinsicArgumentMatcher.ANY_CLASS_REFERENCE;
 import static au.com.integradev.delphi.type.intrinsic.IntrinsicArgumentMatcher.ANY_DYNAMIC_ARRAY;
 import static au.com.integradev.delphi.type.intrinsic.IntrinsicArgumentMatcher.ANY_FILE;
@@ -35,6 +36,7 @@ import au.com.integradev.delphi.type.factory.ArrayOption;
 import au.com.integradev.delphi.type.factory.TypeFactoryImpl;
 import au.com.integradev.delphi.utils.types.TypeFactoryUtils;
 import au.com.integradev.delphi.utils.types.TypeMocker;
+import java.math.BigInteger;
 import java.util.Collections;
 import java.util.List;
 import java.util.Set;
@@ -42,6 +44,7 @@ import org.junit.jupiter.api.Test;
 import org.sonar.plugins.communitydelphi.api.type.IntrinsicType;
 import org.sonar.plugins.communitydelphi.api.type.StructKind;
 import org.sonar.plugins.communitydelphi.api.type.Type;
+import org.sonar.plugins.communitydelphi.api.type.Type.IntegerType;
 import org.sonar.plugins.communitydelphi.api.type.TypeFactory;
 
 class IntrinsicArgumentMatcherTest {
@@ -139,6 +142,19 @@ class IntrinsicArgumentMatcherTest {
     assertThat(matches(ANY_ORDINAL, FACTORY.enumeration("TFoo", null))).isTrue();
     assertThat(matches(ANY_ORDINAL, FACTORY.getIntrinsic(IntrinsicType.CHAR))).isTrue();
     assertThat(matches(ANY_ORDINAL, FACTORY.getIntrinsic(IntrinsicType.STRING))).isFalse();
+  }
+
+  @Test
+  void testAny32BitInteger() {
+    IntegerType u16 = ((IntegerType) FACTORY.getIntrinsic(IntrinsicType.WORD));
+    Type subrange16 = FACTORY.subrange("TFoo", BigInteger.ZERO, u16.max());
+    Type subrange32 = FACTORY.subrange("TFoo", BigInteger.ZERO, u16.max().add(BigInteger.ONE));
+
+    assertThat(matches(ANY_32_BIT_INTEGER, FACTORY.getIntrinsic(IntrinsicType.INTEGER))).isTrue();
+    assertThat(matches(ANY_32_BIT_INTEGER, FACTORY.getIntrinsic(IntrinsicType.CARDINAL))).isTrue();
+    assertThat(matches(ANY_32_BIT_INTEGER, subrange32)).isTrue();
+    assertThat(matches(ANY_32_BIT_INTEGER, subrange16)).isFalse();
+    assertThat(matches(ANY_32_BIT_INTEGER, FACTORY.getIntrinsic(IntrinsicType.STRING))).isFalse();
   }
 
   @Test


### PR DESCRIPTION
This PR:
- Improves type comparisons between text types
  - `AnsiString` -> `UnicodeString` conversions are preferred over
    `UnicodeString` -> `AnsiString` conversions.
  - `UnicodeString` -> `Variant` conversions are preferred over
    `UnicodeString` -> `AnsiString` conversions.
  - `AnsiString` -> `UnicodeString` conversions are preferred over
    `AnsiString` -> `Variant` conversions.
  - ⭐ discovered while fixing the `Concat` intrinsic, which was originally going to have `(AnsiString, AnsiString)` and `(UnicodeString, UnicodeString)` overloads to disambiguate
- Improves type conversions from character pointers to strings
  - `PAnsiChar` -> `AnsiString` conversions are preferred over `PAnsiChar` -> `ShortString`.
  - ⭐ important for the `Length` intrinsic, which has `AnsiString` and `ShortString` overloads
- Fixes various intrinsic signatures
  - incorrect return types (`Concat`, `Copy`,  `Slice`, `Succ`)
  - incorrect parameter types (`Assert`, `Assign`, `AssignFile`, `Sqr`)
  - missing overloads (`Copy`, `Length`)
  - overly-strict `var` parameter typings (`var` parameters are expected to have an exact type-match with the argument)