### PR TITLE
Fix type resolution errors on expressions with procedural operands

### DIFF
--- a/delphi-frontend/src/main/java/au/com/integradev/delphi/operator/OperatorInvocableCollector.java
+++ b/delphi-frontend/src/main/java/au/com/integradev/delphi/operator/OperatorInvocableCollector.java
@@ -43,6 +43,7 @@ import org.sonar.plugins.communitydelphi.api.type.Type.ArrayConstructorType;
 import org.sonar.plugins.communitydelphi.api.type.Type.CollectionType;
 import org.sonar.plugins.communitydelphi.api.type.Type.IntegerType;
 import org.sonar.plugins.communitydelphi.api.type.Type.PointerType;
+import org.sonar.plugins.communitydelphi.api.type.Type.ProceduralType;
 import org.sonar.plugins.communitydelphi.api.type.Type.StructType;
 import org.sonar.plugins.communitydelphi.api.type.TypeFactory;
 
@@ -55,6 +56,8 @@ public class OperatorInvocableCollector {
   }
 
   public Set<Invocable> collect(BinaryOperator operator, Type left, Type right) {
+    left = invokeProcedural(left);
+    right = invokeProcedural(right);
     operands = List.of(left, right);
 
     Set<Invocable> result = collectBinary(left, operator);
@@ -64,9 +67,17 @@ public class OperatorInvocableCollector {
   }
 
   public Set<Invocable> collect(UnaryOperator operator, Type operand) {
+    operand = invokeProcedural(operand);
     operands = List.of(operand);
 
     return collectUnary(operand, operator);
+  }
+
+  private static Type invokeProcedural(Type type) {
+    if (type instanceof ProceduralType) {
+      return ((ProceduralType) type).returnType();
+    }
+    return type;
   }
 
   private Set<Invocable> collectBinary(Type type, BinaryOperator operator) {

--- a/delphi-frontend/src/test/java/au/com/integradev/delphi/executor/DelphiSymbolTableExecutorTest.java
+++ b/delphi-frontend/src/test/java/au/com/integradev/delphi/executor/DelphiSymbolTableExecutorTest.java
@@ -559,7 +559,8 @@ class DelphiSymbolTableExecutorTest {
         reference(78, 2),
         reference(79, 2),
         reference(80, 2),
-        reference(81, 2));
+        reference(81, 2),
+        reference(133, 2));
     verifyUsages(
         20,
         10,
@@ -600,7 +601,10 @@ class DelphiSymbolTableExecutorTest {
         reference(105, 2),
         reference(106, 2),
         reference(107, 2),
-        reference(108, 2));
+        reference(108, 2),
+        reference(134, 2),
+        reference(135, 2),
+        reference(136, 2));
     verifyUsages(30, 10, reference(111, 2), reference(112, 2));
     verifyUsages(35, 10, reference(116, 2), reference(117, 2), reference(118, 2));
   }

--- a/delphi-frontend/src/test/resources/au/com/integradev/delphi/symbol/operators/BinaryOperatorIntrinsics.pas
+++ b/delphi-frontend/src/test/resources/au/com/integradev/delphi/symbol/operators/BinaryOperatorIntrinsics.pas
@@ -118,4 +118,22 @@ begin
   ExpectSet([1, 2, 3, 4, 5] * [3, 4, 5]);
 end;
 
+function GetInteger: Integer;
+begin
+  Result := 1;
+end;
+
+function GetExtended: Extended;
+begin
+  Result := 1.0;
+end;
+
+procedure TestFunctionOperands;
+begin
+  ExpectNumber(GetInteger + 2);
+  ExpectNumber(GetExtended + 2);
+  ExpectNumber(GetInteger + 2.0);
+  ExpectNumber(GetExtended + 2.0);
+end;
+
 end.


### PR DESCRIPTION
Intrinsic operator overloads were not being collected for the return types of procedural operands.
This was broken by commit c151981.