### PR TITLE
Update `sonar.delphi.version` property in `prepare-release`

### DIFF
--- a/prepare-release.sh
+++ b/prepare-release.sh
@@ -28,6 +28,9 @@ if [ $(git tag -l "$TAG") ]; then
 fi
 
 mvn versions:set -DnewVersion=$1 -DgenerateBackupPoms=false --non-recursive
+mvn versions:set-property \
+  -Dproperty=sonar.delphi.version -DnewVersion=$1 -DgenerateBackupPoms=false \
+  -f docs/delphi-custom-rules-example/
 mvn keepachangelog:release --non-recursive
 
 git add .


### PR DESCRIPTION
This PR fixes a minor issue in the release process.
The `sonar.delphi.version` property in `delphi-custom-rules-example` wasn't being updated in `prepare-release`.