### PR TITLE
Migrate from `json-simple` to `gson`

### DIFF
--- a/delphi-checks/pom.xml
+++ b/delphi-checks/pom.xml
@@ -60,8 +60,8 @@
     </dependency>
 
     <dependency>
-      <groupId>com.googlecode.json-simple</groupId>
-      <artifactId>json-simple</artifactId>
+      <groupId>com.google.code.gson</groupId>
+      <artifactId>gson</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/delphi-frontend/pom.xml
+++ b/delphi-frontend/pom.xml
@@ -62,8 +62,8 @@
       <artifactId>jdom2</artifactId>
     </dependency>
     <dependency>
-      <groupId>com.googlecode.json-simple</groupId>
-      <artifactId>json-simple</artifactId>
+      <groupId>com.google.code.gson</groupId>
+      <artifactId>gson</artifactId>
     </dependency>
     <dependency>
       <groupId>net.bytebuddy</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -119,7 +119,7 @@
     <antlr-runtime.version>3.5.3</antlr-runtime.version>
     <commons-text.version>1.10.0</commons-text.version>
     <jdom.version>2.0.6.1</jdom.version>
-    <json-simple.version>1.1.1</json-simple.version>
+    <gson.version>2.10.1</gson.version>
     <jsr305.version>3.0.2</jsr305.version>
     <guava.version>32.1.3-jre</guava.version>
     <commons-lang.version>3.12.0</commons-lang.version>
@@ -205,9 +205,9 @@
         <version>${jdom.version}</version>
       </dependency>
       <dependency>
-        <groupId>com.googlecode.json-simple</groupId>
-        <artifactId>json-simple</artifactId>
-        <version>${json-simple.version}</version>
+        <groupId>com.google.code.gson</groupId>
+        <artifactId>gson</artifactId>
+        <version>${gson.version}</version>
       </dependency>
       <dependency>
         <groupId>net.bytebuddy</groupId>


### PR DESCRIPTION
`json-simple` is unmaintained and has an annoying API that encourages unsafe casts.
It also pulls in a vulnerable version of junit 4 as a compile dependency, generating meaningless noise from Sonatype Lift.

(**note:** there is no actual vulnerability, junit wasn't even supposed to be a compile dependency in `json-simple`)