### PR TITLE
Upgrade maven plugins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - The `Copy` intrinsic inferred an incorrect return type for `PChar`, `PAnsiChar`, and variants.
 - The `Concat` intrinsic inferred an incorrect return type for single-character string literals.
+- Ideographic space (U+3000) was erroneously accepted as a valid identifier character.
 
 ## [1.1.0] - 2024-01-02
 

--- a/delphi-frontend/src/main/antlr3/au/com/integradev/delphi/antlr/Delphi.g
+++ b/delphi-frontend/src/main/antlr3/au/com/integradev/delphi/antlr/Delphi.g
@@ -1239,8 +1239,9 @@ TkCharacterEscapeCode   : '#' ('_' | Digit)+
 fragment
 Alpha                   : 'a'..'z'
                         | 'A'..'Z'
-                        // every non-ASCII character until the surrogate pair range (\u3000 is excluded as WHITESPACE)
-                        | '\u0080'..'\uD7FF'
+                        // every non-ASCII character until the surrogate pair range (except \u3000 which is whitespace)
+                        | '\u0080'..'\u2FFF'
+                        | '\u3001'..'\uD7FF'
                         // everything after the surrogate range up to the start of the fullwidth numerals
                         | '\uE000'..'\uFF0F'
                         // after the fullwidth numerals up to the second last codepoint in the BMP

--- a/delphi-frontend/src/test/java/au/com/integradev/delphi/antlr/GrammarTest.java
+++ b/delphi-frontend/src/test/java/au/com/integradev/delphi/antlr/GrammarTest.java
@@ -256,7 +256,8 @@ class GrammarTest {
   @Test
   void testFullWidthNumeralAtStartOfIdentifierShouldThrow() {
     assertThatThrownBy(() -> parse("FullWidthNumeralBeforeIdentifier.pas"))
-        .isInstanceOf(RuntimeException.class)
-        .hasMessage("line 6:2 mismatched input '０' expecting IMPLEMENTATION");
+        .isInstanceOf(DelphiFileConstructionException.class)
+        .hasCauseInstanceOf(DelphiParser.ParserException.class)
+        .hasMessageContaining("line 6:2 mismatched input '０' expecting IMPLEMENTATION");
   }
 }

--- a/docs/delphi-custom-rules-example/pom.xml
+++ b/docs/delphi-custom-rules-example/pom.xml
@@ -55,12 +55,12 @@
     <junit.version>5.9.0</junit.version>
     <assertj.version>3.23.1</assertj.version>
     <mockito.version>5.4.0</mockito.version>
-    <compiler.plugin.version>3.11.0</compiler.plugin.version>
-    <jacoco.plugin.version>0.8.8</jacoco.plugin.version>
-    <fmt.plugin.version>2.19</fmt.plugin.version>
-    <license.plugin.version>4.2</license.plugin.version>
+    <compiler.plugin.version>3.12.1</compiler.plugin.version>
+    <jacoco.plugin.version>0.8.11</jacoco.plugin.version>
+    <fmt.plugin.version>2.21.1</fmt.plugin.version>
+    <license.plugin.version>4.3</license.plugin.version>
     <sonar.packaging.plugin.version>1.23.0.740</sonar.packaging.plugin.version>
-    <shade.plugin.version>3.2.1</shade.plugin.version>
+    <shade.plugin.version>3.5.1</shade.plugin.version>
   </properties>
 
   <dependencies>

--- a/docs/delphi-custom-rules-example/pom.xml
+++ b/docs/delphi-custom-rules-example/pom.xml
@@ -146,16 +146,22 @@
         <configuration>
           <createDependencyReducedPom>false</createDependencyReducedPom>
           <shadedArtifactAttached>false</shadedArtifactAttached>
-          <createDependencyReducedPom>false</createDependencyReducedPom>
           <minimizeJar>true</minimizeJar>
           <filters>
             <filter>
-              <artifact>com.google.code.findbugs:jsr305</artifact>
+              <artifact>org.sonarsource.analyzer-commons:*</artifact>
               <excludes>
                 <exclude>**/javax/annotation/**</exclude>
+                <exclude>META-INF/**</exclude>
               </excludes>
             </filter>
           </filters>
+          <transformers>
+            <transformer implementation="org.apache.maven.plugins.shade.resource.DontIncludeResourceTransformer">
+              <resource>MANIFEST.MF</resource>
+            </transformer>
+            <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer" />
+        </transformers>
         </configuration>
         <executions>
           <execution>

--- a/pom.xml
+++ b/pom.xml
@@ -133,21 +133,21 @@
     <errorprone.version>2.20.0</errorprone.version>
     <slf4j.version>1.7.30</slf4j.version>
     <!-- Plugin versions -->
-    <compiler-plugin.version>3.11.0</compiler-plugin.version>
-    <jacoco-plugin.version>0.8.8</jacoco-plugin.version>
-    <surefire-plugin.version>3.0.0-M6</surefire-plugin.version>
-    <enforcer-plugin.version>3.1.0</enforcer-plugin.version>
+    <compiler-plugin.version>3.12.1</compiler-plugin.version>
+    <jacoco-plugin.version>0.8.11</jacoco-plugin.version>
+    <surefire-plugin.version>3.2.3</surefire-plugin.version>
+    <enforcer-plugin.version>3.4.1</enforcer-plugin.version>
     <sonar-packaging-plugin.version>1.23.0.740</sonar-packaging-plugin.version>
-    <spotless-plugin.version>2.40.0</spotless-plugin.version>
+    <spotless-plugin.version>2.41.1</spotless-plugin.version>
     <antlr3-plugin.version>3.5.3</antlr3-plugin.version>
-    <build-helper-plugin.version>3.3.0</build-helper-plugin.version>
+    <build-helper-plugin.version>3.5.0</build-helper-plugin.version>
     <replacer-plugin.version>1.5.3</replacer-plugin.version>
-    <shade-plugin.version>3.2.1</shade-plugin.version>
-    <versions-plugin.version>2.14.2</versions-plugin.version>
+    <shade-plugin.version>3.5.1</shade-plugin.version>
+    <versions-plugin.version>2.16.2</versions-plugin.version>
     <keepachangelog-plugin.version>2.1.1</keepachangelog-plugin.version>
-    <source-plugin.version>3.2.1</source-plugin.version>
-    <javadoc-plugin.version>3.4.1</javadoc-plugin.version>
-    <gpg-plugin.version>3.0.1</gpg-plugin.version>
+    <source-plugin.version>3.3.0</source-plugin.version>
+    <javadoc-plugin.version>3.6.3</javadoc-plugin.version>
+    <gpg-plugin.version>3.1.0</gpg-plugin.version>
     <nexus-staging-plugin.version>1.6.13</nexus-staging-plugin.version>
   </properties>
 

--- a/sonar-delphi-plugin/pom.xml
+++ b/sonar-delphi-plugin/pom.xml
@@ -119,7 +119,7 @@
                 <filter>
                   <artifact>*:*</artifact>
                   <excludes>
-                    <exclude>module-info.class</exclude>
+                    <exclude>**/module-info.class</exclude>
                     <exclude>META-INF/LICENSE*</exclude>
                     <exclude>META-INF/NOTICE*</exclude>
                     <exclude>META-INF/*.RSA</exclude>
@@ -138,9 +138,16 @@
                   <artifact>org.sonarsource.analyzer-commons:*</artifact>
                   <excludes>
                     <exclude>**/javax/annotation/**</exclude>
+                    <exclude>META-INF/**</exclude>
                   </excludes>
                 </filter>
               </filters>
+              <transformers>
+                <transformer implementation="org.apache.maven.plugins.shade.resource.DontIncludeResourceTransformer">
+                  <resource>MANIFEST.MF</resource>
+                </transformer>
+                <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer" />
+              </transformers>
             </configuration>
           </execution>
         </executions>


### PR DESCRIPTION
This PR upgrades all of the maven plugin dependencies.

It fixes the following error that occurred during tests:
`"Corrupted STDOUT by directly writing to native stream in forked JVM"`

This error was masking 2 failing tests in `GrammarTest`, one of which was a minor v1.1.0 regression introduced in #130.
(@zaneduffield, can you follow up and push a fix for that second failing test to this PR?)