### PR TITLE
Downgrade duplicate unit import error to warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The `Copy` intrinsic inferred an incorrect return type for `PChar`, `PAnsiChar`, and variants.
 - The `Concat` intrinsic inferred an incorrect return type for single-character string literals.
 - Ideographic space (U+3000) was erroneously accepted as a valid identifier character.
+- Duplicate imports in a `requires` clause now log a warning instead of throwing an exception.
 
 ## [1.1.0] - 2024-01-02
 


### PR DESCRIPTION
Delphi `requires` clauses permit duplicate units, e.g. a `.dpk` with the following code compiles:

```delphi
package MyPackage;

requires
  rtl,
  vcl,
  rtl;

end.
```

SonarDelphi does not currently permit this. This PR adds a special case to `DelphiScopeImpl::addDeclaration` that catches the duplicate declaration exception and logs a warning instead if the declaration is a unit import.

Note that this change also "permits" duplicate imports in normal uses clauses, but since this is a compilation error anyway I think it's the most practical way to solve this problem. Happy to hear other thoughts.