### PR TITLE
Define the `LLVM` symbol on LLVM-based toolchains

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Support for the `LLVM` symbol, which is defined on LLVM-based toolchains from Delphi 12 onward.
+
 ### Fixed
 
 - Parsing errors on `.dpr` files without a top-level `begin`.

--- a/delphi-frontend/src/main/java/au/com/integradev/delphi/compiler/PredefinedConditionals.java
+++ b/delphi-frontend/src/main/java/au/com/integradev/delphi/compiler/PredefinedConditionals.java
@@ -30,6 +30,7 @@ public final class PredefinedConditionals {
   private static final CompilerVersion VERSION_2009 = CompilerVersion.fromVersionNumber("20.0");
   private static final CompilerVersion VERSION_TOKYO = CompilerVersion.fromVersionNumber("32.0");
   private static final CompilerVersion VERSION_SYDNEY = CompilerVersion.fromVersionNumber("34.0");
+  private static final CompilerVersion VERSION_ATHENS = CompilerVersion.fromVersionNumber("36.0");
 
   private final Toolchain toolchain;
   private final CompilerVersion compilerVersion;
@@ -177,7 +178,11 @@ public final class PredefinedConditionals {
             Toolchain.DCCLINUX64);
 
     if (basedOnLLVM) {
-      return Set.of("EXTERNALLINKER");
+      Set<String> result = Sets.newHashSet("EXTERNALLINKER");
+      if (compilerVersion.compareTo(VERSION_ATHENS) >= 0) {
+        result.add("LLVM");
+      }
+      return result;
     } else {
       return Set.of("ASSEMBLER");
     }

--- a/delphi-frontend/src/test/java/au/com/integradev/delphi/compiler/PredefinedConditionalsTest.java
+++ b/delphi-frontend/src/test/java/au/com/integradev/delphi/compiler/PredefinedConditionalsTest.java
@@ -22,6 +22,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.Set;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
 
 class PredefinedConditionalsTest {
   private static final CompilerVersion VERSION_5 = CompilerVersion.fromVersionNumber("13.0");
@@ -31,6 +33,7 @@ class PredefinedConditionalsTest {
   private static final CompilerVersion VERSION_SYDNEY = CompilerVersion.fromVersionNumber("34.0");
   private static final CompilerVersion VERSION_ALEXANDRIA =
       CompilerVersion.fromVersionNumber("35.0");
+  private static final CompilerVersion VERSION_ATHENS = CompilerVersion.fromVersionNumber("36.0");
 
   private static final Set<String> NEXT_GEN_FEATURES =
       Set.of("NEXTGEN", "AUTOREFCOUNT", "WEAKINSTREF");
@@ -367,5 +370,39 @@ class PredefinedConditionalsTest {
 
     assertThat(PredefinedConditionals.getConditionalDefines(Toolchain.DCCLINUX64, VERSION_RIO))
         .doesNotContainAnyElementsOf(NEXT_GEN_FEATURES);
+  }
+
+  @ParameterizedTest
+  @EnumSource(
+      value = Toolchain.class,
+      names = {
+        "DCCOSX64",
+        "DCCOSXARM64",
+        "DCCIOSARM",
+        "DCCIOSARM64",
+        "DCCIOSSIMARM64",
+        "DCCAARM",
+        "DCCAARM64",
+        "DCCLINUX64"
+      })
+  void testLLVMToolchainsAfterDelphiAlexandriaShouldDefineLLVM(Toolchain toolchain) {
+    assertThat(PredefinedConditionals.getConditionalDefines(toolchain, VERSION_ATHENS))
+        .contains("LLVM");
+  }
+
+  @ParameterizedTest
+  @EnumSource(
+      value = Toolchain.class,
+      names = {"DCC32", "DCC64", "DCCOSX", "DCCIOS32"})
+  void testNonLLVMToolchainsAfterDelphiAlexandriaShouldNotDefineLLVM(Toolchain toolchain) {
+    assertThat(PredefinedConditionals.getConditionalDefines(toolchain, VERSION_ATHENS))
+        .doesNotContain("LLVM");
+  }
+
+  @ParameterizedTest
+  @EnumSource(value = Toolchain.class)
+  void testToolchainsBeforeDelphiAthensShouldNotDefineLLVM(Toolchain toolchain) {
+    assertThat(PredefinedConditionals.getConditionalDefines(toolchain, VERSION_ALEXANDRIA))
+        .doesNotContain("LLVM");
   }
 }


### PR DESCRIPTION
This PR adds support for the `LLVM` symbol, which is defined on LLVM-based toolchains from Delphi 12 onward.

Closes #160.