### PR TITLE
Define the `IOSSIMULATOR` symbol on `DCCIOSSIMARM64`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Support for the `LLVM` symbol, which is defined on LLVM-based toolchains from Delphi 12 onward.
+- Support for the `IOSSIMULATOR` symbol, which is defined on the `DCCIOSSIMARM64` toolchain.
 
 ### Fixed
 

--- a/delphi-frontend/src/main/java/au/com/integradev/delphi/compiler/PredefinedConditionals.java
+++ b/delphi-frontend/src/main/java/au/com/integradev/delphi/compiler/PredefinedConditionals.java
@@ -226,6 +226,10 @@ public final class PredefinedConditionals {
       result.add("WEAKINTFREF");
     }
 
+    if (checkToolchain(Toolchain.DCCIOSSIMARM64)) {
+      result.add("IOSSIMULATOR");
+    }
+
     return result;
   }
 

--- a/delphi-frontend/src/test/java/au/com/integradev/delphi/compiler/PredefinedConditionalsTest.java
+++ b/delphi-frontend/src/test/java/au/com/integradev/delphi/compiler/PredefinedConditionalsTest.java
@@ -236,7 +236,8 @@ class PredefinedConditionalsTest {
             "CONDITIONALEXPRESSIONS",
             "PIC",
             "WEAKREF",
-            "WEAKINTFREF");
+            "WEAKINTFREF",
+            "IOSSIMULATOR");
   }
 
   @Test


### PR DESCRIPTION
This PR adds support for the `IOSSIMULATOR` symbol, which is defined on the `DCCIOSSIMARM64` toolchain.

Closes #163.