### PR TITLE
Add checks to detect forms/frames without accompanying resource files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Support for the `LLVM` symbol, which is defined on LLVM-based toolchains from Delphi 12 onward.
 - Support for the `IOSSIMULATOR` symbol, which is defined on the `DCCIOSSIMARM64` toolchain.
+- **API:** `CompilerDirectiveParser` now returns a new `ResourceDirective` type when parsing
+  [resource directives](https://docwiki.embarcadero.com/RADStudio/en/Resource_file_(Delphi)).
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Support for the `LLVM` symbol, which is defined on LLVM-based toolchains from Delphi 12 onward.
 - Support for the `IOSSIMULATOR` symbol, which is defined on the `DCCIOSSIMARM64` toolchain.
 - `FormDfm` analysis rule, which flags VCL forms/frames that lack a `.dfm` resource.
+- `FormFmx` analysis rule, which flags FireMonkey forms/frames that lack a `.fmx` resource.
 - **API:** `CompilerDirectiveParser` now returns a new `ResourceDirective` type when parsing
   [resource directives](https://docwiki.embarcadero.com/RADStudio/en/Resource_file_(Delphi)).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Support for the `LLVM` symbol, which is defined on LLVM-based toolchains from Delphi 12 onward.
 - Support for the `IOSSIMULATOR` symbol, which is defined on the `DCCIOSSIMARM64` toolchain.
+- `FormDfm` analysis rule, which flags VCL forms/frames that lack a `.dfm` resource.
 - **API:** `CompilerDirectiveParser` now returns a new `ResourceDirective` type when parsing
   [resource directives](https://docwiki.embarcadero.com/RADStudio/en/Resource_file_(Delphi)).
 

--- a/delphi-checks/src/main/java/au/com/integradev/delphi/checks/AbstractFormResourceCheck.java
+++ b/delphi-checks/src/main/java/au/com/integradev/delphi/checks/AbstractFormResourceCheck.java
@@ -1,0 +1,81 @@
+/*
+ * Sonar Delphi Plugin
+ * Copyright (C) 2024 Integrated Application Development
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02
+ */
+package au.com.integradev.delphi.checks;
+
+import java.util.Optional;
+import org.apache.commons.lang3.StringUtils;
+import org.sonar.plugins.communitydelphi.api.ast.DelphiAst;
+import org.sonar.plugins.communitydelphi.api.ast.DelphiNode;
+import org.sonar.plugins.communitydelphi.api.ast.TypeDeclarationNode;
+import org.sonar.plugins.communitydelphi.api.check.DelphiCheck;
+import org.sonar.plugins.communitydelphi.api.check.DelphiCheckContext;
+import org.sonar.plugins.communitydelphi.api.directive.CompilerDirective;
+import org.sonar.plugins.communitydelphi.api.directive.ResourceDirective;
+import org.sonar.plugins.communitydelphi.api.token.DelphiToken;
+import org.sonar.plugins.communitydelphi.api.type.Type;
+
+abstract class AbstractFormResourceCheck extends DelphiCheck {
+  protected abstract String getFrameworkName();
+
+  protected abstract String getFormTypeImage();
+
+  protected abstract String getFrameTypeImage();
+
+  protected abstract String getResourceFileExtension();
+
+  @Override
+  public DelphiCheckContext visit(DelphiAst ast, DelphiCheckContext context) {
+    if (context.getTokens().stream()
+        .filter(DelphiToken::isCompilerDirective)
+        .map(token -> context.getCompilerDirectiveParser().parse(token))
+        .flatMap(Optional::stream)
+        .anyMatch(this::isFormResource)) {
+      return context;
+    }
+    return super.visit(ast, context);
+  }
+
+  @Override
+  public DelphiCheckContext visit(TypeDeclarationNode declaration, DelphiCheckContext context) {
+    DelphiNode location = declaration.getTypeNameNode();
+
+    Type type = declaration.getType();
+    if (!type.isAlias()) {
+      if (type.isDescendantOf(getFormTypeImage())) {
+        reportIssue(context, location, getMessage("form"));
+      } else if (type.isDescendantOf(getFrameTypeImage())) {
+        reportIssue(context, location, getMessage("frame"));
+      }
+    }
+
+    return context;
+  }
+
+  private boolean isFormResource(CompilerDirective directive) {
+    return directive instanceof ResourceDirective
+        && StringUtils.endsWithIgnoreCase(
+            ((ResourceDirective) directive).getResourceFile(), "." + getResourceFileExtension());
+  }
+
+  private String getMessage(String componentKind) {
+    return String.format(
+        "Add a '.%s' resource for this %s %s.",
+        getResourceFileExtension(), getFrameworkName(), componentKind);
+  }
+}

--- a/delphi-checks/src/main/java/au/com/integradev/delphi/checks/CheckList.java
+++ b/delphi-checks/src/main/java/au/com/integradev/delphi/checks/CheckList.java
@@ -77,6 +77,7 @@ public final class CheckList {
           ForbiddenPropertyCheck.class,
           ForbiddenRoutineCheck.class,
           ForbiddenTypeCheck.class,
+          FormDfmCheck.class,
           FreeAndNilTObjectCheck.class,
           GotoStatementCheck.class,
           GroupedFieldDeclarationCheck.class,

--- a/delphi-checks/src/main/java/au/com/integradev/delphi/checks/CheckList.java
+++ b/delphi-checks/src/main/java/au/com/integradev/delphi/checks/CheckList.java
@@ -78,6 +78,7 @@ public final class CheckList {
           ForbiddenRoutineCheck.class,
           ForbiddenTypeCheck.class,
           FormDfmCheck.class,
+          FormFmxCheck.class,
           FreeAndNilTObjectCheck.class,
           GotoStatementCheck.class,
           GroupedFieldDeclarationCheck.class,

--- a/delphi-checks/src/main/java/au/com/integradev/delphi/checks/FormDfmCheck.java
+++ b/delphi-checks/src/main/java/au/com/integradev/delphi/checks/FormDfmCheck.java
@@ -1,0 +1,45 @@
+/*
+ * Sonar Delphi Plugin
+ * Copyright (C) 2024 Integrated Application Development
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02
+ */
+package au.com.integradev.delphi.checks;
+
+import org.sonar.check.Rule;
+
+@Rule(key = "FormDfm")
+public class FormDfmCheck extends AbstractFormResourceCheck {
+
+  @Override
+  protected String getFrameworkName() {
+    return "VCL";
+  }
+
+  @Override
+  protected String getFormTypeImage() {
+    return "Vcl.Forms.TForm";
+  }
+
+  @Override
+  protected String getFrameTypeImage() {
+    return "Vcl.Forms.TFrame";
+  }
+
+  @Override
+  protected String getResourceFileExtension() {
+    return "dfm";
+  }
+}

--- a/delphi-checks/src/main/java/au/com/integradev/delphi/checks/FormFmxCheck.java
+++ b/delphi-checks/src/main/java/au/com/integradev/delphi/checks/FormFmxCheck.java
@@ -1,0 +1,44 @@
+/*
+ * Sonar Delphi Plugin
+ * Copyright (C) 2024 Integrated Application Development
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02
+ */
+package au.com.integradev.delphi.checks;
+
+import org.sonar.check.Rule;
+
+@Rule(key = "FormFmx")
+public class FormFmxCheck extends AbstractFormResourceCheck {
+  @Override
+  protected String getFrameworkName() {
+    return "FireMonkey";
+  }
+
+  @Override
+  protected String getFormTypeImage() {
+    return "FMX.Forms.TForm";
+  }
+
+  @Override
+  protected String getFrameTypeImage() {
+    return "FMX.Forms.TFrame";
+  }
+
+  @Override
+  protected String getResourceFileExtension() {
+    return "fmx";
+  }
+}

--- a/delphi-checks/src/main/resources/org/sonar/l10n/delphi/rules/community-delphi/FormDfm.html
+++ b/delphi-checks/src/main/resources/org/sonar/l10n/delphi/rules/community-delphi/FormDfm.html
@@ -1,0 +1,52 @@
+<h2>Why is this an issue?</h2>
+<p>
+  Omitting the corresponding <code>.dfm</code> resource for a VCL form or frame is typically a
+  programming error. While there are some cases that won't cause problems at runtime, it remains
+  unintuitive and confusing.
+</p>
+<p>
+  Additionally, a unit that doesn't contain a <code>.dfm</code> resource will lack design-time form
+  editing functionality.
+</p>
+<p>
+  This rule flags any <code>TForm</code> or <code>TFrame</code> descendant in a unit that doesn't
+  include a <code>.dfm</code> resource.
+</p>
+<h2>How to fix it</h2>
+<p>Add a <code>.dfm</code> resource to the unit:</p>
+<pre data-diff-id="1" data-diff-type="noncompliant">
+unit Foo;
+
+interface
+
+uses
+  Vcl.Forms;
+
+type
+  TFoo = class(TForm)
+    // ...
+  end;
+
+implementation
+
+end.
+</pre>
+<pre data-diff-id="1" data-diff-type="compliant">
+unit Foo;
+
+interface
+
+uses
+  Vcl.Forms;
+
+type
+  TFoo = class(TForm)
+    // ...
+  end;
+
+implementation
+
+{$R *.dfm}
+
+end.
+</pre>

--- a/delphi-checks/src/main/resources/org/sonar/l10n/delphi/rules/community-delphi/FormDfm.json
+++ b/delphi-checks/src/main/resources/org/sonar/l10n/delphi/rules/community-delphi/FormDfm.json
@@ -1,0 +1,19 @@
+{
+  "title": "VCL forms and frames should have a corresponding .dfm form file",
+  "type": "CODE_SMELL",
+  "status": "ready",
+  "remediation": {
+    "func": "Constant/Issue",
+    "constantCost": "5min"
+  },
+  "code": {
+    "attribute": "COMPLETE",
+    "impacts": {
+      "MAINTAINABILITY": "MEDIUM"
+    }
+  },
+  "tags": ["bad-practice", "confusing"],
+  "defaultSeverity": "Major",
+  "scope": "ALL",
+  "quickfix": "unknown"
+}

--- a/delphi-checks/src/main/resources/org/sonar/l10n/delphi/rules/community-delphi/FormFmx.html
+++ b/delphi-checks/src/main/resources/org/sonar/l10n/delphi/rules/community-delphi/FormFmx.html
@@ -1,0 +1,52 @@
+<h2>Why is this an issue?</h2>
+<p>
+  Omitting the corresponding <code>.fmx</code> resource for a FireMonkey form or frame is typically
+  a programming error. While there are some cases that won't cause problems at runtime, it remains
+  unintuitive and confusing.
+</p>
+<p>
+  Additionally, a unit that doesn't contain a <code>.fmx</code> resource will lack design-time form
+  editing functionality.
+</p>
+<p>
+  This rule flags any <code>TForm</code> or <code>TFrame</code> descendant in a unit that doesn't
+  include a <code>.fmx</code> resource.
+</p>
+<h2>How to fix it</h2>
+<p>Add a <code>.fmx</code> resource to the unit:</p>
+<pre data-diff-id="1" data-diff-type="noncompliant">
+unit Foo;
+
+interface
+
+uses
+  FMX.Forms;
+
+type
+  TFoo = class(TForm)
+    // ...
+  end;
+
+implementation
+
+end.
+</pre>
+<pre data-diff-id="1" data-diff-type="compliant">
+unit Foo;
+
+interface
+
+uses
+  FMX.Forms;
+
+type
+  TFoo = class(TForm)
+    // ...
+  end;
+
+implementation
+
+{$R *.fmx}
+
+end.
+</pre>

--- a/delphi-checks/src/main/resources/org/sonar/l10n/delphi/rules/community-delphi/FormFmx.json
+++ b/delphi-checks/src/main/resources/org/sonar/l10n/delphi/rules/community-delphi/FormFmx.json
@@ -1,0 +1,19 @@
+{
+  "title": "FireMonkey forms and frames should have a corresponding .fmx form file",
+  "type": "CODE_SMELL",
+  "status": "ready",
+  "remediation": {
+    "func": "Constant/Issue",
+    "constantCost": "5min"
+  },
+  "code": {
+    "attribute": "COMPLETE",
+    "impacts": {
+      "MAINTAINABILITY": "MEDIUM"
+    }
+  },
+  "tags": ["bad-practice", "confusing"],
+  "defaultSeverity": "Major",
+  "scope": "ALL",
+  "quickfix": "unknown"
+}

--- a/delphi-checks/src/test/java/au/com/integradev/delphi/checks/FormDfmCheckTest.java
+++ b/delphi-checks/src/test/java/au/com/integradev/delphi/checks/FormDfmCheckTest.java
@@ -1,0 +1,174 @@
+/*
+ * Sonar Delphi Plugin
+ * Copyright (C) 2024 Integrated Application Development
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02
+ */
+package au.com.integradev.delphi.checks;
+
+import au.com.integradev.delphi.builders.DelphiTestUnitBuilder;
+import au.com.integradev.delphi.checks.verifier.CheckVerifier;
+import org.junit.jupiter.api.Test;
+
+class FormDfmCheckTest {
+  @Test
+  void testNormalClassWithoutDfmShouldNotAddIssue() {
+    CheckVerifier.newVerifier()
+        .withCheck(new FormDfmCheck())
+        .onFile(
+            new DelphiTestUnitBuilder()
+                .appendDecl("type")
+                .appendDecl("  TFoo = class(TObject)")
+                .appendDecl("  end;"))
+        .verifyNoIssues();
+  }
+
+  @Test
+  void testAliasesWithoutDfmShouldNotAddIssue() {
+    CheckVerifier.newVerifier()
+        .withCheck(new FormDfmCheck())
+        .withSearchPathUnit(createVclForms())
+        .onFile(
+            new DelphiTestUnitBuilder()
+                .appendDecl("uses")
+                .appendDecl("  Vcl.Forms;")
+                .appendDecl("type")
+                .appendDecl("  TFormWeakAlias = TForm;")
+                .appendDecl("  TFrameWeakAlias = TFrame;")
+                .appendDecl("  TFormStrongAlias = type TForm;")
+                .appendDecl("  TFrameStrongAlias = type TFrame;"))
+        .verifyNoIssues();
+  }
+
+  @Test
+  void testFormWithDfmShouldNotAddIssue() {
+    CheckVerifier.newVerifier()
+        .withCheck(new FormDfmCheck())
+        .withSearchPathUnit(createVclForms())
+        .onFile(
+            new DelphiTestUnitBuilder()
+                .appendDecl("uses")
+                .appendDecl("  Vcl.Forms;")
+                .appendDecl("type")
+                .appendDecl("  TFoo = class(TForm)")
+                .appendDecl("  end;")
+                .appendImpl("{$R Foo.dfm}"))
+        .verifyNoIssues();
+  }
+
+  @Test
+  void testFrameWithDfmShouldNotAddIssue() {
+    CheckVerifier.newVerifier()
+        .withCheck(new FormDfmCheck())
+        .withSearchPathUnit(createVclForms())
+        .onFile(
+            new DelphiTestUnitBuilder()
+                .appendDecl("uses")
+                .appendDecl("  Vcl.Forms;")
+                .appendDecl("type")
+                .appendDecl("  TFoo = class(TFrame)")
+                .appendDecl("  end;")
+                .appendImpl("{$R Foo.dfm}"))
+        .verifyNoIssues();
+  }
+
+  @Test
+  void testFormWithoutDfmShouldAddIssue() {
+    CheckVerifier.newVerifier()
+        .withCheck(new FormDfmCheck())
+        .withSearchPathUnit(createVclForms())
+        .onFile(
+            new DelphiTestUnitBuilder()
+                .appendDecl("uses")
+                .appendDecl("  Vcl.Forms;")
+                .appendDecl("type")
+                .appendDecl("  TFoo = class(TForm) // Noncompliant")
+                .appendDecl("  end;"))
+        .verifyIssues();
+  }
+
+  @Test
+  void testFrameWithoutDfmShouldAddIssue() {
+    CheckVerifier.newVerifier()
+        .withCheck(new FormDfmCheck())
+        .withSearchPathUnit(createVclForms())
+        .onFile(
+            new DelphiTestUnitBuilder()
+                .appendDecl("uses")
+                .appendDecl("  Vcl.Forms;")
+                .appendDecl("type")
+                .appendDecl("  TFoo = class(TFrame) // Noncompliant")
+                .appendDecl("  end;"))
+        .verifyIssues();
+  }
+
+  @Test
+  void testNonDfmResourceShouldAddIssue() {
+    CheckVerifier.newVerifier()
+        .withCheck(new FormDfmCheck())
+        .withSearchPathUnit(createVclForms())
+        .onFile(
+            new DelphiTestUnitBuilder()
+                .appendDecl("uses")
+                .appendDecl("  Vcl.Forms;")
+                .appendDecl("type")
+                .appendDecl("  TFoo = class(TForm) // Noncompliant")
+                .appendDecl("  end;")
+                .appendImpl("{$R Foo.bar}"))
+        .verifyIssues();
+  }
+
+  @Test
+  void testNonDfmResourceContainingDotDfmShouldAddIssue() {
+    CheckVerifier.newVerifier()
+        .withCheck(new FormDfmCheck())
+        .withSearchPathUnit(createVclForms())
+        .onFile(
+            new DelphiTestUnitBuilder()
+                .appendDecl("uses")
+                .appendDecl("  Vcl.Forms;")
+                .appendDecl("type")
+                .appendDecl("  TFoo = class(TForm) // Noncompliant")
+                .appendDecl("  end;")
+                .appendImpl("{$R Foo.dfm.bar}"))
+        .verifyIssues();
+  }
+
+  @Test
+  void testIncludeDfmShouldAddIssue() {
+    CheckVerifier.newVerifier()
+        .withCheck(new FormDfmCheck())
+        .withSearchPathUnit(createVclForms())
+        .onFile(
+            new DelphiTestUnitBuilder()
+                .appendDecl("uses")
+                .appendDecl("  Vcl.Forms;")
+                .appendDecl("type")
+                .appendDecl("  TFoo = class(TForm) // Noncompliant")
+                .appendDecl("  end;")
+                .appendImpl("{$I Foo.dfm}"))
+        .verifyIssues();
+  }
+
+  private static DelphiTestUnitBuilder createVclForms() {
+    return new DelphiTestUnitBuilder()
+        .unitName("Vcl.Forms")
+        .appendDecl("type")
+        .appendDecl("  TForm = class")
+        .appendDecl("  end;")
+        .appendDecl("  TFrame = class")
+        .appendDecl("  end;");
+  }
+}

--- a/delphi-checks/src/test/java/au/com/integradev/delphi/checks/FormFmxCheckTest.java
+++ b/delphi-checks/src/test/java/au/com/integradev/delphi/checks/FormFmxCheckTest.java
@@ -1,0 +1,174 @@
+/*
+ * Sonar Delphi Plugin
+ * Copyright (C) 2024 Integrated Application Development
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02
+ */
+package au.com.integradev.delphi.checks;
+
+import au.com.integradev.delphi.builders.DelphiTestUnitBuilder;
+import au.com.integradev.delphi.checks.verifier.CheckVerifier;
+import org.junit.jupiter.api.Test;
+
+class FormFmxCheckTest {
+  @Test
+  void testNormalClassWithoutFmxShouldNotAddIssue() {
+    CheckVerifier.newVerifier()
+        .withCheck(new FormFmxCheck())
+        .onFile(
+            new DelphiTestUnitBuilder()
+                .appendDecl("type")
+                .appendDecl("  TFoo = class(TObject)")
+                .appendDecl("  end;"))
+        .verifyNoIssues();
+  }
+
+  @Test
+  void testAliasesWithoutFmxShouldNotAddIssue() {
+    CheckVerifier.newVerifier()
+        .withCheck(new FormFmxCheck())
+        .withSearchPathUnit(createFmxForms())
+        .onFile(
+            new DelphiTestUnitBuilder()
+                .appendDecl("uses")
+                .appendDecl("  FMX.Forms;")
+                .appendDecl("type")
+                .appendDecl("  TFormWeakAlias = TForm;")
+                .appendDecl("  TFrameWeakAlias = TFrame;")
+                .appendDecl("  TFormStrongAlias = type TForm;")
+                .appendDecl("  TFrameStrongAlias = type TFrame;"))
+        .verifyNoIssues();
+  }
+
+  @Test
+  void testFormWithFmxShouldNotAddIssue() {
+    CheckVerifier.newVerifier()
+        .withCheck(new FormFmxCheck())
+        .withSearchPathUnit(createFmxForms())
+        .onFile(
+            new DelphiTestUnitBuilder()
+                .appendDecl("uses")
+                .appendDecl("  FMX.Forms;")
+                .appendDecl("type")
+                .appendDecl("  TFoo = class(TForm)")
+                .appendDecl("  end;")
+                .appendImpl("{$R Foo.fmx}"))
+        .verifyNoIssues();
+  }
+
+  @Test
+  void testFrameWithFmxShouldNotAddIssue() {
+    CheckVerifier.newVerifier()
+        .withCheck(new FormFmxCheck())
+        .withSearchPathUnit(createFmxForms())
+        .onFile(
+            new DelphiTestUnitBuilder()
+                .appendDecl("uses")
+                .appendDecl("  FMX.Forms;")
+                .appendDecl("type")
+                .appendDecl("  TFoo = class(TFrame)")
+                .appendDecl("  end;")
+                .appendImpl("{$R Foo.fmx}"))
+        .verifyNoIssues();
+  }
+
+  @Test
+  void testFormWithoutFmxShouldAddIssue() {
+    CheckVerifier.newVerifier()
+        .withCheck(new FormFmxCheck())
+        .withSearchPathUnit(createFmxForms())
+        .onFile(
+            new DelphiTestUnitBuilder()
+                .appendDecl("uses")
+                .appendDecl("  FMX.Forms;")
+                .appendDecl("type")
+                .appendDecl("  TFoo = class(TForm) // Noncompliant")
+                .appendDecl("  end;"))
+        .verifyIssues();
+  }
+
+  @Test
+  void testFrameWithoutFmxShouldAddIssue() {
+    CheckVerifier.newVerifier()
+        .withCheck(new FormFmxCheck())
+        .withSearchPathUnit(createFmxForms())
+        .onFile(
+            new DelphiTestUnitBuilder()
+                .appendDecl("uses")
+                .appendDecl("  FMX.Forms;")
+                .appendDecl("type")
+                .appendDecl("  TFoo = class(TFrame) // Noncompliant")
+                .appendDecl("  end;"))
+        .verifyIssues();
+  }
+
+  @Test
+  void testNonFmxResourceShouldAddIssue() {
+    CheckVerifier.newVerifier()
+        .withCheck(new FormFmxCheck())
+        .withSearchPathUnit(createFmxForms())
+        .onFile(
+            new DelphiTestUnitBuilder()
+                .appendDecl("uses")
+                .appendDecl("  FMX.Forms;")
+                .appendDecl("type")
+                .appendDecl("  TFoo = class(TForm) // Noncompliant")
+                .appendDecl("  end;")
+                .appendImpl("{$R Foo.bar}"))
+        .verifyIssues();
+  }
+
+  @Test
+  void testNonFmxResourceContainingDotFmxShouldAddIssue() {
+    CheckVerifier.newVerifier()
+        .withCheck(new FormFmxCheck())
+        .withSearchPathUnit(createFmxForms())
+        .onFile(
+            new DelphiTestUnitBuilder()
+                .appendDecl("uses")
+                .appendDecl("  FMX.Forms;")
+                .appendDecl("type")
+                .appendDecl("  TFoo = class(TForm) // Noncompliant")
+                .appendDecl("  end;")
+                .appendImpl("{$R Foo.fmx.bar}"))
+        .verifyIssues();
+  }
+
+  @Test
+  void testIncludeFmxShouldAddIssue() {
+    CheckVerifier.newVerifier()
+        .withCheck(new FormFmxCheck())
+        .withSearchPathUnit(createFmxForms())
+        .onFile(
+            new DelphiTestUnitBuilder()
+                .appendDecl("uses")
+                .appendDecl("  FMX.Forms;")
+                .appendDecl("type")
+                .appendDecl("  TFoo = class(TForm) // Noncompliant")
+                .appendDecl("  end;")
+                .appendImpl("{$I Foo.fmx}"))
+        .verifyIssues();
+  }
+
+  private static DelphiTestUnitBuilder createFmxForms() {
+    return new DelphiTestUnitBuilder()
+        .unitName("FMX.Forms")
+        .appendDecl("type")
+        .appendDecl("  TForm = class")
+        .appendDecl("  end;")
+        .appendDecl("  TFrame = class")
+        .appendDecl("  end;");
+  }
+}

--- a/delphi-frontend/src/main/java/au/com/integradev/delphi/preprocessor/directive/ResourceDirectiveImpl.java
+++ b/delphi-frontend/src/main/java/au/com/integradev/delphi/preprocessor/directive/ResourceDirectiveImpl.java
@@ -1,0 +1,57 @@
+/*
+ * Sonar Delphi Plugin
+ * Copyright (C) 2024 Integrated Application Development
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02
+ */
+package au.com.integradev.delphi.preprocessor.directive;
+
+import java.util.List;
+import javax.annotation.Nullable;
+import org.sonar.plugins.communitydelphi.api.directive.ResourceDirective;
+import org.sonar.plugins.communitydelphi.api.token.DelphiToken;
+
+class ResourceDirectiveImpl extends ParameterDirectiveImpl implements ResourceDirective {
+  private final String resourceFile;
+  private final String resourceScriptFile;
+  private final List<String> predicates;
+
+  ResourceDirectiveImpl(
+      DelphiToken token,
+      String resourceFile,
+      @Nullable String resourceScriptFile,
+      List<String> predicates) {
+    super(token, ParameterKind.RESOURCE);
+    this.resourceFile = resourceFile;
+    this.resourceScriptFile = resourceScriptFile;
+    this.predicates = predicates;
+  }
+
+  @Override
+  public String getResourceFile() {
+    return resourceFile;
+  }
+
+  @Nullable
+  @Override
+  public String getResourceScriptFile() {
+    return resourceScriptFile;
+  }
+
+  @Override
+  public List<String> getPredicates() {
+    return predicates;
+  }
+}

--- a/delphi-frontend/src/main/java/org/sonar/plugins/communitydelphi/api/directive/ResourceDirective.java
+++ b/delphi-frontend/src/main/java/org/sonar/plugins/communitydelphi/api/directive/ResourceDirective.java
@@ -1,0 +1,31 @@
+/*
+ * Sonar Delphi Plugin
+ * Copyright (C) 2024 Integrated Application Development
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02
+ */
+package org.sonar.plugins.communitydelphi.api.directive;
+
+import java.util.List;
+import javax.annotation.Nullable;
+
+public interface ResourceDirective extends CompilerDirective {
+  String getResourceFile();
+
+  @Nullable
+  String getResourceScriptFile();
+
+  List<String> getPredicates();
+}

--- a/delphi-frontend/src/test/java/au/com/integradev/delphi/preprocessor/directive/CompilerDirectiveParserTest.java
+++ b/delphi-frontend/src/test/java/au/com/integradev/delphi/preprocessor/directive/CompilerDirectiveParserTest.java
@@ -40,6 +40,7 @@ import org.sonar.plugins.communitydelphi.api.directive.IfnDefDirective;
 import org.sonar.plugins.communitydelphi.api.directive.IncludeDirective;
 import org.sonar.plugins.communitydelphi.api.directive.ParameterDirective;
 import org.sonar.plugins.communitydelphi.api.directive.ParameterDirective.ParameterKind;
+import org.sonar.plugins.communitydelphi.api.directive.ResourceDirective;
 import org.sonar.plugins.communitydelphi.api.directive.SwitchDirective;
 import org.sonar.plugins.communitydelphi.api.directive.SwitchDirective.SwitchKind;
 import org.sonar.plugins.communitydelphi.api.directive.UndefineDirective;
@@ -60,6 +61,31 @@ class CompilerDirectiveParserTest {
 
     directive = parse("{$I file.inc}");
     assertThat(directive).isInstanceOf(IncludeDirective.class);
+  }
+
+  @Test
+  void testCreateResourceDirective() {
+    CompilerDirective directive = parse("{$RESOURCE file.res}");
+    assertThat(directive).isInstanceOf(ResourceDirective.class);
+    assertThat(((ResourceDirective) directive).getResourceFile()).isEqualTo("file.res");
+    assertThat(((ResourceDirective) directive).getResourceScriptFile()).isNull();
+
+    directive = parse("{$R 'file.res' 'script.rc'}");
+    assertThat(directive).isInstanceOf(ResourceDirective.class);
+    assertThat(((ResourceDirective) directive).getResourceFile()).isEqualTo("file.res");
+    assertThat(((ResourceDirective) directive).getResourceScriptFile()).isEqualTo("script.rc");
+
+    directive = parse("{$R 'file.res' foo}");
+    assertThat(directive).isInstanceOf(ResourceDirective.class);
+    assertThat(((ResourceDirective) directive).getResourceFile()).isEqualTo("file.res");
+    assertThat(((ResourceDirective) directive).getResourceScriptFile()).isNull();
+    assertThat(((ResourceDirective) directive).getPredicates()).containsExactly("foo");
+
+    directive = parse("{$R 'file.res' foo bar}");
+    assertThat(directive).isInstanceOf(ResourceDirective.class);
+    assertThat(((ResourceDirective) directive).getResourceFile()).isEqualTo("file.res");
+    assertThat(((ResourceDirective) directive).getResourceScriptFile()).isNull();
+    assertThat(((ResourceDirective) directive).getPredicates()).containsExactly("foo", "bar");
   }
 
   @Test


### PR DESCRIPTION
**New rules:**
* `FormDfm`: “VCL forms and frames should have a .dfm form file”
* `FormFmx`: “FireMonkey forms and frames should have a .fmx form file”

Neither rule is included in `Sonar way`.

**Compiler directives API:**
* The `RESOURCE` directive is modeled with a new `ResourceDirective` type.