### PR TITLE
Allow unit imports to be shadowed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Parsing errors on `.dpr` files without a top-level `begin`.
+- Symbol table errors on declarations that shared a name with a unit import.
 - The `Copy` intrinsic inferred an incorrect return type for `PChar`, `PAnsiChar`, and variants.
 - The `Concat` intrinsic inferred an incorrect return type for single-character string literals.
 - Ideographic space (U+3000) was erroneously accepted as a valid identifier character.

--- a/delphi-frontend/src/main/java/au/com/integradev/delphi/symbol/scope/DelphiScopeImpl.java
+++ b/delphi-frontend/src/main/java/au/com/integradev/delphi/symbol/scope/DelphiScopeImpl.java
@@ -170,6 +170,14 @@ public class DelphiScopeImpl implements DelphiScope {
 
     Set<NameDeclaration> duplicates = declarationsByName.get(declaration.getImage());
 
+    // Unit imports can clash with other declarations, except other imports
+    if (declaration instanceof UnitImportNameDeclaration) {
+      return duplicates.stream().noneMatch(UnitImportNameDeclaration.class::isInstance);
+    } else {
+      // Disregard unit imports when checking for duplicates
+      duplicates.removeIf(UnitImportNameDeclaration.class::isInstance);
+    }
+
     if (declaration instanceof GenerifiableDeclaration) {
       GenerifiableDeclaration generic = (GenerifiableDeclaration) declaration;
       if (generic.isGeneric()) {

--- a/delphi-frontend/src/test/java/au/com/integradev/delphi/executor/DelphiSymbolTableExecutorTest.java
+++ b/delphi-frontend/src/test/java/au/com/integradev/delphi/executor/DelphiSymbolTableExecutorTest.java
@@ -1104,6 +1104,54 @@ class DelphiSymbolTableExecutorTest {
   }
 
   @Test
+  void testVarShadowingImport() {
+    execute("shadowedImports/VarShadowingImport.pas", "shadowedImports");
+    verifyUsages(10, 15, reference(19, 15));
+  }
+
+  @Test
+  void testTypeShadowingImport() {
+    execute("shadowedImports/TypeShadowingImport.pas", "shadowedImports");
+    verifyUsages(10, 21, reference(16, 15));
+  }
+
+  @Test
+  void testConstShadowingImport() {
+    execute("shadowedImports/ConstShadowingImport.pas", "shadowedImports");
+    verifyUsages(10, 15, reference(19, 15));
+  }
+
+  @Test
+  void testRoutineShadowingImport() {
+    execute("shadowedImports/RoutineShadowingImport.pas", "shadowedImports");
+    verifyUsages(10, 15, reference(23, 15));
+  }
+
+  @Test
+  void testShadowedImplementationImport() {
+    execute("shadowedImports/ShadowedImplementationImport.pas", "shadowedImports");
+    verifyUsages(12, 21, reference(16, 15));
+  }
+
+  @Test
+  void testUnshadowedImplementationImport() {
+    execute("shadowedImports/UnshadowedImplementationImport.pas", "shadowedImports");
+    verifyUsages(13, 6, reference(16, 2));
+  }
+
+  @Test
+  void testInterfaceImportShadowedLater() {
+    execute("shadowedImports/InterfaceImportShadowedLater.pas", "shadowedImports");
+    verifyUsages(5, 6, reference(7, 28));
+  }
+
+  @Test
+  void testInterfaceImportShadowedInImplementation() {
+    execute("shadowedImports/InterfaceImportShadowedInImplementation.pas", "shadowedImports");
+    verifyUsages(5, 6, reference(7, 28));
+  }
+
+  @Test
   void testImports() {
     execute("imports/source/Unit1.pas", "imports/", "imports/source/", "imports/ignored/");
     verifyUsages(1, 5, reference(23, 2), reference(26, 18));

--- a/delphi-frontend/src/test/resources/au/com/integradev/delphi/symbol/ShadowedImportedUnitName.pas
+++ b/delphi-frontend/src/test/resources/au/com/integradev/delphi/symbol/ShadowedImportedUnitName.pas
@@ -1,0 +1,7 @@
+unit ShadowedImportedUnitName;
+
+uses Unit1;
+
+type
+  Unit1 = class(TObject)
+  end;

--- a/delphi-frontend/src/test/resources/au/com/integradev/delphi/symbol/shadowedImports/ConstShadowingImport.pas
+++ b/delphi-frontend/src/test/resources/au/com/integradev/delphi/symbol/shadowedImports/ConstShadowingImport.pas
@@ -1,0 +1,20 @@
+unit ConstShadowingImport;
+
+interface
+
+uses ShadowedName;
+
+type
+  TStringHelper = record helper for string
+  public
+    procedure Foo;
+  end;
+
+const
+  ShadowedName = 'hello';
+
+implementation
+
+initialization
+  ShadowedName.Foo; // Should reference TStringHelper.Foo
+end.

--- a/delphi-frontend/src/test/resources/au/com/integradev/delphi/symbol/shadowedImports/InterfaceImportShadowedInImplementation.pas
+++ b/delphi-frontend/src/test/resources/au/com/integradev/delphi/symbol/shadowedImports/InterfaceImportShadowedInImplementation.pas
@@ -1,0 +1,17 @@
+unit InterfaceImportShadowedInImplementation;
+
+interface
+
+uses ShadowedName;
+
+procedure Foo(Id: Integer = ShadowedName.Bar);
+
+implementation
+
+type
+  ShadowedName = class
+  public const
+    Bar = 5;
+  end;
+
+end.

--- a/delphi-frontend/src/test/resources/au/com/integradev/delphi/symbol/shadowedImports/InterfaceImportShadowedLater.pas
+++ b/delphi-frontend/src/test/resources/au/com/integradev/delphi/symbol/shadowedImports/InterfaceImportShadowedLater.pas
@@ -1,0 +1,17 @@
+unit InterfaceImportShadowedLater;
+
+interface
+
+uses ShadowedName;
+
+procedure Foo(Id: Integer = ShadowedName.Bar);
+
+type
+  ShadowedName = class
+  public const
+    Bar = 5;
+  end;
+
+implementation
+
+end.

--- a/delphi-frontend/src/test/resources/au/com/integradev/delphi/symbol/shadowedImports/RoutineShadowingImport.pas
+++ b/delphi-frontend/src/test/resources/au/com/integradev/delphi/symbol/shadowedImports/RoutineShadowingImport.pas
@@ -1,0 +1,24 @@
+unit VarShadowingImport;
+
+interface
+
+uses ShadowedName;
+
+type
+  TFooObject = class(TObject)
+  public
+    procedure Foo;
+  end;
+
+function ShadowedName: TFooObject;
+
+implementation
+
+function ShadowedName: TFooObject;
+begin
+  // xyz
+end;
+
+initialization
+  ShadowedName.Foo; // Should reference TFooObject.Foo
+end.

--- a/delphi-frontend/src/test/resources/au/com/integradev/delphi/symbol/shadowedImports/ShadowedImplementationImport.pas
+++ b/delphi-frontend/src/test/resources/au/com/integradev/delphi/symbol/shadowedImports/ShadowedImplementationImport.pas
@@ -1,0 +1,17 @@
+unit ShadowedImplementationImport;
+
+interface
+
+implementation
+
+uses ShadowedName;
+
+type
+  ShadowedName = class(TObject)
+  public
+    class procedure Foo;
+  end;
+
+initialization
+  ShadowedName.Foo; // Should reference class procedure
+end.

--- a/delphi-frontend/src/test/resources/au/com/integradev/delphi/symbol/shadowedImports/ShadowedName.pas
+++ b/delphi-frontend/src/test/resources/au/com/integradev/delphi/symbol/shadowedImports/ShadowedName.pas
@@ -1,0 +1,11 @@
+unit ShadowedName;
+
+interface
+
+procedure Foo;
+
+const Bar = 5;
+
+implementation
+
+end.

--- a/delphi-frontend/src/test/resources/au/com/integradev/delphi/symbol/shadowedImports/TypeShadowingImport.pas
+++ b/delphi-frontend/src/test/resources/au/com/integradev/delphi/symbol/shadowedImports/TypeShadowingImport.pas
@@ -1,0 +1,17 @@
+unit TypeShadowingImport;
+
+interface
+
+uses ShadowedName;
+
+type
+  ShadowedName = class(TObject)
+  public
+    class procedure Foo;
+  end;
+
+implementation
+
+initialization
+  ShadowedName.Foo; // Should reference class procedure
+end.

--- a/delphi-frontend/src/test/resources/au/com/integradev/delphi/symbol/shadowedImports/UnshadowedImplementationImport.pas
+++ b/delphi-frontend/src/test/resources/au/com/integradev/delphi/symbol/shadowedImports/UnshadowedImplementationImport.pas
@@ -1,0 +1,17 @@
+unit UnshadowedImplementationImport;
+
+interface
+
+type
+  ShadowedName = class(TObject)
+  public
+    class procedure Foo;
+  end;
+
+implementation
+
+uses ShadowedName;
+
+initialization
+  ShadowedName.Foo; // Should reference other unit
+end.

--- a/delphi-frontend/src/test/resources/au/com/integradev/delphi/symbol/shadowedImports/VarShadowingImport.pas
+++ b/delphi-frontend/src/test/resources/au/com/integradev/delphi/symbol/shadowedImports/VarShadowingImport.pas
@@ -1,0 +1,20 @@
+unit VarShadowingImport;
+
+interface
+
+uses ShadowedName;
+
+type
+  TStringHelper = record helper for string
+  public
+    procedure Foo;
+  end;
+
+var
+  ShadowedName: string;
+
+implementation
+
+initialization
+  ShadowedName.Foo; // Should reference TStringHelper.Foo
+end.


### PR DESCRIPTION
In Delphi, symbols can be declared with the same name as an imported unit. The behaviour seems to be that unit imports are shadowed by any subsequent declaration, but shadow all previous declarations. This PR implements this behaviour in SonarDelphi, which currently fails if a file-level symbol is declared with the same name as a unit import.

Fixes #161 