### PR TITLE
Support alternative casings for `WriteLn` and `ReadLn`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Support for the `LLVM` symbol, which is defined on LLVM-based toolchains from Delphi 12 onward.
 - Support for the `IOSSIMULATOR` symbol, which is defined on the `DCCIOSSIMARM64` toolchain.
 
+### Changed
+
+- Alternative casings `Writeln` and `Readln` are now allowed in `MixedNames`.
+
 ### Fixed
 
 - Parsing errors on `.dpr` files without a top-level `begin`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Parsing errors on `.dpr` files without a top-level `begin`.
 - The `Copy` intrinsic inferred an incorrect return type for `PChar`, `PAnsiChar`, and variants.
 - The `Concat` intrinsic inferred an incorrect return type for single-character string literals.
+- The `ReadLn` intrinsic was missing the standard input overload.
 - Ideographic space (U+3000) was erroneously accepted as a valid identifier character.
 - Duplicate imports in a `requires` clause now log a warning instead of throwing an exception.
 

--- a/delphi-checks/src/main/java/au/com/integradev/delphi/checks/MixedNamesCheck.java
+++ b/delphi-checks/src/main/java/au/com/integradev/delphi/checks/MixedNamesCheck.java
@@ -34,6 +34,7 @@ import org.sonar.plugins.communitydelphi.api.check.DelphiCheck;
 import org.sonar.plugins.communitydelphi.api.check.DelphiCheckContext;
 import org.sonar.plugins.communitydelphi.api.symbol.NameOccurrence;
 import org.sonar.plugins.communitydelphi.api.symbol.declaration.NameDeclaration;
+import org.sonar.plugins.communitydelphi.api.symbol.declaration.RoutineNameDeclaration;
 import org.sonar.plugins.communitydelphi.api.symbol.declaration.UnitImportNameDeclaration;
 import org.sonar.plugins.communitydelphi.api.symbol.declaration.UnitNameDeclaration;
 import org.sonar.plugins.communitydelphi.api.symbol.declaration.VariableNameDeclaration;
@@ -58,7 +59,7 @@ public class MixedNamesCheck extends DelphiCheck {
             context,
             occurrence.getImage(),
             (UnitImportNameDeclaration) declaration);
-      } else {
+      } else if (!isSpecialCase(declaration, occurrence)) {
         String actual = occurrence.getImage();
         String expected = declaration.getImage();
         if (!actual.equals(expected)) {
@@ -115,6 +116,21 @@ public class MixedNamesCheck extends DelphiCheck {
       return super.visit(argumentListNode, context);
     } else {
       return context;
+    }
+  }
+
+  private static boolean isSpecialCase(NameDeclaration declaration, NameOccurrence occurrence) {
+    if (!(declaration instanceof RoutineNameDeclaration)) {
+      return false;
+    }
+
+    switch (((RoutineNameDeclaration) declaration).fullyQualifiedName()) {
+      case "System.WriteLn":
+        return occurrence.getImage().equals("Writeln");
+      case "System.ReadLn":
+        return occurrence.getImage().equals("Readln");
+      default:
+        return false;
     }
   }
 

--- a/delphi-checks/src/test/java/au/com/integradev/delphi/checks/MixedNamesCheckTest.java
+++ b/delphi-checks/src/test/java/au/com/integradev/delphi/checks/MixedNamesCheckTest.java
@@ -21,6 +21,8 @@ package au.com.integradev.delphi.checks;
 import au.com.integradev.delphi.builders.DelphiTestUnitBuilder;
 import au.com.integradev.delphi.checks.verifier.CheckVerifier;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 class MixedNamesCheckTest {
   @Test
@@ -381,6 +383,28 @@ class MixedNamesCheckTest {
                 .appendDecl("  [foo.Bar] // Noncompliant")
                 .appendDecl("  TBar = class(TObject)")
                 .appendDecl("  end;"))
+        .verifyIssues();
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {"WriteLn", "ReadLn", "Writeln", "Readln"})
+  void testRoutinesWithMultipleCanonicalCasesShouldNotAddIssue(String routineName) {
+    CheckVerifier.newVerifier()
+        .withCheck(new MixedNamesCheck())
+        .onFile(
+            new DelphiTestUnitBuilder().appendImpl("initialization").appendImpl("  " + routineName))
+        .verifyNoIssues();
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {"writeln", "readln"})
+  void testWrongCasingOfRoutinesWithMultipleCanonicalCasesShouldAddIssue(String routineName) {
+    CheckVerifier.newVerifier()
+        .withCheck(new MixedNamesCheck())
+        .onFile(
+            new DelphiTestUnitBuilder()
+                .appendImpl("initialization")
+                .appendImpl("  " + routineName + " // Noncompliant"))
         .verifyIssues();
   }
 

--- a/delphi-frontend/src/main/java/au/com/integradev/delphi/type/intrinsic/IntrinsicsInjector.java
+++ b/delphi-frontend/src/main/java/au/com/integradev/delphi/type/intrinsic/IntrinsicsInjector.java
@@ -239,6 +239,7 @@ public final class IntrinsicsInjector {
         .param(TypeFactory.untypedType())
         .variadic(TypeFactory.untypedType());
     routine("ReadLn").varParam(ANY_FILE).variadic(TypeFactory.untypedType());
+    routine("ReadLn").variadic(TypeFactory.untypedType());
     routine("ReallocMem").varParam(ANY_POINTER).param(type(INTEGER));
     routine("Rename").varParam(ANY_FILE).param(ANY_STRING);
     routine("Reset").varParam(ANY_FILE).param(type(INTEGER)).required(1);


### PR DESCRIPTION
As described in #102, the jury is out on the casing of the `WriteLn` and `ReadLn` intrinsics - the debug information says `Ln`, while the documentation and the IDE say `ln`. For the purposes of the MixedNames check, SonarDelphi currently only accepts `WriteLn` and `ReadLn`.

This PR amends the MixedNames check to also accept the `ln` casing, and adds an additional (only partially documented) overload to the `ReadLn` intrinsic that does not include a file parameter. This was causing SonarDelphi to fail to resolve `Readln`and accidentally correctly accept it in some cases.

Fixes #102 