### PR TITLE
Correct inaccuracies in EmptyRoutine description

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Alternative casings `Writeln` and `Readln` are now allowed in `MixedNames`.
+- Improve clarity of the rule description for `EmptyRoutine`.
 
 ### Fixed
 

--- a/delphi-checks/src/main/resources/org/sonar/l10n/delphi/rules/community-delphi/EmptyRoutine.html
+++ b/delphi-checks/src/main/resources/org/sonar/l10n/delphi/rules/community-delphi/EmptyRoutine.html
@@ -1,27 +1,29 @@
 <h2>Why is this an issue?</h2>
 <p>
   Empty routines are usually superfluous, and should be removed to prevent unexpected behaviour.
+  In some cases, however, empty routines are necessary. In these cases they should be accompanied
+  by an explanatory comment in the body of the routine.
 </p>
-<p>Some valid empty routines could include:</p>
+<p>This rule ignores the following, when annotated with a comment:</p>
 <ul>
-  <li>A virtual method that is intended to be overridden</li>
-  <li>An override method of a non-empty virtual method</li>
-  <li>A method that exists only to implement an interface</li>
+  <li>Virtual methods (e.g. to provide a no-op default behaviour for child classes)</li>
+  <li>Override methods (e.g. to not run behaviour implemented in ancestor classes)</li>
+  <li>Methods that implement an interface</li>
 </ul>
-<p>
-  In these cases, a comment should be added to the routine body to explain why the routine is blank.
-</p>
 <h2>How to fix it</h2>
 <p>If the empty routine is an omission, remove it.</p>
-<p>If the routine should be empty, add a nested comment explaining why the routine is blank:</p>
+<p>
+  If the routine has a valid reason to be empty, add a nested comment explaining why the routine is
+  blank:
+</p>
 <pre data-diff-id="1" data-diff-type="noncompliant">
-procedure TExample.MyEmptyMethod;
+procedure TExample.OverriddenMethod;
 begin
 end;
 </pre>
 <pre data-diff-id="1" data-diff-type="compliant">
-procedure TExample.MyEmptyMethod;
+procedure TExample.OverriddenMethod;
 begin
-  // Empty because I really want it to be!
+  // Overrides base class behaviour
 end;
 </pre>


### PR DESCRIPTION
The EmptyRoutine description currently gives the impression that *any* routine with an explanatory comment is excluded from the check. The actual behaviour is that routines have to both have a comment *and* be a valid exclusion to be excluded.

This PR updates the description to agree with the behaviour of the check.