### PR TITLE
Disable integration tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -472,7 +472,8 @@
       <id>ci</id>
       <properties>
         <license.failIfMissing>true</license.failIfMissing>
-        <skipITs>false</skipITs>
+        <!-- Changes to upstream SonarSource servers have broken the integration tests.-->
+        <skipITs>true</skipITs>
       </properties>
     </profile>
 


### PR DESCRIPTION
Our integration tests, which only run in a CI environment, use SonarSource's open-source [sonar-orchestrator](https://github.com/SonarSource/orchestrator) library to orchestrate a SonarQube server.

These tests are currently failing, seemingly due to SonarSource changing the Artifactory server the orchestrator communicates with to require SonarSource authentication ([see here](https://sonarsource.atlassian.net/browse/SONAR-21476)). We have made [an inquiry](https://community.sonarsource.com/t/community-plugins-can-no-longer-make-requests-to-jfrog-via-the-orchestrator-library/107955), and in the meantime we will disable the ITs so our CI checks don't give an inaccurate impression of SonarDelphi's functionality.