### PR TITLE
Handle function return types and Variants in FormatArgumentType

### DIFF
--- a/delphi-checks/src/main/java/au/com/integradev/delphi/checks/FormatArgumentTypeCheck.java
+++ b/delphi-checks/src/main/java/au/com/integradev/delphi/checks/FormatArgumentTypeCheck.java
@@ -30,6 +30,7 @@ import org.sonar.plugins.communitydelphi.api.ast.ExpressionNode;
 import org.sonar.plugins.communitydelphi.api.check.DelphiCheckContext;
 import org.sonar.plugins.communitydelphi.api.type.Type;
 import org.sonar.plugins.communitydelphi.api.type.Type.PointerType;
+import org.sonar.plugins.communitydelphi.api.type.Type.ProceduralType;
 
 @Rule(key = "FormatArgumentType")
 public class FormatArgumentTypeCheck extends AbstractFormatArgumentCheck {
@@ -68,6 +69,10 @@ public class FormatArgumentTypeCheck extends AbstractFormatArgumentCheck {
   }
 
   private static boolean isAcceptedType(Type exprType, FormatSpecifierType specifierType) {
+    if (exprType instanceof ProceduralType) {
+      exprType = ((ProceduralType) exprType).returnType();
+    }
+
     switch (specifierType) {
       case DECIMAL:
       case UNSIGNED_DECIMAL:

--- a/delphi-checks/src/main/java/au/com/integradev/delphi/checks/FormatArgumentTypeCheck.java
+++ b/delphi-checks/src/main/java/au/com/integradev/delphi/checks/FormatArgumentTypeCheck.java
@@ -89,6 +89,7 @@ public class FormatArgumentTypeCheck extends AbstractFormatArgumentCheck {
       case STRING:
         return exprType.isString()
             || exprType.isChar()
+            || exprType.isVariant()
             || ((exprType instanceof PointerType)
                 && ((PointerType) exprType).dereferencedType().isChar());
       default:

--- a/delphi-checks/src/main/resources/org/sonar/l10n/delphi/rules/community-delphi/FormatArgumentType.html
+++ b/delphi-checks/src/main/resources/org/sonar/l10n/delphi/rules/community-delphi/FormatArgumentType.html
@@ -7,7 +7,7 @@
   <li><code>%d</code>, <code>%u</code>, and <code>%x</code> must be an integer value</li>
   <li><code>%e</code>, <code>%f</code>, <code>%g</code>, <code>%n</code>, and <code>%m</code> must be a floating-point value</li>
   <li><code>%p</code> must be a pointer value</li>
-  <li><code>%s</code> must be a string, character, or <code>PChar</code> value</li>
+  <li><code>%s</code> must be a string, character, <code>PChar</code>, or variant value</li>
   <li>Floating-point width and precision must be integer values</li>
 </ul>
 <h2>How to fix it</h2>

--- a/delphi-checks/src/main/resources/org/sonar/l10n/delphi/rules/community-delphi/FormatStringValid.html
+++ b/delphi-checks/src/main/resources/org/sonar/l10n/delphi/rules/community-delphi/FormatStringValid.html
@@ -1,7 +1,9 @@
 <h2>Why is this an issue?</h2>
 <p>
   Passing an invalid format string to <code>System.SysUtils.Format</code>
-  raises a runtime exception.
+  can raise a runtime exception. In addition, even if an exception is not raised
+  <code>Format</code> stops processing the string after the first invalid
+  character, which will result in an unexpected value.
 </p>
 <h2>How to fix it</h2>
 <p>

--- a/delphi-checks/src/test/java/au/com/integradev/delphi/checks/FormatArgumentTypeCheckTest.java
+++ b/delphi-checks/src/test/java/au/com/integradev/delphi/checks/FormatArgumentTypeCheckTest.java
@@ -241,4 +241,61 @@ class FormatArgumentTypeCheckTest {
                 .appendImpl("  ]);"))
         .verifyNoIssues();
   }
+
+  @Test
+  void testCorrectProcedureResultShouldNotAddIssue() {
+    CheckVerifier.newVerifier()
+        .withCheck(new FormatArgumentTypeCheck())
+        .withStandardLibraryUnit(sysUtils())
+        .onFile(
+            new DelphiTestUnitBuilder()
+                .appendImpl("uses System.SysUtils;")
+                .appendImpl("function GetName: string;")
+                .appendImpl("begin")
+                .appendImpl("  Result := 'Ted';")
+                .appendImpl("end;")
+                .appendImpl("initialization")
+                .appendImpl("  Format('I got %s', [")
+                .appendImpl("    GetName")
+                .appendImpl("  ]);"))
+        .verifyNoIssues();
+  }
+
+  @Test
+  void testUnfulfilledCorrectProcedureResultShouldAddIssue() {
+    CheckVerifier.newVerifier()
+        .withCheck(new FormatArgumentTypeCheck())
+        .withStandardLibraryUnit(sysUtils())
+        .onFile(
+            new DelphiTestUnitBuilder()
+                .appendImpl("uses System.SysUtils;")
+                .appendImpl("function GetName(Last: Boolean): string;")
+                .appendImpl("begin")
+                .appendImpl("  Result := 'Ted';")
+                .appendImpl("end;")
+                .appendImpl("initialization")
+                .appendImpl("  Format('I got %s', [")
+                .appendImpl("    GetName // Noncompliant")
+                .appendImpl("  ]);"))
+        .verifyIssues();
+  }
+
+  @Test
+  void testIncorrectProcedureResultShouldAddIssue() {
+    CheckVerifier.newVerifier()
+        .withCheck(new FormatArgumentTypeCheck())
+        .withStandardLibraryUnit(sysUtils())
+        .onFile(
+            new DelphiTestUnitBuilder()
+                .appendImpl("uses System.SysUtils;")
+                .appendImpl("function GetAge: Integer;")
+                .appendImpl("begin")
+                .appendImpl("  Result := 30;")
+                .appendImpl("end;")
+                .appendImpl("initialization")
+                .appendImpl("  Format('I got %s', [")
+                .appendImpl("    GetAge // Noncompliant")
+                .appendImpl("  ]);"))
+        .verifyIssues();
+  }
 }

--- a/delphi-checks/src/test/java/au/com/integradev/delphi/checks/FormatArgumentTypeCheckTest.java
+++ b/delphi-checks/src/test/java/au/com/integradev/delphi/checks/FormatArgumentTypeCheckTest.java
@@ -243,6 +243,43 @@ class FormatArgumentTypeCheckTest {
   }
 
   @Test
+  void testVariantForStringShouldNotAddIssue() {
+    CheckVerifier.newVerifier()
+        .withCheck(new FormatArgumentTypeCheck())
+        .withStandardLibraryUnit(sysUtils())
+        .onFile(
+            new DelphiTestUnitBuilder()
+                .appendImpl("uses System.SysUtils;")
+                .appendImpl("var")
+                .appendImpl("  MyVariant: Variant;")
+                .appendImpl("initialization")
+                .appendImpl("  Format('I got %s', [")
+                .appendImpl("    MyVariant")
+                .appendImpl("  ]);"))
+        .verifyNoIssues();
+  }
+
+  @Test
+  void testVariantForNonStringShouldAddIssue() {
+    CheckVerifier.newVerifier()
+        .withCheck(new FormatArgumentTypeCheck())
+        .withStandardLibraryUnit(sysUtils())
+        .onFile(
+            new DelphiTestUnitBuilder()
+                .appendImpl("uses System.SysUtils;")
+                .appendImpl("var")
+                .appendImpl("  MyVariant: Variant;")
+                .appendImpl("initialization")
+                .appendImpl("  Format('%d %n %x %p', [")
+                .appendImpl("    MyVariant, // Noncompliant")
+                .appendImpl("    MyVariant, // Noncompliant")
+                .appendImpl("    MyVariant, // Noncompliant")
+                .appendImpl("    MyVariant  // Noncompliant")
+                .appendImpl("  ]);"))
+        .verifyIssues();
+  }
+
+  @Test
   void testCorrectProcedureResultShouldNotAddIssue() {
     CheckVerifier.newVerifier()
         .withCheck(new FormatArgumentTypeCheck())


### PR DESCRIPTION
This PR fixes two problems with the FormatArgumentType rule:

* Function invocations returning a value of an acceptable type were incorrectly highlighted as an issue
* Variants were incorrectly not considered an acceptable type for the `%s` format specifier

Bundled with this PR is a minor wording change to the FormatStringValid rule to clarify some Delphi behaviour.