### PR TITLE
Fix symbol table executor failures on include directives with declarations and references

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Parsing errors on `.dpr` files without a top-level `begin`.
 - Symbol table errors on declarations that shared a name with a unit import.
+- Symbol table executor failures on include directives that include multiple symbol declarations or
+  references.
 - The `Copy` intrinsic inferred an incorrect return type for `PChar`, `PAnsiChar`, and variants.
 - The `Concat` intrinsic inferred an incorrect return type for single-character string literals.
 - The `ReadLn` intrinsic was missing the standard input overload.

--- a/delphi-frontend/src/main/java/au/com/integradev/delphi/antlr/ast/token/DelphiTokenImpl.java
+++ b/delphi-frontend/src/main/java/au/com/integradev/delphi/antlr/ast/token/DelphiTokenImpl.java
@@ -83,7 +83,7 @@ public class DelphiTokenImpl implements DelphiToken {
   }
 
   private void calculatePosition() {
-    if (isIncludeToken()) {
+    if (isIncludedToken()) {
       FilePosition insertionPosition = ((IncludeToken) token).getInsertionPosition();
       beginLine = insertionPosition.getBeginLine();
       beginColumn = insertionPosition.getBeginColumn();
@@ -134,7 +134,8 @@ public class DelphiTokenImpl implements DelphiToken {
     return DelphiKeywords.KEYWORDS.contains(tokenType);
   }
 
-  private boolean isIncludeToken() {
+  @Override
+  public boolean isIncludedToken() {
     return token instanceof IncludeToken;
   }
 

--- a/delphi-frontend/src/main/java/au/com/integradev/delphi/antlr/ast/visitors/SonarSymbolTableVisitor.java
+++ b/delphi-frontend/src/main/java/au/com/integradev/delphi/antlr/ast/visitors/SonarSymbolTableVisitor.java
@@ -18,6 +18,7 @@
  */
 package au.com.integradev.delphi.antlr.ast.visitors;
 
+import au.com.integradev.delphi.symbol.SymbolicNode;
 import com.google.common.collect.Lists;
 import java.util.List;
 import javax.annotation.Nullable;
@@ -43,6 +44,12 @@ public class SonarSymbolTableVisitor implements DelphiParserVisitor<NewSymbolTab
 
     Node location = declaration.getNode();
     String symbolUnit = location.getUnitName();
+
+    if (location instanceof SymbolicNode && ((SymbolicNode) location).isIncludedNode()) {
+      // Symbols from include files may overlap with both their own
+      // references and other symbols from the same file.
+      return;
+    }
 
     NewSymbol newSymbol =
         table.newSymbol(

--- a/delphi-frontend/src/main/java/au/com/integradev/delphi/symbol/SymbolicNode.java
+++ b/delphi-frontend/src/main/java/au/com/integradev/delphi/symbol/SymbolicNode.java
@@ -36,6 +36,7 @@ public final class SymbolicNode implements Node {
   private final int beginColumn;
   private final int endColumn;
   private final DelphiScope scope;
+  private final boolean isIncludedNode;
 
   public SymbolicNode(DelphiNode node) {
     this(node, node.getScope());
@@ -50,7 +51,8 @@ public final class SymbolicNode implements Node {
         node.getEndLine(),
         node.getBeginColumn(),
         node.getEndColumn(),
-        scope);
+        scope,
+        node.getFirstToken().isIncludedToken());
   }
 
   private SymbolicNode(
@@ -61,7 +63,8 @@ public final class SymbolicNode implements Node {
       int endLine,
       int beginColumn,
       int endColumn,
-      DelphiScope scope) {
+      DelphiScope scope,
+      boolean isIncludedNode) {
     this.tokenType = tokenType;
     this.tokenIndex = tokenIndex;
     this.image = image;
@@ -70,11 +73,20 @@ public final class SymbolicNode implements Node {
     this.beginColumn = beginColumn;
     this.endColumn = endColumn;
     this.scope = scope;
+    this.isIncludedNode = isIncludedNode;
   }
 
   public static SymbolicNode imaginary(String image, DelphiScope scope) {
     return new SymbolicNode(
-        DelphiTokenType.INVALID, IMAGINARY_TOKEN_INDEX.incrementAndGet(), image, 0, 0, 0, 0, scope);
+        DelphiTokenType.INVALID,
+        IMAGINARY_TOKEN_INDEX.incrementAndGet(),
+        image,
+        0,
+        0,
+        0,
+        0,
+        scope,
+        false);
   }
 
   public static SymbolicNode fromRange(String image, DelphiNode begin, DelphiNode end) {
@@ -86,7 +98,8 @@ public final class SymbolicNode implements Node {
         end.getEndLine(),
         begin.getBeginColumn(),
         end.getEndColumn(),
-        begin.getScope());
+        begin.getScope(),
+        begin.getFirstToken().isIncludedToken() || end.getFirstToken().isIncludedToken());
   }
 
   @Override
@@ -127,6 +140,10 @@ public final class SymbolicNode implements Node {
   @Override
   public DelphiScope getScope() {
     return scope;
+  }
+
+  public boolean isIncludedNode() {
+    return isIncludedNode;
   }
 
   @Override

--- a/delphi-frontend/src/main/java/org/sonar/plugins/communitydelphi/api/token/DelphiToken.java
+++ b/delphi-frontend/src/main/java/org/sonar/plugins/communitydelphi/api/token/DelphiToken.java
@@ -46,4 +46,6 @@ public interface DelphiToken {
   int getIndex();
 
   DelphiTokenType getType();
+
+  boolean isIncludedToken();
 }

--- a/delphi-frontend/src/test/java/au/com/integradev/delphi/executor/DelphiSymbolTableExecutorTest.java
+++ b/delphi-frontend/src/test/java/au/com/integradev/delphi/executor/DelphiSymbolTableExecutorTest.java
@@ -1017,6 +1017,13 @@ class DelphiSymbolTableExecutorTest {
   }
 
   @Test
+  void testIncludes() {
+    execute("includes/Includes.pas");
+    Collection<TextRange> references = context.referencesForSymbolAt(componentKey, 5, 0);
+    assertThat(references).isNull();
+  }
+
+  @Test
   void testSimpleAttribute() {
     execute("attributes/SimpleAttribute.pas");
     verifyUsages(6, 2, reference(9, 3));

--- a/delphi-frontend/src/test/java/au/com/integradev/delphi/symbol/scope/UnknownScopeImplTest.java
+++ b/delphi-frontend/src/test/java/au/com/integradev/delphi/symbol/scope/UnknownScopeImplTest.java
@@ -34,6 +34,7 @@ import org.sonar.plugins.communitydelphi.api.ast.DelphiNode;
 import org.sonar.plugins.communitydelphi.api.symbol.NameOccurrence;
 import org.sonar.plugins.communitydelphi.api.symbol.declaration.NameDeclaration;
 import org.sonar.plugins.communitydelphi.api.symbol.declaration.VariableNameDeclaration;
+import org.sonar.plugins.communitydelphi.api.token.DelphiToken;
 
 class UnknownScopeImplTest {
   private final UnknownScopeImpl unknownScope = UnknownScopeImpl.instance();
@@ -127,8 +128,13 @@ class UnknownScopeImplTest {
   }
 
   private static NameOccurrence makeNameOccurrence() {
+    DelphiToken token = mock(DelphiToken.class);
+    when(token.isIncludedToken()).thenReturn(false);
+
     DelphiNode location = mock(DelphiNode.class);
     when(location.getScope()).thenReturn(unknownScope());
+    when(location.getFirstToken()).thenReturn(token);
+
     return new NameOccurrenceImpl(location, "Image");
   }
 }

--- a/delphi-frontend/src/test/resources/au/com/integradev/delphi/symbol/includes/Includes.pas
+++ b/delphi-frontend/src/test/resources/au/com/integradev/delphi/symbol/includes/Includes.pas
@@ -1,0 +1,11 @@
+unit Includes;
+
+interface
+
+{$I MyInclude.inc}
+
+implementation
+
+begin
+  WriteLn(CFoo);
+end.

--- a/delphi-frontend/src/test/resources/au/com/integradev/delphi/symbol/includes/MyInclude.inc
+++ b/delphi-frontend/src/test/resources/au/com/integradev/delphi/symbol/includes/MyInclude.inc
@@ -1,0 +1,4 @@
+const
+  CFoo = 'hello world';
+
+procedure BarProc(Msg: string = CFoo);


### PR DESCRIPTION
This PR fixes #174 by excluding all symbols that are declared in an include file from the Sonar symbol table. There are two properties of symbols declared in include files that make them inappropriate to add to the Sonar symbol table:

- If more than one symbol is declared, both symbol declarations have the same text range, which is problematic as Sonar uses the declaration text range as the unique key for the symbol.
- If a symbol is both declared and referenced in the include file, an exception is raised because both the declaration and reference are overlapping.

Unfortunately this means that symbols declared in include files will not have symbol table information associated with them in the SonarQube UI, but in the grand scheme of things this isn't too much of a problem.

Note that this affects the symbol table that is reported to Sonar for use in the UI, **not** the symbol tables used by SonarDelphi itself for name resolution. Those symbol tables have full support for symbols in include files.