### PR TITLE
Improve rule metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ SonarDelphi understands what your code *means*, paving the way for powerful rule
    * [Redundant casts should not be used](delphi-checks/src/main/java/au/com/integradev/delphi/checks/RedundantCastCheck.java)
    * [Platform-dependent casts should not be used](delphi-checks/src/main/java/au/com/integradev/delphi/checks/PlatformDependentCastCheck.java)
    * [Unicode types should not be cast to ANSI types](delphi-checks/src/main/java/au/com/integradev/delphi/checks/UnicodeToAnsiCastCheck.java)
+   * ['Format' calls should be supplied arguments of the correct type](delphi-checks/src/main/java/au/com/integradev/delphi/checks/FormatArgumentTypeCheck.java)
    * Your own custom rules to [enforce a naming convention for descendants of specific types](delphi-checks/src/main/java/au/com/integradev/delphi/checks/InheritedTypeNameCheck.java)
    * Your own custom rules to forbid usage of
      [types](delphi-checks/src/main/java/au/com/integradev/delphi/checks/ForbiddenTypeCheck.java),

--- a/delphi-checks/src/main/resources/org/sonar/l10n/delphi/rules/community-delphi/AddressOfCharacterData.json
+++ b/delphi-checks/src/main/resources/org/sonar/l10n/delphi/rules/community-delphi/AddressOfCharacterData.json
@@ -1,5 +1,5 @@
 {
-  "title": "The first character in a string should not be addressed by index.",
+  "title": "The first character in a string should not be addressed by index",
   "type": "BUG",
   "status": "ready",
   "remediation": {

--- a/delphi-checks/src/main/resources/org/sonar/l10n/delphi/rules/community-delphi/BeginEndRequired.json
+++ b/delphi-checks/src/main/resources/org/sonar/l10n/delphi/rules/community-delphi/BeginEndRequired.json
@@ -1,5 +1,5 @@
 {
-  "title": "\u0027begin\u0027..\u0027end\u0027 should always be used",
+  "title": "'begin'..'end' should always be used",
   "type": "CODE_SMELL",
   "status": "ready",
   "remediation": {

--- a/delphi-checks/src/main/resources/org/sonar/l10n/delphi/rules/community-delphi/CharacterToCharacterPointerCast.json
+++ b/delphi-checks/src/main/resources/org/sonar/l10n/delphi/rules/community-delphi/CharacterToCharacterPointerCast.json
@@ -1,5 +1,5 @@
 {
-  "title": "Character types should not be cast to Character Pointer types",
+  "title": "Character types should not be cast to character pointer types",
   "type": "BUG",
   "status": "ready",
   "remediation": {

--- a/delphi-checks/src/main/resources/org/sonar/l10n/delphi/rules/community-delphi/ConstructorWithoutInherited.json
+++ b/delphi-checks/src/main/resources/org/sonar/l10n/delphi/rules/community-delphi/ConstructorWithoutInherited.json
@@ -1,5 +1,5 @@
 {
-  "title": "Constructors should contain an \u0027inherited\u0027 statement",
+  "title": "Constructors should contain an 'inherited' statement",
   "type": "BUG",
   "status": "ready",
   "remediation": {

--- a/delphi-checks/src/main/resources/org/sonar/l10n/delphi/rules/community-delphi/DestructorWithoutInherited.json
+++ b/delphi-checks/src/main/resources/org/sonar/l10n/delphi/rules/community-delphi/DestructorWithoutInherited.json
@@ -1,5 +1,5 @@
 {
-  "title": "Destructors should contain an \u0027inherited\u0027 statement",
+  "title": "Destructors should contain an 'inherited' statement",
   "type": "BUG",
   "status": "ready",
   "remediation": {

--- a/delphi-checks/src/main/resources/org/sonar/l10n/delphi/rules/community-delphi/EmptyFinallyBlock.json
+++ b/delphi-checks/src/main/resources/org/sonar/l10n/delphi/rules/community-delphi/EmptyFinallyBlock.json
@@ -1,5 +1,5 @@
 {
-  "title": "\u0027finally\u0027 blocks should not be empty",
+  "title": "'finally' blocks should not be empty",
   "type": "CODE_SMELL",
   "status": "ready",
   "remediation": {

--- a/delphi-checks/src/main/resources/org/sonar/l10n/delphi/rules/community-delphi/ExplicitTObjectInheritance.json
+++ b/delphi-checks/src/main/resources/org/sonar/l10n/delphi/rules/community-delphi/ExplicitTObjectInheritance.json
@@ -1,5 +1,5 @@
 {
-  "title": "Top-level classes should explicitly inherit from TObject",
+  "title": "Top-level classes should explicitly inherit from 'TObject'",
   "type": "CODE_SMELL",
   "status": "ready",
   "remediation": {

--- a/delphi-checks/src/main/resources/org/sonar/l10n/delphi/rules/community-delphi/FormatArgumentCount.html
+++ b/delphi-checks/src/main/resources/org/sonar/l10n/delphi/rules/community-delphi/FormatArgumentCount.html
@@ -4,10 +4,19 @@
   raises a runtime exception.
 </p>
 <p>
-  Generally speaking, the number of arguments should exactly match the number of format specifiers
-  in the string. <code>Format</code> allows you to format the same argument multiple times using
-  index specifiers, in which case the number of arguments may be more difficult to determine.
+  Typically, the number of arguments should exactly match the number of format specifiers
+  in the string. For some complex cases, a different number of arguments is required
 </p>
+<ul>
+  <li>
+    Width and precision wildcards in floating point format specifiers
+    (e.g. <code>%*.*f</code>) require corresponding arguments
+  </li>
+  <li>
+    Format specifiers with a specified index (e.g. <code>%1:s</code>)
+    can reuse existing arguments or require additional arguments
+  </li>
+</ul>
 <h2>How to fix it</h2>
 <p>
   Ensure that the arguments to the <code>Format</code> call match the specifiers in the format
@@ -16,7 +25,7 @@
 <pre data-diff-id="1" data-diff-type="noncompliant">
 Format('%s (class %d) got %.*f percent on the test.', ['Bob', 74.599]);
 </pre>
-<pre data-diff-id="1" data-diff-type="noncompliant">
+<pre data-diff-id="1" data-diff-type="compliant">
 Format('%s (class %d) got %.*f percent on the test.', ['Bob', 6, 2, 74.599]);
 </pre>
 <h2>Resources</h2>

--- a/delphi-checks/src/main/resources/org/sonar/l10n/delphi/rules/community-delphi/FormatArgumentType.json
+++ b/delphi-checks/src/main/resources/org/sonar/l10n/delphi/rules/community-delphi/FormatArgumentType.json
@@ -1,5 +1,5 @@
 {
-  "title": "Format argument types should match the corresponding format specifier",
+  "title": "'Format' calls should be supplied arguments of the correct type",
   "type": "BUG",
   "status": "ready",
   "remediation": {

--- a/delphi-checks/src/main/resources/org/sonar/l10n/delphi/rules/community-delphi/FreeAndNilTObject.json
+++ b/delphi-checks/src/main/resources/org/sonar/l10n/delphi/rules/community-delphi/FreeAndNilTObject.json
@@ -1,5 +1,5 @@
 {
-  "title": "FreeAndNil must only be passed an instance of a TObject descendant",
+  "title": "'FreeAndNil' must only be passed an instance of a 'TObject' descendant",
   "type": "BUG",
   "status": "ready",
   "remediation": {

--- a/delphi-checks/src/main/resources/org/sonar/l10n/delphi/rules/community-delphi/GotoStatement.json
+++ b/delphi-checks/src/main/resources/org/sonar/l10n/delphi/rules/community-delphi/GotoStatement.json
@@ -1,5 +1,5 @@
 {
-  "title": "\u0027goto\u0027 statements should not be used",
+  "title": "'goto' statements should not be used",
   "type": "CODE_SMELL",
   "status": "ready",
   "remediation": {

--- a/delphi-checks/src/main/resources/org/sonar/l10n/delphi/rules/community-delphi/IfThenShortCircuit.json
+++ b/delphi-checks/src/main/resources/org/sonar/l10n/delphi/rules/community-delphi/IfThenShortCircuit.json
@@ -1,5 +1,5 @@
 {
-  "title": "IfThen should not be used like a short-circuit operator",
+  "title": "'IfThen' should not be used like a short-circuit operator",
   "type": "BUG",
   "status": "ready",
   "remediation": {

--- a/delphi-checks/src/main/resources/org/sonar/l10n/delphi/rules/community-delphi/ImplicitDefaultEncoding.json
+++ b/delphi-checks/src/main/resources/org/sonar/l10n/delphi/rules/community-delphi/ImplicitDefaultEncoding.json
@@ -1,5 +1,5 @@
 {
-  "title": "Routines implicitly using TEncoding.Default should not be used",
+  "title": "Routines implicitly using 'TEncoding.Default' should not be used",
   "type": "CODE_SMELL",
   "status": "ready",
   "remediation": {

--- a/delphi-checks/src/main/resources/org/sonar/l10n/delphi/rules/community-delphi/IndexLastListElement.html
+++ b/delphi-checks/src/main/resources/org/sonar/l10n/delphi/rules/community-delphi/IndexLastListElement.html
@@ -7,9 +7,20 @@
 
 <h2>How to fix it</h2>
 <p>
-  Use <code>TList.Last</code> instead of indexing with <code>Count - 1</code>.
+  Use <code>TList.Last</code> instead of indexing with <code>Count - 1</code>:
 </p>
-
+<pre data-diff-id="1" data-diff-type="noncompliant">
+procedure PrintMostRecent(MyList: TList<Integer>);
+begin
+  WriteLn(MyList[MyList.Count - 1]);
+end;
+</pre>
+<pre data-diff-id="1" data-diff-type="compliant">
+procedure PrintMostRecent(MyList: TList<Integer>);
+begin
+  WriteLn(MyList.Last);
+end;
+</pre>
 <ul>
   <li>
     <a href="https://docwiki.embarcadero.com/Libraries/en/Special:Search/System.Generics.Collections.TList.Last">

--- a/delphi-checks/src/main/resources/org/sonar/l10n/delphi/rules/community-delphi/IndexLastListElement.json
+++ b/delphi-checks/src/main/resources/org/sonar/l10n/delphi/rules/community-delphi/IndexLastListElement.json
@@ -1,5 +1,5 @@
 {
-  "title": "The last element in a `TList` descendant should be retrieved with the `Last` method.",
+  "title": "The last element in a `TList` descendant should be retrieved with the `Last` method",
   "type": "CODE_SMELL",
   "status": "ready",
   "remediation": {

--- a/delphi-checks/src/main/resources/org/sonar/l10n/delphi/rules/community-delphi/IndexLastListElement.json
+++ b/delphi-checks/src/main/resources/org/sonar/l10n/delphi/rules/community-delphi/IndexLastListElement.json
@@ -1,5 +1,5 @@
 {
-  "title": "The last element in a `TList` descendant should be retrieved with the `Last` method",
+  "title": "The last element in a 'TList' descendant should be retrieved with the 'Last' method",
   "type": "CODE_SMELL",
   "status": "ready",
   "remediation": {

--- a/delphi-checks/src/main/resources/org/sonar/l10n/delphi/rules/community-delphi/NilComparison.json
+++ b/delphi-checks/src/main/resources/org/sonar/l10n/delphi/rules/community-delphi/NilComparison.json
@@ -1,5 +1,5 @@
 {
-  "title": "Nil checks should be performed with Assigned",
+  "title": "Nil checks should be performed with 'Assigned'",
   "type": "CODE_SMELL",
   "status": "ready",
   "remediation": {

--- a/delphi-checks/src/main/resources/org/sonar/l10n/delphi/rules/community-delphi/NoSonar.json
+++ b/delphi-checks/src/main/resources/org/sonar/l10n/delphi/rules/community-delphi/NoSonar.json
@@ -1,5 +1,5 @@
 {
-  "title": "Track uses of \"NOSONAR\" comments",
+  "title": "Track uses of 'NOSONAR' comments",
   "type": "CODE_SMELL",
   "status": "ready",
   "remediation": {

--- a/delphi-checks/src/main/resources/org/sonar/l10n/delphi/rules/community-delphi/StringListDuplicates.json
+++ b/delphi-checks/src/main/resources/org/sonar/l10n/delphi/rules/community-delphi/StringListDuplicates.json
@@ -1,5 +1,5 @@
 {
-  "title": "TStringLists should be sorted when setting Duplicates",
+  "title": "'TStringList' objects should be sorted when setting 'Duplicates'",
   "type": "BUG",
   "status": "ready",
   "remediation": {

--- a/delphi-checks/src/main/resources/org/sonar/l10n/delphi/rules/community-delphi/WithStatement.json
+++ b/delphi-checks/src/main/resources/org/sonar/l10n/delphi/rules/community-delphi/WithStatement.json
@@ -1,5 +1,5 @@
 {
-  "title": "\u0027with\u0027 statements should not be used",
+  "title": "'with' statements should not be used",
   "type": "CODE_SMELL",
   "status": "ready",
   "remediation": {


### PR DESCRIPTION
This PR contains a number of miscellaneous metadata improvements:

- Rewords FormatArgumentType title to be more consistent with FormatArgumentCount
- Adds a reference to FormatArgumentType to the README
- Removes `.` from the end of the IndexLastListElement and AddressOfCharacterData rule titles
- Adds an example to IndexLastListElement
- Fix an incorrect diff and do partial rewording in FormatArgumentCount