### PR TITLE
Enable on-demand plugin downloading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Support for on-demand plugin downloading, which is being
+  [introduced in SonarQube 10.4](https://community.sonarsource.com/t/the-sonarscanners-download-only-required-3rd-party-plugins/108156).
 - Support for the `LLVM` symbol, which is defined on LLVM-based toolchains from Delphi 12 onward.
 - Support for the `IOSSIMULATOR` symbol, which is defined on the `DCCIOSSIMARM64` toolchain.
 - `FormDfm` analysis rule, which flags VCL forms/frames that lack a `.dfm` resource.

--- a/docs/CUSTOM_RULES_101.md
+++ b/docs/CUSTOM_RULES_101.md
@@ -62,6 +62,7 @@ In the code snippet below, there's a couple of important configuration propertie
 * `<pluginClass>` provides the **entry point of the plugin**. You must change this configuration if
 you rename or move the class implementing `org.sonar.api.Plugin`.
 * `<pluginApiMinVersion>` guarantees compatibility with the plugin API version you target.
+* `<requiredForLanguages>` indicates which language your custom plugin will be available.
 
 ```xml
 <plugin>
@@ -76,6 +77,7 @@ you rename or move the class implementing `org.sonar.api.Plugin`.
     <skipDependenciesPackaging>true</skipDependenciesPackaging>
     <pluginApiMinVersion>9.14.0.375</pluginApiMinVersion>
     <requirePlugins>communitydelphi:${sonar.delphi.version}</requirePlugins>
+    <requiredForLanguages>delphi</requiredForLanguages>
   </configuration>
 </plugin>
 ```

--- a/docs/delphi-custom-rules-example/pom.xml
+++ b/docs/delphi-custom-rules-example/pom.xml
@@ -137,6 +137,7 @@
           <skipDependenciesPackaging>true</skipDependenciesPackaging>
           <pluginApiMinVersion>9.14.0.375</pluginApiMinVersion>
           <requirePlugins>communitydelphi:${sonar.delphi.version}</requirePlugins>
+          <requiredForLanguages>delphi</requiredForLanguages>
         </configuration>
       </plugin>
       <plugin>

--- a/sonar-delphi-plugin/pom.xml
+++ b/sonar-delphi-plugin/pom.xml
@@ -98,6 +98,7 @@
           <pluginName>Delphi</pluginName>
           <skipDependenciesPackaging>true</skipDependenciesPackaging>
           <pluginClass>au.com.integradev.delphi.DelphiPlugin</pluginClass>
+          <requiredForLanguages>delphi</requiredForLanguages>
           <pluginApiMinVersion>9.14.0.375</pluginApiMinVersion>
           <jreMinVersion>11</jreMinVersion>
         </configuration>


### PR DESCRIPTION
This PR adds support for the new on-demand plugin loading feature in SonarQube 10.4.

See: [The SonarScanners download only required 3rd-party plugins](https://community.sonarsource.com/t/the-sonarscanners-download-only-required-3rd-party-plugins/108156)