### PR TITLE
Support ampersand-prefixed number literals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Support for numeric literals prefixed by ampersands.
+- Support for identifiers prefixed by more than 2 ampersands.
+
 ### Fixed
 
 - Static char arrays weren't accepted for `'%s'` in `FormatArgumentType`.

--- a/delphi-checks/src/main/java/au/com/integradev/delphi/checks/DigitGroupingCheck.java
+++ b/delphi-checks/src/main/java/au/com/integradev/delphi/checks/DigitGroupingCheck.java
@@ -29,7 +29,8 @@ import org.sonar.plugins.communitydelphi.api.token.DelphiToken;
 @Rule(key = "DigitGrouping")
 public class DigitGroupingCheck extends DelphiCheck {
 
-  private static final Pattern VALID_DEC_UNDERSCORE_PATTERN = Pattern.compile("\\d{1,3}(_\\d{3})*");
+  private static final Pattern VALID_DEC_UNDERSCORE_PATTERN =
+      Pattern.compile("&*\\d{1,3}(_\\d{3})*");
   private static final Pattern VALID_DEC_FLOAT_UNDERSCORE_PATTERN =
       Pattern.compile(VALID_DEC_UNDERSCORE_PATTERN.pattern() + "\\..*");
 

--- a/delphi-checks/src/test/java/au/com/integradev/delphi/checks/DigitGroupingCheckTest.java
+++ b/delphi-checks/src/test/java/au/com/integradev/delphi/checks/DigitGroupingCheckTest.java
@@ -36,6 +36,10 @@ class DigitGroupingCheckTest {
         "$ABC_DEF",
         "$ABC_DE_F",
         "%1_001_01",
+        "&1_000_00",
+        "&&&1_000_00",
+        "&10_00.00",
+        "&&&10_00.00",
       })
   void testNonStandardGroupingShouldAddIssue(String actual) {
     CheckVerifier.newVerifier()
@@ -62,6 +66,10 @@ class DigitGroupingCheckTest {
         "%1_01_01",
         "%10_101",
         "%10_1010",
+        "&100_000",
+        "&&&100_000",
+        "&1_000.0_0",
+        "&&&1_000.0_0",
       })
   void testStandardGroupingShouldNotAddIssue(String actual) {
     CheckVerifier.newVerifier()

--- a/delphi-frontend/src/main/antlr3/au/com/integradev/delphi/antlr/Delphi.g
+++ b/delphi-frontend/src/main/antlr3/au/com/integradev/delphi/antlr/Delphi.g
@@ -862,8 +862,6 @@ dispIDDirective              : 'dispid' expression
 // General
 //----------------------------------------------------------------------------
 ident                        : TkIdentifier
-                             | '&'! identifierOrKeyword
-                             | '&' '&' identifierOrKeyword -> ^({combineLastNTokens(2)})
                              | keywordsUsedAsNames -> ^({changeTokenType(TkIdentifier)})
                              ;
 identifierOrKeyword          : TkIdentifier
@@ -1090,7 +1088,7 @@ DEREFERENCE          : '^'  ;
 ADDRESS              : '@'  ;
 DOT                  : '.'  ;
 DOT_DOT              : '..' ;
-AMPERSAND            : '&'  ;
+AMPERSAND            : '@AMPERSAND@'  ;
 
 //****************************
 // Imaginary tokens
@@ -1203,11 +1201,11 @@ TkArrayIndices          : 'ARRAY_INDICES'
 //****************************
 // Tokens
 //****************************
-TkIdentifier            : (Alpha | '_') (Alpha | FullWidthNumeral | Digit | '_')*
+TkIdentifier            : '&'* (Alpha | '_') (Alpha | FullWidthNumeral | Digit | '_')*
                         ;
                         // We use a lookahead here to avoid lexer failures on range operations like '1..2'
                         // or record helper invocations on Integer literals
-TkIntNumber             : DigitSeq (
+TkIntNumber             : '&'* DigitSeq (
                             {input.LA(1) != '.' || Character.isDigit(input.LA(2))}? =>
                               (
                                 '.' DigitSeq

--- a/delphi-frontend/src/main/java/au/com/integradev/delphi/antlr/ast/node/IdentifierNodeImpl.java
+++ b/delphi-frontend/src/main/java/au/com/integradev/delphi/antlr/ast/node/IdentifierNodeImpl.java
@@ -20,9 +20,12 @@ package au.com.integradev.delphi.antlr.ast.node;
 
 import au.com.integradev.delphi.antlr.ast.visitors.DelphiParserVisitor;
 import org.antlr.runtime.Token;
+import org.apache.commons.lang3.StringUtils;
 import org.sonar.plugins.communitydelphi.api.ast.IdentifierNode;
 
 public final class IdentifierNodeImpl extends DelphiNodeImpl implements IdentifierNode {
+  private String normalizedImage = null;
+
   public IdentifierNodeImpl(Token token) {
     super(token);
   }
@@ -30,5 +33,13 @@ public final class IdentifierNodeImpl extends DelphiNodeImpl implements Identifi
   @Override
   public <T> T accept(DelphiParserVisitor<T> visitor, T data) {
     return visitor.visit(this, data);
+  }
+
+  @Override
+  public String getImage() {
+    if (normalizedImage == null) {
+      normalizedImage = StringUtils.removeStart(super.getImage(), "&");
+    }
+    return normalizedImage;
   }
 }

--- a/delphi-frontend/src/main/java/au/com/integradev/delphi/antlr/ast/node/IntegerLiteralNodeImpl.java
+++ b/delphi-frontend/src/main/java/au/com/integradev/delphi/antlr/ast/node/IntegerLiteralNodeImpl.java
@@ -56,7 +56,7 @@ public final class IntegerLiteralNodeImpl extends DelphiNodeImpl implements Inte
 
   @Override
   public String getDigits() {
-    String digits = getImage();
+    String digits = StringUtils.stripStart(getImage(), "&");
     digits = StringUtils.remove(digits, '_');
     switch (getTokenType()) {
       case HEX_NUMBER:

--- a/delphi-frontend/src/main/java/au/com/integradev/delphi/antlr/ast/node/RealLiteralNodeImpl.java
+++ b/delphi-frontend/src/main/java/au/com/integradev/delphi/antlr/ast/node/RealLiteralNodeImpl.java
@@ -38,11 +38,15 @@ public final class RealLiteralNodeImpl extends DelphiNodeImpl implements RealLit
 
   @Override
   public BigDecimal getValue() {
-    return new BigDecimal(StringUtils.remove(getImage(), '_'));
+    return new BigDecimal(getNormalizedImage());
   }
 
   @Override
   public Type getType() {
     return getTypeFactory().getIntrinsic(IntrinsicType.EXTENDED);
+  }
+
+  private String getNormalizedImage() {
+    return StringUtils.remove(StringUtils.stripStart(getImage(), "&"), "_");
   }
 }

--- a/delphi-frontend/src/test/java/au/com/integradev/delphi/antlr/GrammarTest.java
+++ b/delphi-frontend/src/test/java/au/com/integradev/delphi/antlr/GrammarTest.java
@@ -263,6 +263,11 @@ class GrammarTest {
   }
 
   @Test
+  void testAmpersandNumericLiterals() {
+    assertParsed("AmpersandNumericLiterals.pas");
+  }
+
+  @Test
   void testEmptyFileShouldThrow() {
     assertThatThrownBy(() -> parse("EmptyFile.pas"))
         .isInstanceOf(DelphiFileConstructionException.class);

--- a/delphi-frontend/src/test/resources/au/com/integradev/delphi/grammar/AmpersandNumericLiterals.pas
+++ b/delphi-frontend/src/test/resources/au/com/integradev/delphi/grammar/AmpersandNumericLiterals.pas
@@ -1,0 +1,13 @@
+unit AmpersandNumericLiterals;
+
+interface
+
+const
+  CAndInt = &12345;
+  CAndNInt = &&&&12345;
+  CAndReal = &123.45;
+  CAndNReal = &&&&123.45;
+
+implementation
+
+end.


### PR DESCRIPTION
Fixes #173 by accepting and discarding any ampersands before a number literal.

Some caveats:

- This occurs during parsing, not lexing (which might be more correct). This is because our ampersand handling for identifiers is in the parser. 
- This grammar will technically support whitespace between the ampersands and the number literals. I don't think this should be an issue as there's no ambiguity with any other language constructs.