### PR TITLE
Accept static char arrays for '%s' in FormatArgumentType

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Static char arrays weren't accepted for `'%s'` in `FormatArgumentType`.
+
 ## [1.2.0] - 2024-02-02
 
 ### Added

--- a/delphi-checks/src/main/java/au/com/integradev/delphi/checks/FormatArgumentTypeCheck.java
+++ b/delphi-checks/src/main/java/au/com/integradev/delphi/checks/FormatArgumentTypeCheck.java
@@ -29,6 +29,7 @@ import org.sonar.plugins.communitydelphi.api.ast.ArrayConstructorNode;
 import org.sonar.plugins.communitydelphi.api.ast.ExpressionNode;
 import org.sonar.plugins.communitydelphi.api.check.DelphiCheckContext;
 import org.sonar.plugins.communitydelphi.api.type.Type;
+import org.sonar.plugins.communitydelphi.api.type.Type.CollectionType;
 import org.sonar.plugins.communitydelphi.api.type.Type.PointerType;
 import org.sonar.plugins.communitydelphi.api.type.Type.ProceduralType;
 
@@ -87,11 +88,14 @@ public class FormatArgumentTypeCheck extends AbstractFormatArgumentCheck {
       case POINTER:
         return exprType.isPointer();
       case STRING:
-        return exprType.isString()
-            || exprType.isChar()
-            || exprType.isVariant()
-            || ((exprType instanceof PointerType)
-                && ((PointerType) exprType).dereferencedType().isChar());
+        if (exprType instanceof CollectionType) {
+          CollectionType collection = (CollectionType) exprType;
+          return collection.isFixedArray() && collection.elementType().isChar();
+        } else if (exprType instanceof PointerType) {
+          return ((PointerType) exprType).dereferencedType().isChar();
+        } else {
+          return exprType.isString() || exprType.isChar() || exprType.isVariant();
+        }
       default:
         throw new AssertionError("Unknown format specifier type");
     }

--- a/delphi-checks/src/main/resources/org/sonar/l10n/delphi/rules/community-delphi/FormatArgumentType.html
+++ b/delphi-checks/src/main/resources/org/sonar/l10n/delphi/rules/community-delphi/FormatArgumentType.html
@@ -7,7 +7,7 @@
   <li><code>%d</code>, <code>%u</code>, and <code>%x</code> must be an integer value</li>
   <li><code>%e</code>, <code>%f</code>, <code>%g</code>, <code>%n</code>, and <code>%m</code> must be a floating-point value</li>
   <li><code>%p</code> must be a pointer value</li>
-  <li><code>%s</code> must be a string, character, <code>PChar</code>, or variant value</li>
+  <li><code>%s</code> must be a string, character, <code>PChar</code>, static array of <code>Char</code>, or variant value</li>
   <li>Floating-point width and precision must be integer values</li>
 </ul>
 <h2>How to fix it</h2>
@@ -16,7 +16,7 @@
   string:
 </p>
 <pre data-diff-id="1" data-diff-type="noncompliant">
-Format('%d got %.*f percent on the test.', ['Bob', 74.599]);
+Format('%d got %.2f percent on the test.', ['Bob', 74.599]);
 </pre>
 <pre data-diff-id="1" data-diff-type="compliant">
 Format('%s got %.2f percent on the test.', ['Bob', 74.599]);

--- a/delphi-checks/src/test/java/au/com/integradev/delphi/checks/FormatArgumentTypeCheckTest.java
+++ b/delphi-checks/src/test/java/au/com/integradev/delphi/checks/FormatArgumentTypeCheckTest.java
@@ -243,6 +243,40 @@ class FormatArgumentTypeCheckTest {
   }
 
   @Test
+  void testStaticCharArrayForStringShouldNotAddIssue() {
+    CheckVerifier.newVerifier()
+        .withCheck(new FormatArgumentTypeCheck())
+        .withStandardLibraryUnit(sysUtils())
+        .onFile(
+            new DelphiTestUnitBuilder()
+                .appendImpl("uses System.SysUtils;")
+                .appendImpl("var")
+                .appendImpl("  MyArr: array[0..4] of Char = ('a', 'b', 'c', 'd', #0);")
+                .appendImpl("initialization")
+                .appendImpl("  Format('I got %s', [")
+                .appendImpl("    MyArr")
+                .appendImpl("  ]);"))
+        .verifyNoIssues();
+  }
+
+  @Test
+  void testDynamicCharArrayForStringShouldAddIssue() {
+    CheckVerifier.newVerifier()
+        .withCheck(new FormatArgumentTypeCheck())
+        .withStandardLibraryUnit(sysUtils())
+        .onFile(
+            new DelphiTestUnitBuilder()
+                .appendImpl("uses System.SysUtils;")
+                .appendImpl("var")
+                .appendImpl("  MyArr: array of Char = ['a', 'b', 'c', 'd', #0];")
+                .appendImpl("initialization")
+                .appendImpl("  Format('I got %s', [")
+                .appendImpl("    MyArr // Noncompliant")
+                .appendImpl("  ]);"))
+        .verifyIssues();
+  }
+
+  @Test
   void testVariantForStringShouldNotAddIssue() {
     CheckVerifier.newVerifier()
         .withCheck(new FormatArgumentTypeCheck())


### PR DESCRIPTION
`Format`'s (undocumented) behaviour seems to be that static char arrays are allowed as an argument to the `%s` (string) specifier, where they are interpreted as null-terminated strings. Dynamic char arrays do not have this ability, but can be printed by casting to `PChar` instead.

This PR updates FormatArgumentType to match this behaviour.