### PR TITLE
Bump versions of workflow dependencies

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,7 +21,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: Setup Java
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           java-version: '17'
           distribution: 'temurin'
@@ -29,7 +29,7 @@ jobs:
       - name: Maven Install
         run: mvn clean install -Pci --batch-mode --no-transfer-progress
       - name: Upload plugin jar
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: sonar-delphi-plugin-jar
           path: sonar-delphi-plugin/target/sonar-delphi-plugin-*.jar

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -14,7 +14,7 @@ jobs:
   check-format:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: axel-op/googlejavaformat-action@v3
         with:
           version: 1.18.1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,7 +33,7 @@ jobs:
         uses: battila7/get-version-action@v2
       - name: Get changelog release info
         id: changelog
-        uses: release-flow/keep-a-changelog-action@v2
+        uses: release-flow/keep-a-changelog-action@v3
         with:
           command: query
           version: ${{ steps.get-version.outputs.version-without-v }}

--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -13,13 +13,13 @@ jobs:
         with:
           fetch-depth: 0
       - name: Setup Java
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           java-version: '17'
           distribution: 'temurin'
           cache: maven
       - name: Cache SonarCloud packages
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ~/.sonar/cache
           key: ${{ runner.os }}-sonar


### PR DESCRIPTION
This PR fixes a bunch of CI warnings due to Node 16 being deprecated.