### PR TITLE
Remove dependency on `battila7/get-version-action`

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,7 +30,7 @@ jobs:
           MAVEN_GPG_PASSPHRASE: ${{ secrets.MAVEN_GPG_PASSPHRASE }}
       - name: Get version from tag
         id: get-version
-        uses: battila7/get-version-action@v2
+        run: echo "version-without-v=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
       - name: Get changelog release info
         id: changelog
         uses: release-flow/keep-a-changelog-action@v2


### PR DESCRIPTION
This PR fixes warnings in the release workflow by removing our dependency on `battila7/get-version-action`.

The `get-version-action` action has a couple of issues:
- It uses the deprecated `set-output` (https://github.com/battila7/get-version-action/issues/22)
- It runs on the deprecated Node 12 (https://github.com/battila7/get-version-action/issues/18)

This action doesn't do much though, and our use-case can be trivially satisfied using `GITHUB_REF_NAME`.