### PR TITLE
Bump Orchestrator to v4.7.1.1872

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -115,7 +115,7 @@
     <sonarqube.version>9.9.0.65466</sonarqube.version>
     <sonar-plugin-api.version>10.1.0.809</sonar-plugin-api.version>
     <sonar-analyzer-commons.version>2.7.0.1482</sonar-analyzer-commons.version>
-    <sonar-orchestrator.version>4.7.0.1861</sonar-orchestrator.version>
+    <sonar-orchestrator.version>4.7.1.1872</sonar-orchestrator.version>
     <antlr-runtime.version>3.5.3</antlr-runtime.version>
     <commons-text.version>1.10.0</commons-text.version>
     <jdom.version>2.0.6.1</jdom.version>


### PR DESCRIPTION
SonarSource has released a patch to fix an issue where Orchestrator was pulling the wrong SonarQube version for the `LATEST_RELEASE` alias (which we use).