### PR TITLE
Implement token deprecation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Support for numeric literals prefixed by ampersands.
 - Support for identifiers prefixed by more than 2 ampersands.
 
+### Deprecated
+
+- `DelphiTokenType.AMPERSAND`, as `&` is now lexed directly into numeric literals and identifiers.
+
 ### Fixed
 
 - Static char arrays weren't accepted for `'%s'` in `FormatArgumentType`.

--- a/delphi-frontend/src/main/antlr3/au/com/integradev/delphi/antlr/Delphi.g
+++ b/delphi-frontend/src/main/antlr3/au/com/integradev/delphi/antlr/Delphi.g
@@ -1088,7 +1088,6 @@ DEREFERENCE          : '^'  ;
 ADDRESS              : '@'  ;
 DOT                  : '.'  ;
 DOT_DOT              : '..' ;
-AMPERSAND            : '@AMPERSAND@'  ;
 
 //****************************
 // Imaginary tokens
@@ -1312,3 +1311,7 @@ WHITESPACE              : ('\u0000'..'\u0020' | '\u3000')+ {$channel=HIDDEN;}
 TkAnyChar               : .
                         ;
 
+//----------------------------------------------------------------------------
+// Deprecated tokens
+//----------------------------------------------------------------------------
+AMPERSAND__deprecated   : '@AMPERSAND@';


### PR DESCRIPTION
This PR implements token deprecation in `DelphiTokenType` generation.
Any token suffixed with `__deprecated` in the grammar will be generated with `@Deprecated(forRemoval = true)`.

Additionally, the `AMPERSAND` token (which prompted this change) has been marked as deprecated.