### PR TITLE
Refactor `delphi-tokens-generator-maven-plugin` and add unit tests

### DIFF
--- a/delphi-tokens-generator-maven-plugin/pom.xml
+++ b/delphi-tokens-generator-maven-plugin/pom.xml
@@ -52,6 +52,16 @@
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-lang3</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/delphi-tokens-generator-maven-plugin/src/main/java/au/com/integradev/delphi/DelphiTokensGenerator.java
+++ b/delphi-tokens-generator-maven-plugin/src/main/java/au/com/integradev/delphi/DelphiTokensGenerator.java
@@ -1,0 +1,211 @@
+/*
+ * Sonar Delphi Plugin
+ * Copyright (C) 2024 Integrated Application Development
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02
+ */
+package au.com.integradev.delphi;
+
+import com.google.common.collect.ImmutableList;
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Objects;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import org.apache.commons.lang3.StringUtils;
+
+public class DelphiTokensGenerator {
+  private static final Pattern TOKENS_LINE_PATTERN =
+      Pattern.compile("(?i)([a-z_][a-z_\\d]+)=(\\d+)");
+  private static final String DEPRECATED_SUFFIX = "__deprecated";
+
+  private final File tokensFile;
+  private final File outputDirectory;
+
+  public DelphiTokensGenerator(File tokensFile, File outputDirectory) {
+    this.tokensFile = tokensFile;
+    this.outputDirectory = outputDirectory;
+  }
+
+  public void generate() throws IOException {
+    if (!tokensFile.isFile()) {
+      throw new FileNotFoundException("Tokens file does not exist");
+    }
+
+    if (!outputDirectory.isDirectory()) {
+      try {
+        Files.createDirectories(outputDirectory.toPath());
+      } catch (IOException e) {
+        throw new IOException("Failed to create output directory", e);
+      }
+    }
+
+    List<TokenTypeRecord> tokenTypes = readTokenTypes();
+    generateEnum(tokenTypes);
+    generateEnumFactory(tokenTypes);
+  }
+
+  private List<TokenTypeRecord> readTokenTypes() throws IOException {
+    ImmutableList.Builder<TokenTypeRecord> result = ImmutableList.builder();
+
+    result.add(new TokenTypeRecord("EOF", -1, false));
+    result.add(new TokenTypeRecord("INVALID", 0, false));
+
+    Files.readAllLines(tokensFile.toPath()).stream()
+        .map(DelphiTokensGenerator::createTokenType)
+        .filter(Objects::nonNull)
+        .forEach(result::add);
+
+    return result.build();
+  }
+
+  private void generateEnum(List<TokenTypeRecord> tokenTypes) throws IOException {
+    Path outputPath = outputDirectory.toPath().resolve("org/sonar/plugins/delphi/api/token");
+
+    Files.createDirectories(outputPath);
+
+    StringBuilder builder =
+        new StringBuilder()
+            .append("package org.sonar.plugins.communitydelphi.api.token;\n\n")
+            .append("public enum DelphiTokenType {\n");
+
+    for (TokenTypeRecord tokenType : tokenTypes) {
+      if (tokenType.isDeprecated()) {
+        builder.append("  @Deprecated(forRemoval = true)\n");
+      }
+      builder.append("  ").append(tokenType.getName()).append(",\n");
+    }
+
+    builder.append("}\n");
+
+    Files.writeString(outputPath.resolve("DelphiTokenType.java"), builder);
+  }
+
+  private void generateEnumFactory(List<TokenTypeRecord> tokenTypes) throws IOException {
+    Path outputPath = outputDirectory.toPath().resolve("au/com/integradev/delphi/antlr/ast/token");
+
+    Files.createDirectories(outputPath);
+
+    var builder =
+        new StringBuilder()
+            .append("package au.com.integradev.delphi.antlr.ast.token;\n\n")
+            .append("import org.sonar.plugins.communitydelphi.api.token.DelphiTokenType;\n\n");
+
+    if (tokenTypes.stream().anyMatch(TokenTypeRecord::isDeprecated)) {
+      builder.append("@SuppressWarnings(\"removal\")\n");
+    }
+
+    builder
+        .append("public final class DelphiTokenTypeFactory {\n")
+        .append("  private DelphiTokenTypeFactory() {\n")
+        .append("    // utility class\n")
+        .append("  }\n\n")
+        .append("  public static DelphiTokenType createTokenType(int value) {\n")
+        .append("    switch(value) {\n");
+
+    for (TokenTypeRecord tokenType : tokenTypes) {
+      builder.append("      case ").append(tokenType.getValue()).append(":\n");
+      builder.append("        return DelphiTokenType.").append(tokenType.getName()).append(";\n");
+    }
+
+    builder
+        .append("      default:\n")
+        .append("        throw new IllegalArgumentException(\"Unknown value: \" + value);\n")
+        .append("    }\n")
+        .append("  }\n\n")
+        .append("  public static int getValueFromTokenType(DelphiTokenType tokenType) {\n")
+        .append("    switch(tokenType) {\n");
+
+    for (TokenTypeRecord tokenType : tokenTypes) {
+      builder.append("      case ").append(tokenType.getName()).append(":\n");
+      builder.append("        return ").append(tokenType.getValue()).append(";\n");
+    }
+
+    builder
+        .append("      default:\n")
+        .append("        throw new IllegalArgumentException(\"Unknown type: \" + tokenType);\n")
+        .append("    }\n")
+        .append("  }\n")
+        .append("}\n");
+
+    Files.writeString(outputPath.resolve("DelphiTokenTypeFactory.java"), builder);
+  }
+
+  private static TokenTypeRecord createTokenType(String line) {
+    Matcher matcher = TOKENS_LINE_PATTERN.matcher(line);
+    if (matcher.matches()) {
+      String antlrName = matcher.group(1);
+      String value = matcher.group(2);
+      return new TokenTypeRecord(
+          antlrNameToEnumName(antlrName),
+          Integer.parseInt(value),
+          antlrName.endsWith(DEPRECATED_SUFFIX));
+    }
+    return null;
+  }
+
+  private static String antlrNameToEnumName(String antlrName) {
+    antlrName = StringUtils.removeStart(antlrName, "Tk");
+    antlrName = StringUtils.removeEnd(antlrName, DEPRECATED_SUFFIX);
+
+    StringBuilder result = new StringBuilder();
+    boolean nextCapitalIsNewWord = true;
+
+    for (int i = 0; i < antlrName.length(); ++i) {
+      char c = antlrName.charAt(i);
+      if (Character.isUpperCase(c)) {
+        if (nextCapitalIsNewWord
+            && result.length() > 0
+            && result.charAt(result.length() - 1) != '_') {
+          result.append('_');
+        }
+        nextCapitalIsNewWord = false;
+      } else if (!Character.isDigit(c)) {
+        nextCapitalIsNewWord = true;
+      }
+      result.append(Character.toUpperCase(c));
+    }
+
+    return result.toString();
+  }
+
+  private static class TokenTypeRecord {
+    private final String name;
+    private final int value;
+    private final boolean deprecated;
+
+    public TokenTypeRecord(String name, int value, boolean deprecated) {
+      this.name = name;
+      this.value = value;
+      this.deprecated = deprecated;
+    }
+
+    public String getName() {
+      return name;
+    }
+
+    public int getValue() {
+      return value;
+    }
+
+    public boolean isDeprecated() {
+      return deprecated;
+    }
+  }
+}

--- a/delphi-tokens-generator-maven-plugin/src/main/java/au/com/integradev/delphi/DelphiTokensGeneratorMojo.java
+++ b/delphi-tokens-generator-maven-plugin/src/main/java/au/com/integradev/delphi/DelphiTokensGeneratorMojo.java
@@ -18,16 +18,7 @@
  */
 package au.com.integradev.delphi;
 
-import com.google.common.collect.ImmutableList;
 import java.io.File;
-import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.util.List;
-import java.util.Objects;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
-import org.apache.commons.lang3.StringUtils;
 import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.plugins.annotations.LifecyclePhase;
@@ -43,10 +34,6 @@ import org.apache.maven.project.MavenProject;
     requiresDependencyResolution = ResolutionScope.COMPILE,
     threadSafe = true)
 public class DelphiTokensGeneratorMojo extends AbstractMojo {
-  private static final Pattern TOKENS_LINE_PATTERN =
-      Pattern.compile("(?i)([a-z_]+[a-z_\\d])=(\\d+)");
-  private static final String DEPRECATED_SUFFIX = "__deprecated";
-
   /** The directory where the ({@code protocol.xml}) files are located. */
   @Parameter(defaultValue = "${project.build.directory}/generated-sources/antlr3/Delphi.tokens")
   private File tokensFile;
@@ -67,167 +54,13 @@ public class DelphiTokensGeneratorMojo extends AbstractMojo {
 
   @Override
   public void execute() throws MojoFailureException {
-    if (!tokensFile.exists()) {
-      throw new MojoFailureException("Tokens file does not exist");
-    }
-
-    if (!outputDirectory.exists() && !outputDirectory.mkdirs()) {
-      throw new MojoFailureException("Failed to create output directory");
-    }
-
+    DelphiTokensGenerator generator = new DelphiTokensGenerator(tokensFile, outputDirectory);
     try {
-      List<TokenTypeRecord> tokenTypes = readTokenTypes();
-      generateEnum(tokenTypes);
-      generateEnumFactory(tokenTypes);
+      generator.generate();
     } catch (Exception e) {
       getLog().error(e.getMessage());
       throw new MojoFailureException(e.getMessage(), e);
     }
-
     project.addCompileSourceRoot(outputDirectory.getPath());
-  }
-
-  private List<TokenTypeRecord> readTokenTypes() throws IOException {
-    ImmutableList.Builder<TokenTypeRecord> result = ImmutableList.builder();
-
-    result.add(new TokenTypeRecord("EOF", -1, false));
-    result.add(new TokenTypeRecord("INVALID", 0, false));
-
-    Files.readAllLines(tokensFile.toPath()).stream()
-        .map(DelphiTokensGeneratorMojo::createTokenType)
-        .filter(Objects::nonNull)
-        .forEach(result::add);
-
-    return result.build();
-  }
-
-  private void generateEnum(List<TokenTypeRecord> tokenTypes) throws IOException {
-    Path outputPath = outputDirectory.toPath().resolve("org/sonar/plugins/delphi/api/token");
-
-    Files.createDirectories(outputPath);
-
-    StringBuilder builder =
-        new StringBuilder()
-            .append("package org.sonar.plugins.communitydelphi.api.token;\n\n")
-            .append("public enum DelphiTokenType {\n");
-
-    for (TokenTypeRecord tokenType : tokenTypes) {
-      if (tokenType.isDeprecated()) {
-        builder.append("  @Deprecated(forRemoval = true)\n");
-      }
-      builder.append("  ").append(tokenType.getName()).append(",\n");
-    }
-
-    builder.append("}\n");
-
-    Files.writeString(outputPath.resolve("DelphiTokenType.java"), builder);
-  }
-
-  private void generateEnumFactory(List<TokenTypeRecord> tokenTypes) throws IOException {
-    Path outputPath = outputDirectory.toPath().resolve("au/com/integradev/delphi/antlr/ast/token");
-
-    Files.createDirectories(outputPath);
-
-    StringBuilder builder =
-        new StringBuilder()
-            .append("package au.com.integradev.delphi.antlr.ast.token;\n\n")
-            .append("import org.sonar.plugins.communitydelphi.api.token.DelphiTokenType;\n\n")
-            .append("public final class DelphiTokenTypeFactory {\n")
-            .append("  private DelphiTokenTypeFactory() {\n")
-            .append("    // utility class\n")
-            .append("  }\n\n")
-            .append("  @SuppressWarnings(\"removal\")\n")
-            .append("  public static DelphiTokenType createTokenType(int value) {\n")
-            .append("    switch(value) {\n");
-
-    for (TokenTypeRecord tokenType : tokenTypes) {
-      builder.append("      case ").append(tokenType.getValue()).append(":\n");
-      builder.append("        return DelphiTokenType.").append(tokenType.getName()).append(";\n");
-    }
-
-    builder
-        .append("      default:\n")
-        .append("        throw new IllegalArgumentException(\"Unknown value: \" + value);\n")
-        .append("    }\n")
-        .append("  }\n\n")
-        .append("  @SuppressWarnings(\"removal\")\n")
-        .append("  public static int getValueFromTokenType(DelphiTokenType tokenType) {\n")
-        .append("    switch(tokenType) {\n");
-
-    for (TokenTypeRecord tokenType : tokenTypes) {
-      builder.append("      case ").append(tokenType.getName()).append(":\n");
-      builder.append("        return ").append(tokenType.getValue()).append(";\n");
-    }
-
-    builder
-        .append("      default:\n")
-        .append("        throw new IllegalArgumentException(\"Unknown type: \" + tokenType);\n")
-        .append("    }\n")
-        .append("  }\n")
-        .append("}\n");
-
-    Files.writeString(outputPath.resolve("DelphiTokenTypeFactory.java"), builder);
-  }
-
-  private static TokenTypeRecord createTokenType(String line) {
-    Matcher matcher = TOKENS_LINE_PATTERN.matcher(line);
-    if (matcher.matches()) {
-      String antlrName = matcher.group(1);
-      String value = matcher.group(2);
-      return new TokenTypeRecord(
-          antlrNameToEnumName(antlrName),
-          Integer.parseInt(value),
-          antlrName.endsWith(DEPRECATED_SUFFIX));
-    }
-    return null;
-  }
-
-  private static String antlrNameToEnumName(String antlrName) {
-    antlrName = StringUtils.removeStart(antlrName, "Tk");
-    antlrName = StringUtils.removeEnd(antlrName, DEPRECATED_SUFFIX);
-
-    StringBuilder result = new StringBuilder();
-    boolean nextCapitalIsNewWord = true;
-
-    for (int i = 0; i < antlrName.length(); ++i) {
-      char c = antlrName.charAt(i);
-      if (Character.isUpperCase(c)) {
-        if (nextCapitalIsNewWord
-            && result.length() > 0
-            && result.charAt(result.length() - 1) != '_') {
-          result.append('_');
-        }
-        nextCapitalIsNewWord = false;
-      } else if (!Character.isDigit(c)) {
-        nextCapitalIsNewWord = true;
-      }
-      result.append(Character.toUpperCase(c));
-    }
-
-    return result.toString();
-  }
-
-  private static class TokenTypeRecord {
-    private final String name;
-    private final int value;
-    private final boolean deprecated;
-
-    public TokenTypeRecord(String name, int value, boolean deprecated) {
-      this.name = name;
-      this.value = value;
-      this.deprecated = deprecated;
-    }
-
-    public String getName() {
-      return name;
-    }
-
-    public int getValue() {
-      return value;
-    }
-
-    public boolean isDeprecated() {
-      return deprecated;
-    }
   }
 }

--- a/delphi-tokens-generator-maven-plugin/src/test/java/au/com/integradev/delphi/DelphiTokensGeneratorTest.java
+++ b/delphi-tokens-generator-maven-plugin/src/test/java/au/com/integradev/delphi/DelphiTokensGeneratorTest.java
@@ -1,0 +1,284 @@
+/*
+ * Sonar Delphi Plugin
+ * Copyright (C) 2024 Integrated Application Development
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02
+ */
+package au.com.integradev.delphi;
+
+import static org.assertj.core.api.Assertions.*;
+
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.FileAlreadyExistsException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.apache.commons.io.FileUtils;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class DelphiTokensGeneratorTest {
+  @Test
+  void testSimpleTokens(@TempDir Path tempDir) {
+    generate(
+        tempDir,
+        "FOO=4\n" //
+            + "BAR=5\n"
+            + "BAZ=6\n"
+            + "'foo'=4\n"
+            + "'bar'=5\n"
+            + "'baz'=6\n");
+
+    assertThat(getTokenFactory(tempDir))
+        .isEqualTo(
+            "package au.com.integradev.delphi.antlr.ast.token;\n"
+                + "\n"
+                + "import org.sonar.plugins.communitydelphi.api.token.DelphiTokenType;\n"
+                + "\n"
+                + "public final class DelphiTokenTypeFactory {\n"
+                + "  private DelphiTokenTypeFactory() {\n"
+                + "    // utility class\n"
+                + "  }\n"
+                + "\n"
+                + "  public static DelphiTokenType createTokenType(int value) {\n"
+                + "    switch(value) {\n"
+                + "      case -1:\n"
+                + "        return DelphiTokenType.EOF;\n"
+                + "      case 0:\n"
+                + "        return DelphiTokenType.INVALID;\n"
+                + "      case 4:\n"
+                + "        return DelphiTokenType.FOO;\n"
+                + "      case 5:\n"
+                + "        return DelphiTokenType.BAR;\n"
+                + "      case 6:\n"
+                + "        return DelphiTokenType.BAZ;\n"
+                + "      default:\n"
+                + "        throw new IllegalArgumentException(\"Unknown value: \" + value);\n"
+                + "    }\n"
+                + "  }\n"
+                + "\n"
+                + "  public static int getValueFromTokenType(DelphiTokenType tokenType) {\n"
+                + "    switch(tokenType) {\n"
+                + "      case EOF:\n"
+                + "        return -1;\n"
+                + "      case INVALID:\n"
+                + "        return 0;\n"
+                + "      case FOO:\n"
+                + "        return 4;\n"
+                + "      case BAR:\n"
+                + "        return 5;\n"
+                + "      case BAZ:\n"
+                + "        return 6;\n"
+                + "      default:\n"
+                + "        throw new IllegalArgumentException(\"Unknown type: \" + tokenType);\n"
+                + "    }\n"
+                + "  }\n"
+                + "}\n");
+
+    assertThat(getTokenEnum(tempDir))
+        .isEqualTo(
+            "package org.sonar.plugins.communitydelphi.api.token;\n"
+                + "\n"
+                + "public enum DelphiTokenType {\n"
+                + "  EOF,\n"
+                + "  INVALID,\n"
+                + "  FOO,\n"
+                + "  BAR,\n"
+                + "  BAZ,\n"
+                + "}\n");
+  }
+
+  @Test
+  void testTokensRequiringNameProcessing(@TempDir Path tempDir) {
+    generate(
+        tempDir,
+        "TkFoo=4\n" //
+            + "Bar_Baz123Flarp=5\n");
+
+    assertThat(getTokenFactory(tempDir))
+        .isEqualTo(
+            "package au.com.integradev.delphi.antlr.ast.token;\n"
+                + "\n"
+                + "import org.sonar.plugins.communitydelphi.api.token.DelphiTokenType;\n"
+                + "\n"
+                + "public final class DelphiTokenTypeFactory {\n"
+                + "  private DelphiTokenTypeFactory() {\n"
+                + "    // utility class\n"
+                + "  }\n"
+                + "\n"
+                + "  public static DelphiTokenType createTokenType(int value) {\n"
+                + "    switch(value) {\n"
+                + "      case -1:\n"
+                + "        return DelphiTokenType.EOF;\n"
+                + "      case 0:\n"
+                + "        return DelphiTokenType.INVALID;\n"
+                + "      case 4:\n"
+                + "        return DelphiTokenType.FOO;\n"
+                + "      case 5:\n"
+                + "        return DelphiTokenType.BAR_BAZ123_FLARP;\n"
+                + "      default:\n"
+                + "        throw new IllegalArgumentException(\"Unknown value: \" + value);\n"
+                + "    }\n"
+                + "  }\n"
+                + "\n"
+                + "  public static int getValueFromTokenType(DelphiTokenType tokenType) {\n"
+                + "    switch(tokenType) {\n"
+                + "      case EOF:\n"
+                + "        return -1;\n"
+                + "      case INVALID:\n"
+                + "        return 0;\n"
+                + "      case FOO:\n"
+                + "        return 4;\n"
+                + "      case BAR_BAZ123_FLARP:\n"
+                + "        return 5;\n"
+                + "      default:\n"
+                + "        throw new IllegalArgumentException(\"Unknown type: \" + tokenType);\n"
+                + "    }\n"
+                + "  }\n"
+                + "}\n");
+
+    assertThat(getTokenEnum(tempDir))
+        .isEqualTo(
+            "package org.sonar.plugins.communitydelphi.api.token;\n"
+                + "\n"
+                + "public enum DelphiTokenType {\n"
+                + "  EOF,\n"
+                + "  INVALID,\n"
+                + "  FOO,\n"
+                + "  BAR_BAZ123_FLARP,\n"
+                + "}\n");
+  }
+
+  @Test
+  void testDeprecatedTokens(@TempDir Path tempDir) {
+    generate(
+        tempDir,
+        "CARET=4\n" //
+            + "CARROT__deprecated=5\n"
+            + "'^'=4\n"
+            + "'\uD83E\uDD55'=5\n");
+
+    assertThat(getTokenFactory(tempDir))
+        .isEqualTo(
+            "package au.com.integradev.delphi.antlr.ast.token;\n"
+                + "\n"
+                + "import org.sonar.plugins.communitydelphi.api.token.DelphiTokenType;\n"
+                + "\n"
+                + "@SuppressWarnings(\"removal\")\n"
+                + "public final class DelphiTokenTypeFactory {\n"
+                + "  private DelphiTokenTypeFactory() {\n"
+                + "    // utility class\n"
+                + "  }\n"
+                + "\n"
+                + "  public static DelphiTokenType createTokenType(int value) {\n"
+                + "    switch(value) {\n"
+                + "      case -1:\n"
+                + "        return DelphiTokenType.EOF;\n"
+                + "      case 0:\n"
+                + "        return DelphiTokenType.INVALID;\n"
+                + "      case 4:\n"
+                + "        return DelphiTokenType.CARET;\n"
+                + "      case 5:\n"
+                + "        return DelphiTokenType.CARROT;\n"
+                + "      default:\n"
+                + "        throw new IllegalArgumentException(\"Unknown value: \" + value);\n"
+                + "    }\n"
+                + "  }\n"
+                + "\n"
+                + "  public static int getValueFromTokenType(DelphiTokenType tokenType) {\n"
+                + "    switch(tokenType) {\n"
+                + "      case EOF:\n"
+                + "        return -1;\n"
+                + "      case INVALID:\n"
+                + "        return 0;\n"
+                + "      case CARET:\n"
+                + "        return 4;\n"
+                + "      case CARROT:\n"
+                + "        return 5;\n"
+                + "      default:\n"
+                + "        throw new IllegalArgumentException(\"Unknown type: \" + tokenType);\n"
+                + "    }\n"
+                + "  }\n"
+                + "}\n");
+
+    assertThat(getTokenEnum(tempDir))
+        .isEqualTo(
+            "package org.sonar.plugins.communitydelphi.api.token;\n"
+                + "\n"
+                + "public enum DelphiTokenType {\n"
+                + "  EOF,\n"
+                + "  INVALID,\n"
+                + "  CARET,\n"
+                + "  @Deprecated(forRemoval = true)\n"
+                + "  CARROT,\n"
+                + "}\n");
+  }
+
+  @Test
+  void testTokensFileDoesNotExist(@TempDir Path root) {
+    File tokensFile = root.resolve("Delphi.tokens").toFile();
+    File outputDirectory = root.resolve("out").toFile();
+
+    DelphiTokensGenerator generator = new DelphiTokensGenerator(tokensFile, outputDirectory);
+
+    assertThatThrownBy(generator::generate).isExactlyInstanceOf(FileNotFoundException.class);
+  }
+
+  @Test
+  void testOutputDirectoryCannotBeCreated(@TempDir Path root) throws IOException {
+    File tokensFile = Files.createFile(root.resolve("Delphi.tokens")).toFile();
+    File outputDirectory = Files.createFile(root.resolve("out")).toFile();
+
+    DelphiTokensGenerator generator = new DelphiTokensGenerator(tokensFile, outputDirectory);
+
+    assertThatThrownBy(generator::generate)
+        .isExactlyInstanceOf(IOException.class)
+        .hasCauseInstanceOf(FileAlreadyExistsException.class);
+  }
+
+  private static void generate(Path root, String tokens) {
+    File tokensFile = root.resolve("Delphi.tokens").toFile();
+    File outputDirectory = root.resolve("out").toFile();
+
+    DelphiTokensGenerator generator = new DelphiTokensGenerator(tokensFile, outputDirectory);
+    try {
+      FileUtils.writeStringToFile(tokensFile, tokens, StandardCharsets.UTF_8);
+      generator.generate();
+    } catch (IOException e) {
+      throw new UncheckedIOException(e);
+    }
+  }
+
+  private static String getTokenFactory(Path root) {
+    try {
+      return Files.readString(
+          root.resolve("out/au/com/integradev/delphi/antlr/ast/token/DelphiTokenTypeFactory.java"));
+    } catch (IOException e) {
+      throw new UncheckedIOException(e);
+    }
+  }
+
+  private static String getTokenEnum(Path root) {
+    try {
+      return Files.readString(
+          root.resolve("out/org/sonar/plugins/delphi/api/token/DelphiTokenType.java"));
+    } catch (IOException e) {
+      throw new UncheckedIOException(e);
+    }
+  }
+}


### PR DESCRIPTION
This PR:
- splits `DelphiTokensGenerator` from `DelphiTokensGeneratorMojo`
- adds unit tests for `DelphiTokensGenerator`
- fixes a bug where tokens from the `Delphi.tokens` would not be recognized if their names contained numbers
- adds `@SuppressWarnings("removal")` to the entire `DelphiTokenTypeFactory` instead of the 2 methods within it
- only adds `@SuppressWarnings("removal")` to `DelphiTokenTypeFactory` if 1 or more tokens are deprecated