### PR TITLE
Implement multiline strings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Support for multiline string literals.
 - Support for numeric literals prefixed by ampersands.
 - Support for identifiers prefixed by more than 2 ampersands.
+- **API:** `TextLiteralNode::isMultiline` method.
 
 ### Deprecated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,9 +13,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Support for numeric literals prefixed by ampersands.
 - Support for identifiers prefixed by more than 2 ampersands.
 - **API:** `TextLiteralNode::isMultiline` method.
+- **API:** `TextLiteralNode::getValue` method, which returns the effective contents of a text
+  literal.
+
+### Changed
+
+- `TextLiteralNode::getImage` now returns the text literal exactly as it appears in source code.
+- `TextLiteralNode::getImageWithoutQuotes` now simply calls the new `getValue` method.
 
 ### Deprecated
 
+- `TextLiteralNode::getImageWithoutQuotes`, use `getValue` instead.
 - `DelphiTokenType.AMPERSAND`, as `&` is now lexed directly into numeric literals and identifiers.
 
 ### Fixed

--- a/delphi-checks/src/main/java/au/com/integradev/delphi/checks/AbstractFormatArgumentCheck.java
+++ b/delphi-checks/src/main/java/au/com/integradev/delphi/checks/AbstractFormatArgumentCheck.java
@@ -73,7 +73,7 @@ public abstract class AbstractFormatArgumentCheck extends DelphiCheck {
       return;
     }
 
-    String rawFormatString = textLiteral.get().getImageWithoutQuotes().toString();
+    String rawFormatString = textLiteral.get().getValue();
     FormatStringParser parser = new FormatStringParser(rawFormatString);
     try {
       checkFormatStringViolation(parser.parse(), arrayConstructor.get(), context);

--- a/delphi-checks/src/main/java/au/com/integradev/delphi/checks/StringLiteralRegularExpressionCheck.java
+++ b/delphi-checks/src/main/java/au/com/integradev/delphi/checks/StringLiteralRegularExpressionCheck.java
@@ -59,7 +59,7 @@ public class StringLiteralRegularExpressionCheck extends DelphiCheck {
 
   @Override
   public DelphiCheckContext visit(TextLiteralNode string, DelphiCheckContext context) {
-    if (pattern != null && pattern.matcher(string.getImageWithoutQuotes()).matches()) {
+    if (pattern != null && pattern.matcher(string.getValue()).matches()) {
       reportIssue(context, string, message);
     }
     return super.visit(string, context);

--- a/delphi-frontend/src/main/java/au/com/integradev/delphi/antlr/ast/node/TextLiteralNodeImpl.java
+++ b/delphi-frontend/src/main/java/au/com/integradev/delphi/antlr/ast/node/TextLiteralNodeImpl.java
@@ -139,7 +139,7 @@ public final class TextLiteralNodeImpl extends DelphiNodeImpl implements TextLit
           break;
 
         case ESCAPED_CHARACTER:
-          imageBuilder.append(child.getImage());
+          imageBuilder.append((char) ((child.getImage().charAt(0) + 64) % 128));
           break;
 
         default:

--- a/delphi-frontend/src/main/java/au/com/integradev/delphi/antlr/ast/node/TextLiteralNodeImpl.java
+++ b/delphi-frontend/src/main/java/au/com/integradev/delphi/antlr/ast/node/TextLiteralNodeImpl.java
@@ -135,10 +135,7 @@ public final class TextLiteralNodeImpl extends DelphiNodeImpl implements TextLit
           break;
 
         case CHARACTER_ESCAPE_CODE:
-          String escapedChar = child.getImage();
-          boolean isHex = escapedChar.startsWith("#$");
-          escapedChar = escapedChar.substring(isHex ? 2 : 1);
-          imageBuilder.append((char) Integer.parseInt(escapedChar, isHex ? 16 : 10));
+          imageBuilder.append(characterEscapeToChar(child.getImage()));
           break;
 
         case ESCAPED_CHARACTER:
@@ -151,6 +148,28 @@ public final class TextLiteralNodeImpl extends DelphiNodeImpl implements TextLit
     }
 
     return imageBuilder.toString();
+  }
+
+  private static char characterEscapeToChar(String image) {
+    image = image.substring(1);
+    int radix = 10;
+
+    switch (image.charAt(0)) {
+      case '$':
+        radix = 16;
+        image = image.substring(1);
+        break;
+      case '%':
+        radix = 2;
+        image = image.substring(1);
+        break;
+      default:
+        // do nothing
+    }
+
+    image = StringUtils.remove(image, '_');
+
+    return (char) Integer.parseInt(image, radix);
   }
 
   @Override

--- a/delphi-frontend/src/main/java/org/sonar/plugins/communitydelphi/api/ast/TextLiteralNode.java
+++ b/delphi-frontend/src/main/java/org/sonar/plugins/communitydelphi/api/ast/TextLiteralNode.java
@@ -22,4 +22,6 @@ import org.sonar.plugins.communitydelphi.api.type.Typed;
 
 public interface TextLiteralNode extends DelphiNode, Typed {
   CharSequence getImageWithoutQuotes();
+
+  boolean isMultiline();
 }

--- a/delphi-frontend/src/main/java/org/sonar/plugins/communitydelphi/api/ast/TextLiteralNode.java
+++ b/delphi-frontend/src/main/java/org/sonar/plugins/communitydelphi/api/ast/TextLiteralNode.java
@@ -21,7 +21,26 @@ package org.sonar.plugins.communitydelphi.api.ast;
 import org.sonar.plugins.communitydelphi.api.type.Typed;
 
 public interface TextLiteralNode extends DelphiNode, Typed {
+  /**
+   * Returns the evaluated value of the text literal.
+   *
+   * @return evaluated value of the text literal
+   * @deprecated Use {@link TextLiteralNode#getValue} instead.
+   */
+  @Deprecated(forRemoval = true)
   CharSequence getImageWithoutQuotes();
 
+  /**
+   * Returns the evaluated value of the text literal.
+   *
+   * @return evaluated value of the text literal
+   */
+  String getValue();
+
+  /**
+   * Returns whether this is a multiline text literal.
+   *
+   * @return true if this is a multiline text literal
+   */
   boolean isMultiline();
 }

--- a/delphi-frontend/src/test/java/au/com/integradev/delphi/antlr/GrammarTest.java
+++ b/delphi-frontend/src/test/java/au/com/integradev/delphi/antlr/GrammarTest.java
@@ -66,6 +66,21 @@ class GrammarTest {
   }
 
   @Test
+  void testMultilineStrings() {
+    assertParsed("MultilineStrings.pas");
+  }
+
+  @Test
+  void testMultilineLookalikeStrings() {
+    assertParsed("MultilineLookalikeStrings.pas");
+  }
+
+  @Test
+  void testMultilineInvalidButAcceptedStrings() {
+    assertParsed("MultilineInvalidButAcceptedStrings.pas");
+  }
+
+  @Test
   void testEmptyBeginStatement() {
     assertParsed("EmptyProcs.pas");
   }

--- a/delphi-frontend/src/test/java/au/com/integradev/delphi/antlr/ast/node/TextLiteralNodeImplTest.java
+++ b/delphi-frontend/src/test/java/au/com/integradev/delphi/antlr/ast/node/TextLiteralNodeImplTest.java
@@ -1,0 +1,85 @@
+/*
+ * Sonar Delphi Plugin
+ * Copyright (C) 2024 Integrated Application Development
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02
+ */
+package au.com.integradev.delphi.antlr.ast.node;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import au.com.integradev.delphi.antlr.DelphiLexer;
+import org.antlr.runtime.CommonToken;
+import org.junit.jupiter.api.Test;
+import org.sonar.plugins.communitydelphi.api.ast.DelphiNode;
+
+class TextLiteralNodeImplTest {
+  @Test
+  void testMultilineImage() {
+    String image =
+        "'''\n" //
+            + "      Foo\n"
+            + "      Bar\n"
+            + "      Baz\n"
+            + "      '''";
+
+    TextLiteralNodeImpl node = new TextLiteralNodeImpl(DelphiLexer.TkTextLiteral);
+    node.addChild(createNode(DelphiLexer.TkMultilineString, image));
+
+    assertThat(node.getImage()).isEqualTo(image);
+    assertThat(node.getValue()).isEqualTo(node.getImageWithoutQuotes()).isEqualTo("Foo\nBar\nBaz");
+    assertThat(node.isMultiline()).isTrue();
+  }
+
+  @Test
+  void testGetImageWithCharacterEscapes() {
+    TextLiteralNodeImpl node = new TextLiteralNodeImpl(DelphiLexer.TkTextLiteral);
+    node.addChild(createNode(DelphiLexer.TkQuotedString, "'F'"));
+    node.addChild(createNode(DelphiLexer.TkCharacterEscapeCode, "#111"));
+    node.addChild(createNode(DelphiLexer.TkCharacterEscapeCode, "#111"));
+    node.addChild(createNode(DelphiLexer.TkQuotedString, "'B'"));
+    node.addChild(createNode(DelphiLexer.TkCharacterEscapeCode, "#$61"));
+    node.addChild(createNode(DelphiLexer.TkCharacterEscapeCode, "#$72"));
+    node.addChild(createNode(DelphiLexer.TkQuotedString, "'B'"));
+    node.addChild(createNode(DelphiLexer.TkCharacterEscapeCode, "#%01100001"));
+    node.addChild(createNode(DelphiLexer.TkCharacterEscapeCode, "#%01111010"));
+
+    assertThat(node.getImage()).isEqualTo("'F'#111#111'B'#$61#$72'B'#%01100001#%01111010");
+    assertThat(node.getValue()).isEqualTo(node.getImageWithoutQuotes()).isEqualTo("FooBarBaz");
+    assertThat(node.isMultiline()).isFalse();
+  }
+
+  @Test
+  void testGetImageWithCaretNotation() {
+    TextLiteralNodeImpl node = new TextLiteralNodeImpl(DelphiLexer.TkTextLiteral);
+    node.addChild(createNode(DelphiLexer.TkQuotedString, "'F'"));
+    node.addChild(createNode(DelphiLexer.TkEscapedCharacter, "/"));
+    node.addChild(createNode(DelphiLexer.TkEscapedCharacter, "/"));
+    node.addChild(createNode(DelphiLexer.TkQuotedString, "'B'"));
+    node.addChild(createNode(DelphiLexer.TkEscapedCharacter, "!"));
+    node.addChild(createNode(DelphiLexer.TkEscapedCharacter, "2"));
+    node.addChild(createNode(DelphiLexer.TkQuotedString, "'B'"));
+    node.addChild(createNode(DelphiLexer.TkEscapedCharacter, "!"));
+    node.addChild(createNode(DelphiLexer.TkEscapedCharacter, ":"));
+
+    assertThat(node.getImage()).isEqualTo("'F'^/^/'B'^!^2'B'^!^:");
+    assertThat(node.getValue()).isEqualTo(node.getImageWithoutQuotes()).isEqualTo("FooBarBaz");
+    assertThat(node.isMultiline()).isFalse();
+  }
+
+  private static DelphiNode createNode(int tokenType, String image) {
+    return new CommonDelphiNodeImpl(new CommonToken(tokenType, image));
+  }
+}

--- a/delphi-frontend/src/test/resources/au/com/integradev/delphi/grammar/MultilineInvalidButAcceptedStrings.pas
+++ b/delphi-frontend/src/test/resources/au/com/integradev/delphi/grammar/MultilineInvalidButAcceptedStrings.pas
@@ -1,0 +1,19 @@
+unit MultilineInvalidButAcceptedStrings;
+
+interface
+
+const
+  Foo = '''
+  ''';
+
+  Bar = '''
+ bar
+  ''';
+
+  Bar = '''''
+   baz
+   flarp''''';
+
+implementation
+
+end.

--- a/delphi-frontend/src/test/resources/au/com/integradev/delphi/grammar/MultilineLookalikeStrings.pas
+++ b/delphi-frontend/src/test/resources/au/com/integradev/delphi/grammar/MultilineLookalikeStrings.pas
@@ -1,0 +1,14 @@
+unit MultilineLookalikeStrings;
+
+interface
+
+const
+  Foo = ''' Hello this is a foo text ''';
+  Bar = ''''' Hello this is a ''bar'' text ''''';
+  Baz = ''''''''' Hello this is a''''baz''''text ''''''''';
+  Flarp = '''';
+  Boop = ''' Hello this is a boop text ';
+
+implementation
+
+end.

--- a/delphi-frontend/src/test/resources/au/com/integradev/delphi/grammar/MultilineStrings.pas
+++ b/delphi-frontend/src/test/resources/au/com/integradev/delphi/grammar/MultilineStrings.pas
@@ -1,0 +1,23 @@
+unit MultilineStrings;
+
+interface
+
+const
+  Foo = '''
+  Hello this is a
+  foo text
+''';
+  Bar = '''''
+  Hello this is a
+  'bar'
+  text
+''''';
+  Baz = '''''''''
+  Hello this is a
+  '''baz'''
+  text
+''''''''';
+
+implementation
+
+end.


### PR DESCRIPTION
This PR:
- adds support for the multiline strings from Delphi 12
- deprecates `getImageWithoutQuotes` in favor of `getValue`
- improves the evaluation of character escapes
- improves test coverage for `TextLiteralNodeImpl`

Closes #80.