### PR TITLE
Fix null reference in PublicField when encountering anonymous records

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The `ReadLn` intrinsic was missing the standard input overload.
 - Ideographic space (U+3000) was erroneously accepted as a valid identifier character.
 - Duplicate imports in a `requires` clause now log a warning instead of throwing an exception.
+- NPE on anonymous records in `PublicField`.
 
 ## [1.1.0] - 2024-01-02
 

--- a/delphi-checks/src/main/java/au/com/integradev/delphi/checks/PublicFieldCheck.java
+++ b/delphi-checks/src/main/java/au/com/integradev/delphi/checks/PublicFieldCheck.java
@@ -24,7 +24,7 @@ package au.com.integradev.delphi.checks;
 
 import org.sonar.check.Rule;
 import org.sonar.plugins.communitydelphi.api.ast.FieldDeclarationNode;
-import org.sonar.plugins.communitydelphi.api.ast.TypeDeclarationNode;
+import org.sonar.plugins.communitydelphi.api.ast.TypeNode;
 import org.sonar.plugins.communitydelphi.api.check.DelphiCheck;
 import org.sonar.plugins.communitydelphi.api.check.DelphiCheckContext;
 import org.sonarsource.analyzer.commons.annotations.DeprecatedRuleKey;
@@ -43,6 +43,6 @@ public class PublicFieldCheck extends DelphiCheck {
   }
 
   private static boolean isRecordField(FieldDeclarationNode field) {
-    return field.getFirstParentOfType(TypeDeclarationNode.class).isRecord();
+    return field.getFirstParentOfType(TypeNode.class).getType().isRecord();
   }
 }

--- a/delphi-checks/src/test/java/au/com/integradev/delphi/checks/PublicFieldCheckTest.java
+++ b/delphi-checks/src/test/java/au/com/integradev/delphi/checks/PublicFieldCheckTest.java
@@ -77,4 +77,23 @@ class PublicFieldCheckTest {
                 .appendDecl("  end;"))
         .verifyNoIssues();
   }
+
+  @Test
+  void testPublicFieldsInNestedRecordsShouldNotAddIssue() {
+    CheckVerifier.newVerifier()
+        .withCheck(new PublicFieldCheck())
+        .onFile(
+            new DelphiTestUnitBuilder()
+                .appendDecl("var")
+                .appendDecl("  MyRec: record")
+                .appendDecl("     FPublishedField: Integer;")
+                .appendDecl("    private")
+                .appendDecl("     FPrivateField: Integer;")
+                .appendDecl("    protected")
+                .appendDecl("     FProtectedField: String;")
+                .appendDecl("    public")
+                .appendDecl("     FPublicField: String;")
+                .appendDecl("  end;"))
+        .verifyNoIssues();
+  }
 }

--- a/delphi-frontend/src/main/antlr3/au/com/integradev/delphi/antlr/Delphi.g
+++ b/delphi-frontend/src/main/antlr3/au/com/integradev/delphi/antlr/Delphi.g
@@ -968,9 +968,6 @@ dispIDDirective              : 'dispid' expression
 ident                        : TkIdentifier
                              | keywordsUsedAsNames -> ^({changeTokenType(TkIdentifier)})
                              ;
-identifierOrKeyword          : TkIdentifier
-                             | keywords -> ^({changeTokenType(TkIdentifier)})
-                             ;
 keywordsUsedAsNames          : (ABSOLUTE | ABSTRACT | ALIGN | ASSEMBLER | AT | AUTOMATED | CDECL)
                              | (CONTAINS | DEFAULT | DELAYED | DEPRECATED | DISPID | DYNAMIC | EXPERIMENTAL | EXPORT)
                              | (EXTERNAL | FAR | FINAL | FORWARD | HELPER | IMPLEMENTS | INDEX | LOCAL | MESSAGE | NAME)


### PR DESCRIPTION
This PR fixes a null pointer exception that occurs when `PublicFieldCheck` encounters an anonymous record. 

I've also bundled in the removal of a dead rule from the grammar.