### PR TITLE
Remove Orchestrator proxy settings

### DIFF
--- a/its/pom.xml
+++ b/its/pom.xml
@@ -16,8 +16,6 @@
 
   <properties>
     <skipTests>${skipITs}</skipTests>
-    <proxyHost/>
-    <proxyPort/>
   </properties>
 
   <dependencies>
@@ -58,41 +56,4 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
-
-  <build>
-    <plugins>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-surefire-plugin</artifactId>
-        <configuration>
-          <argLine>@{argLine} -Dhttps.proxyHost=${proxyHost} -Dhttps.proxyPort=${proxyPort}</argLine>
-        </configuration>
-      </plugin>
-    </plugins>
-  </build>
-
-  <profiles>
-    <profile>
-      <id>proxy-host-defined</id>
-      <activation>
-        <property>
-          <name>env.HTTP_PROXY_SERVER</name>
-        </property>
-      </activation>
-      <properties>
-        <proxyHost>${env.HTTP_PROXY_SERVER}</proxyHost>
-      </properties>
-    </profile>
-    <profile>
-      <id>proxy-port-defined</id>
-      <activation>
-        <property>
-          <name>env.HTTP_PROXY_PORT</name>
-        </property>
-      </activation>
-      <properties>
-        <proxyPort>${env.HTTP_PROXY_PORT}</proxyPort>
-      </properties>
-    </profile>
-  </profiles>
 </project>


### PR DESCRIPTION
We don't need proxy settings for our integration tests, since the Orchestrator library now downloads artifacts through maven central.