### PR TITLE
Fix InheritedMethodWithNoCode incorrectly retrieving class declarations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Performance improvements.
 
+### Fixed
+
+- The wrong inherited method could be found in `InheritedMethodWithNoCode`, causing false negatives.
+
 ## [1.3.0] - 2024-03-01
 
 ### Added

--- a/delphi-checks/src/test/java/au/com/integradev/delphi/checks/InheritedMethodWithNoCodeCheckTest.java
+++ b/delphi-checks/src/test/java/au/com/integradev/delphi/checks/InheritedMethodWithNoCodeCheckTest.java
@@ -322,4 +322,70 @@ class InheritedMethodWithNoCodeCheckTest {
                 .appendImpl("end;"))
         .verifyNoIssues();
   }
+
+  @Test
+  void testInstanceRoutineOverridingVisibilityOfInheritedClassRoutineShouldNotAddIssue() {
+    CheckVerifier.newVerifier()
+        .withCheck(new InheritedMethodWithNoCodeCheck())
+        .onFile(
+            new DelphiTestUnitBuilder()
+                .appendDecl("type")
+                .appendDecl("  TBase = class(TObject)")
+                .appendDecl("  protected")
+                .appendDecl("    class procedure MyProcedure; virtual;")
+                .appendDecl("  end;")
+                .appendDecl("  TChild = class(TBase)")
+                .appendDecl("  public")
+                .appendDecl("    procedure MyProcedure;")
+                .appendDecl("  end;")
+                .appendImpl("procedure TChild.MyProcedure;")
+                .appendImpl("begin")
+                .appendImpl("  inherited;")
+                .appendImpl("end;"))
+        .verifyNoIssues();
+  }
+
+  @Test
+  void testEmptyInstanceDestructorWithClassDestructorOfDifferentVisibilityShouldAddIssue() {
+    CheckVerifier.newVerifier()
+        .withCheck(new InheritedMethodWithNoCodeCheck())
+        .onFile(
+            new DelphiTestUnitBuilder()
+                .appendDecl("type")
+                .appendDecl("  TBase = class(TObject)")
+                .appendDecl("  protected")
+                .appendDecl("    class destructor Destroy;")
+                .appendDecl("  end;")
+                .appendDecl("  TChild = class(TBase)")
+                .appendDecl("  public")
+                .appendDecl("    destructor Destroy; override;")
+                .appendDecl("  end;")
+                .appendImpl("destructor TChild.Destroy;")
+                .appendImpl("begin")
+                .appendImpl("  inherited; // Noncompliant")
+                .appendImpl("end;"))
+        .verifyIssues();
+  }
+
+  @Test
+  void testEmptyInstanceConstructorWithClassConstructorOfDifferentVisibilityShouldAddIssue() {
+    CheckVerifier.newVerifier()
+        .withCheck(new InheritedMethodWithNoCodeCheck())
+        .onFile(
+            new DelphiTestUnitBuilder()
+                .appendDecl("type")
+                .appendDecl("  TBase = class(TObject)")
+                .appendDecl("  protected")
+                .appendDecl("    class constructor Create;")
+                .appendDecl("  end;")
+                .appendDecl("  TChild = class(TBase)")
+                .appendDecl("  public")
+                .appendDecl("    constructor Create; override;")
+                .appendDecl("  end;")
+                .appendImpl("constructor TChild.Create;")
+                .appendImpl("begin")
+                .appendImpl("  inherited; // Noncompliant")
+                .appendImpl("end;"))
+        .verifyIssues();
+  }
 }


### PR DESCRIPTION
When traversing a routine's inheritance tree, InheritedMethodNoCode currently does not distinguish between class routines and member routines. This can cause the wrong routine to be chosen if a class routine with the same name and number of parameters exists in the inheritance tree.

This PR fixes this issue by filtering out non-callable routines. 