### PR TITLE
Fix type resolution inaccuracies around subtract expressions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Type resolution inaccuracies around subtract expressions.
 - The wrong inherited method could be found in `InheritedMethodWithNoCode`, causing false negatives.
 
 ## [1.3.0] - 2024-03-01

--- a/delphi-frontend/src/main/java/au/com/integradev/delphi/operator/OperatorInvocableCollector.java
+++ b/delphi-frontend/src/main/java/au/com/integradev/delphi/operator/OperatorInvocableCollector.java
@@ -258,7 +258,7 @@ public class OperatorInvocableCollector {
       case ADD:
         return createIntegerArithmeticBinary("Add");
       case SUBTRACT:
-        return createIntegerArithmeticBinary("Subtract");
+        return createSubtract();
       case MULTIPLY:
         return createIntegerArithmeticBinary("Multiply");
       case DIVIDE:
@@ -409,6 +409,15 @@ public class OperatorInvocableCollector {
   }
 
   private Set<Invocable> createIntegerArithmeticBinary(String name) {
+    return createIntegerArithmeticBinary(name, ((TypeFactoryImpl) typeFactory).anonymousUInt31());
+  }
+
+  private Set<Invocable> createSubtract() {
+    return createIntegerArithmeticBinary(
+        "Subtract", typeFactory.getIntrinsic(IntrinsicType.INTEGER));
+  }
+
+  private Set<Invocable> createIntegerArithmeticBinary(String name, Type uint31ReturnType) {
     Set<Invocable> result = createNativeIntegerBinary(name);
     if (!result.isEmpty()) {
       return result;
@@ -425,7 +434,7 @@ public class OperatorInvocableCollector {
         new OperatorIntrinsic(name, List.of(integer, integer), integer),
         new OperatorIntrinsic(name, List.of(integer, int64), int64),
         new OperatorIntrinsic(name, List.of(int64, integer), int64),
-        new OperatorIntrinsic(name, List.of(uint31, uint31), uint31),
+        new OperatorIntrinsic(name, List.of(uint31, uint31), uint31ReturnType),
         new OperatorIntrinsic(name, List.of(cardinal, uint31), cardinal),
         new OperatorIntrinsic(name, List.of(uint31, cardinal), cardinal),
         new OperatorIntrinsic(name, List.of(cardinal, cardinal), cardinal),

--- a/delphi-frontend/src/test/java/au/com/integradev/delphi/symbol/resolve/OperatorOverloadResolutionTest.java
+++ b/delphi-frontend/src/test/java/au/com/integradev/delphi/symbol/resolve/OperatorOverloadResolutionTest.java
@@ -245,7 +245,7 @@ class OperatorOverloadResolutionTest {
   @CsvFileSource(resources = BINARY_OVERLOADS)
   @ParameterizedTest(name = "{0} - {1} = {3}")
   void testSubtractOperatorOverloadResolution(
-      @AggregateWith(ArithmeticDataAggregator.class) BinaryExpressionData expressionData) {
+      @AggregateWith(SubtractDataAggregator.class) BinaryExpressionData expressionData) {
     assertResolved(expressionData, BinaryOperator.SUBTRACT);
   }
 


### PR DESCRIPTION
By random chance, I noticed that `SubtractDataAggregator` wasn't actually being used in `OperatorOverloadResolutionTest`

This PR fixes the test and implements the correct type resolution for subtract expressions.