### PR TITLE
Handle UNC paths correctly during analysis

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Type resolution inaccuracies around subtract expressions.
 - The wrong inherited method could be found in `InheritedMethodWithNoCode`, causing false negatives.
+- Exception when scanning UNC paths.
 
 ## [1.3.0] - 2024-03-01
 

--- a/delphi-checks-testkit/src/main/java/au/com/integradev/delphi/checks/verifier/CheckVerifierImpl.java
+++ b/delphi-checks-testkit/src/main/java/au/com/integradev/delphi/checks/verifier/CheckVerifierImpl.java
@@ -56,7 +56,6 @@ import javax.annotation.Nullable;
 import org.apache.commons.io.FileUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.sonar.api.batch.fs.InputFile;
 import org.sonar.api.batch.fs.TextRange;
 import org.sonar.api.batch.sensor.internal.SensorContextTester;
 import org.sonar.api.batch.sensor.issue.Issue;
@@ -559,9 +558,7 @@ public class CheckVerifierImpl implements CheckVerifier {
     return SearchPath.create(
         searchPathUnits.stream()
             .map(builder -> builder.delphiFile().getInputFile())
-            .map(InputFile::uri)
-            .map(DelphiUtils::uriToAbsolutePath)
-            .map(Path::of)
+            .map(DelphiUtils::inputFileToPath)
             .map(Path::getParent)
             .collect(Collectors.toUnmodifiableList()));
   }

--- a/delphi-frontend/src/main/java/au/com/integradev/delphi/file/DelphiFile.java
+++ b/delphi-frontend/src/main/java/au/com/integradev/delphi/file/DelphiFile.java
@@ -68,7 +68,7 @@ public interface DelphiFile {
 
     static DelphiInputFile from(InputFile inputFile, DelphiFileConfig config) {
       DefaultDelphiInputFile delphiFile = new DefaultDelphiInputFile();
-      File sourceFile = new File(DelphiUtils.uriToAbsolutePath(inputFile.uri()));
+      File sourceFile = DelphiUtils.inputFileToPath(inputFile).toFile();
       setupFile(delphiFile, sourceFile, useInputFileEncoding(inputFile, config));
       delphiFile.setInputFile(inputFile);
       return delphiFile;

--- a/delphi-frontend/src/main/java/au/com/integradev/delphi/utils/DelphiUtils.java
+++ b/delphi-frontend/src/main/java/au/com/integradev/delphi/utils/DelphiUtils.java
@@ -23,7 +23,6 @@
 package au.com.integradev.delphi.utils;
 
 import java.io.File;
-import java.net.URI;
 import java.net.URL;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -79,14 +78,6 @@ public final class DelphiUtils {
     }
 
     return file;
-  }
-
-  public static String uriToAbsolutePath(URI uri) {
-    String path = uri.getPath();
-    if (":".equals(path.substring(2, 3))) {
-      path = path.substring(1);
-    }
-    return path;
   }
 
   public static List<Path> inputFilesToPaths(Iterable<InputFile> inputFiles) {

--- a/delphi-frontend/src/test/java/au/com/integradev/delphi/executor/DelphiSymbolTableExecutorTest.java
+++ b/delphi-frontend/src/test/java/au/com/integradev/delphi/executor/DelphiSymbolTableExecutorTest.java
@@ -1411,7 +1411,7 @@ class DelphiSymbolTableExecutorTest {
     when(fileConfig.getDefinitions()).thenReturn(Collections.emptySet());
 
     mainFile = DelphiInputFile.from(inputFile, fileConfig);
-    List<Path> sourceFiles = List.of(Path.of(mainFile.getInputFile().uri()));
+    List<Path> sourceFiles = List.of(DelphiUtils.inputFileToPath(inputFile));
     SearchPath searchPath =
         SearchPath.create(
             Arrays.stream(searchPaths)


### PR DESCRIPTION
This PR fixes a bug that causes UNC paths to be mangled when converting the Sonar-provided file URI to an absolute path.

`java.io.File` and `java.nio.file.Path` are both convertible to a `java.net.URI`, but they treat UNC paths differently:

- `File` places the entire path in the path portion of the URI - `\\host\a\b\c` becomes `file:////host/a/b/c`
- `Path` (correctly) places the host in the host portion of the URI - `\\host\a\b\c` becomes `file://host/a/b/c`

We were mixing and matching our approach by feeding the `File` constructor with a URI constructed from a `Path` object. This PR fixes the issue by creating a `Path` from the URI, then creating the file via `Path.toFile` instead.