### PR TITLE
Add check for redundant inherited statements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `RedundantInherited` analysis rule, which flags redundant `inherited` statements that can be safely removed.
+
 ## [1.6.0] - 2024-05-31
 
 ### Added

--- a/delphi-checks/src/main/java/au/com/integradev/delphi/checks/CheckList.java
+++ b/delphi-checks/src/main/java/au/com/integradev/delphi/checks/CheckList.java
@@ -125,6 +125,7 @@ public final class CheckList {
           RedundantAssignmentCheck.class,
           RedundantBooleanCheck.class,
           RedundantCastCheck.class,
+          RedundantInheritedCheck.class,
           RedundantParenthesesCheck.class,
           RoutineNameCheck.class,
           RoutineNestingDepthCheck.class,

--- a/delphi-checks/src/main/java/au/com/integradev/delphi/checks/RedundantInheritedCheck.java
+++ b/delphi-checks/src/main/java/au/com/integradev/delphi/checks/RedundantInheritedCheck.java
@@ -1,0 +1,71 @@
+/*
+ * Sonar Delphi Plugin
+ * Copyright (C) 2024 Integrated Application Development
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02
+ */
+package au.com.integradev.delphi.checks;
+
+import au.com.integradev.delphi.utils.RoutineUtils;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.sonar.check.Rule;
+import org.sonar.plugins.communitydelphi.api.ast.CompoundStatementNode;
+import org.sonar.plugins.communitydelphi.api.ast.DelphiNode;
+import org.sonar.plugins.communitydelphi.api.ast.ExpressionStatementNode;
+import org.sonar.plugins.communitydelphi.api.ast.RoutineImplementationNode;
+import org.sonar.plugins.communitydelphi.api.ast.StatementNode;
+import org.sonar.plugins.communitydelphi.api.ast.utils.ExpressionNodeUtils;
+import org.sonar.plugins.communitydelphi.api.check.DelphiCheck;
+import org.sonar.plugins.communitydelphi.api.check.DelphiCheckContext;
+import org.sonar.plugins.communitydelphi.api.symbol.declaration.RoutineNameDeclaration;
+
+@Rule(key = "RedundantInherited")
+public class RedundantInheritedCheck extends DelphiCheck {
+  private static final String MESSAGE = "Remove this redundant inherited call.";
+
+  @Override
+  public DelphiCheckContext visit(RoutineImplementationNode routine, DelphiCheckContext context) {
+    for (DelphiNode violationNode : findViolations(routine)) {
+      reportIssue(context, violationNode, MESSAGE);
+    }
+    return super.visit(routine, context);
+  }
+
+  private static List<DelphiNode> findViolations(RoutineImplementationNode routine) {
+    CompoundStatementNode block = routine.getStatementBlock();
+    if (block == null) {
+      return Collections.emptyList();
+    }
+
+    List<StatementNode> statements = block.getDescendentStatements();
+    if (statements.isEmpty()) {
+      return Collections.emptyList();
+    }
+
+    List<RoutineNameDeclaration> inheritedMethods =
+        RoutineUtils.findParentMethodDeclarations(routine);
+    if (!inheritedMethods.isEmpty()) {
+      return Collections.emptyList();
+    }
+
+    return statements.stream()
+        .filter((statement) -> statement instanceof ExpressionStatementNode)
+        .map((statement) -> ((ExpressionStatementNode) statement).getExpression())
+        .filter(ExpressionNodeUtils::isBareInherited)
+        .collect(Collectors.toList());
+  }
+}

--- a/delphi-checks/src/main/resources/org/sonar/l10n/delphi/rules/community-delphi/RedundantInherited.html
+++ b/delphi-checks/src/main/resources/org/sonar/l10n/delphi/rules/community-delphi/RedundantInherited.html
@@ -1,0 +1,26 @@
+<h2>Why is this an issue?</h2>
+<p>
+  It is possible to use a bare <code>inherited</code> in any method implementation, even if there is
+  no base method to call. Although this statement has no behavioral effect, it is misleading and
+  indicates a possible programming mistake.
+</p>
+<p>
+  Since the <code>inherited</code> keyword works regardless of whether the method is marked as
+  <code>override</code>, it can also lead to unexpected behavioral change if corresponding ancestor
+  methods are added later.
+</p>
+<h2>How to fix it</h2>
+<p>Remove the <code>inherited</code> statement:</p>
+<pre data-diff-id="1" data-diff-type="noncompliant">
+procedure TChild.Proc(Foo: TFoo);
+begin
+  inherited;
+  // ...
+end;
+</pre>
+<pre data-diff-id="1" data-diff-type="compliant">
+procedure TChild.Proc(Foo: TFoo);
+begin
+  // ...
+end;
+</pre>

--- a/delphi-checks/src/main/resources/org/sonar/l10n/delphi/rules/community-delphi/RedundantInherited.json
+++ b/delphi-checks/src/main/resources/org/sonar/l10n/delphi/rules/community-delphi/RedundantInherited.json
@@ -1,0 +1,19 @@
+{
+  "title": "Redundant inherited statements should be removed",
+  "type": "CODE_SMELL",
+  "status": "ready",
+  "remediation": {
+    "func": "Constant/Issue",
+    "constantCost": "5min"
+  },
+  "code": {
+    "attribute": "CLEAR",
+    "impacts": {
+      "MAINTAINABILITY": "MEDIUM"
+    }
+  },
+  "tags": ["unused", "bad-practice"],
+  "defaultSeverity": "Major",
+  "scope": "ALL",
+  "quickfix": "unknown"
+}

--- a/delphi-checks/src/main/resources/org/sonar/l10n/delphi/rules/community-delphi/Sonar_way_profile.json
+++ b/delphi-checks/src/main/resources/org/sonar/l10n/delphi/rules/community-delphi/Sonar_way_profile.json
@@ -68,6 +68,7 @@
     "RedundantAssignment",
     "RedundantBoolean",
     "RedundantCast",
+    "RedundantInherited",
     "RedundantParentheses",
     "RoutineName",
     "RoutineNestingDepth",

--- a/delphi-checks/src/test/java/au/com/integradev/delphi/checks/RedundantInheritedCheckTest.java
+++ b/delphi-checks/src/test/java/au/com/integradev/delphi/checks/RedundantInheritedCheckTest.java
@@ -1,0 +1,147 @@
+/*
+ * Sonar Delphi Plugin
+ * Copyright (C) 2024 Integrated Application Development
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02
+ */
+package au.com.integradev.delphi.checks;
+
+import au.com.integradev.delphi.builders.DelphiTestUnitBuilder;
+import au.com.integradev.delphi.checks.verifier.CheckVerifier;
+import org.junit.jupiter.api.Test;
+
+class RedundantInheritedCheckTest {
+  @Test
+  void testOverridingParentShouldNotAddIssue() {
+    CheckVerifier.newVerifier()
+        .withCheck(new RedundantInheritedCheck())
+        .onFile(
+            new DelphiTestUnitBuilder()
+                .appendDecl("type")
+                .appendDecl("  TBase = class(TObject)")
+                .appendDecl("    procedure MyProcedure;")
+                .appendDecl("  end;")
+                .appendDecl("  TChild = class(TBase)")
+                .appendDecl("    procedure MyProcedure;")
+                .appendDecl("  end;")
+                .appendImpl("procedure TChild.MyProcedure;")
+                .appendImpl("begin")
+                .appendImpl("  inherited; // Compliant")
+                .appendImpl("  begin")
+                .appendImpl("    inherited; // Compliant")
+                .appendImpl("  end;")
+                .appendImpl("  inherited; // Compliant")
+                .appendImpl("end;"))
+        .verifyNoIssues();
+  }
+
+  @Test
+  void testOverridingParentInCompoundStatementShouldNotAddIssue() {
+    CheckVerifier.newVerifier()
+        .withCheck(new RedundantInheritedCheck())
+        .onFile(
+            new DelphiTestUnitBuilder()
+                .appendDecl("type")
+                .appendDecl("  TBase = class(TObject)")
+                .appendDecl("    procedure MyProcedure;")
+                .appendDecl("  end;")
+                .appendDecl("  TChild = class(TBase)")
+                .appendDecl("    procedure MyProcedure;")
+                .appendDecl("  end;")
+                .appendImpl("procedure TChild.MyProcedure;")
+                .appendImpl("begin")
+                .appendImpl("  inherited; // Compliant")
+                .appendImpl("  begin")
+                .appendImpl("    inherited; // Compliant")
+                .appendImpl("  end;")
+                .appendImpl("  inherited; // Compliant")
+                .appendImpl("end;"))
+        .verifyNoIssues();
+  }
+
+  @Test
+  void testOverridingParentAndGrandparentShouldNotAddIssue() {
+    CheckVerifier.newVerifier()
+        .withCheck(new RedundantInheritedCheck())
+        .onFile(
+            new DelphiTestUnitBuilder()
+                .appendDecl("type")
+                .appendDecl("  TBase = class(TObject)")
+                .appendDecl("    procedure MyProcedure;")
+                .appendDecl("  end;")
+                .appendDecl("  TChild = class(TBase)")
+                .appendDecl("    procedure MyProcedure;")
+                .appendDecl("  end;")
+                .appendDecl("  TGrandChild = class(TChild)")
+                .appendDecl("    procedure MyProcedure;")
+                .appendDecl("  end;")
+                .appendImpl("procedure TGrandChild.MyProcedure;")
+                .appendImpl("begin")
+                .appendImpl("  inherited; // Compliant")
+                .appendImpl("  begin")
+                .appendImpl("    inherited; // Compliant")
+                .appendImpl("  end;")
+                .appendImpl("  inherited; // Compliant")
+                .appendImpl("end;"))
+        .verifyNoIssues();
+  }
+
+  @Test
+  void testOverridingGrandparentShouldNotAddIssue() {
+    CheckVerifier.newVerifier()
+        .withCheck(new RedundantInheritedCheck())
+        .onFile(
+            new DelphiTestUnitBuilder()
+                .appendDecl("type")
+                .appendDecl("  TBase = class(TObject)")
+                .appendDecl("    procedure MyProcedure;")
+                .appendDecl("  end;")
+                .appendDecl("  TChild = class(TBase);")
+                .appendDecl("  TGrandChild = class(TChild)")
+                .appendDecl("    procedure MyProcedure;")
+                .appendDecl("  end;")
+                .appendImpl("procedure TGrandChild.MyProcedure;")
+                .appendImpl("begin")
+                .appendImpl("  inherited; // Compliant")
+                .appendImpl("  begin")
+                .appendImpl("    inherited; // Compliant")
+                .appendImpl("  end;")
+                .appendImpl("  inherited; // Compliant")
+                .appendImpl("end;"))
+        .verifyNoIssues();
+  }
+
+  @Test
+  void testNotOverridingMethodShouldAddIssues() {
+    CheckVerifier.newVerifier()
+        .withCheck(new RedundantInheritedCheck())
+        .onFile(
+            new DelphiTestUnitBuilder()
+                .appendDecl("type")
+                .appendDecl("  TBase = class(TObject);")
+                .appendDecl("  TChild = class(TBase)")
+                .appendDecl("    procedure MyProcedure;")
+                .appendDecl("  end;")
+                .appendImpl("procedure TChild.MyProcedure;")
+                .appendImpl("begin")
+                .appendImpl("  inherited; // Noncompliant")
+                .appendImpl("  begin")
+                .appendImpl("    inherited; // Noncompliant")
+                .appendImpl("  end;")
+                .appendImpl("  inherited; // Noncompliant")
+                .appendImpl("end;"))
+        .verifyIssues();
+  }
+}

--- a/delphi-checks/src/test/java/au/com/integradev/delphi/checks/RedundantInheritedCheckTest.java
+++ b/delphi-checks/src/test/java/au/com/integradev/delphi/checks/RedundantInheritedCheckTest.java
@@ -136,10 +136,13 @@ class RedundantInheritedCheckTest {
                 .appendDecl("  end;")
                 .appendImpl("procedure TChild.MyProcedure;")
                 .appendImpl("begin")
+                .appendImpl("  // Fix qf1@[+1:2 to +2:2] <<>>")
                 .appendImpl("  inherited; // Noncompliant")
                 .appendImpl("  begin")
+                .appendImpl("    // Fix qf2@[+1:4 to +1:14] <<>>")
                 .appendImpl("    inherited; // Noncompliant")
                 .appendImpl("  end;")
+                .appendImpl("  // Fix qf3@[-1:5 to +1:11] <<>>")
                 .appendImpl("  inherited; // Noncompliant")
                 .appendImpl("end;"))
         .verifyIssues();


### PR DESCRIPTION
A bare `inherited` statement can be put in any method, regardless of whether the method is overriding a parent's.
The compiler treats these as no-ops, which indicates they can be removed. Using these statements without overriding a method makes the code far more confusing.