### PR TITLE
Add parsing support for `winapi` calling convention

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Support for the `winapi` calling convention.
+- **API:** `DelphiTokenType.WINAPI` token type.
+
 ### Fixed
 
 - Exception when parsing fully qualified attribute references.

--- a/delphi-frontend/src/main/antlr3/au/com/integradev/delphi/antlr/Delphi.g
+++ b/delphi-frontend/src/main/antlr3/au/com/integradev/delphi/antlr/Delphi.g
@@ -953,6 +953,7 @@ callConvention               : CDECL
                              | REGISTER
                              | SAFECALL
                              | STDCALL
+                             | WINAPI
                              | EXPORT // deprecated
                              ;
 oldCallConventionDirective   : FAR // deprecated
@@ -987,7 +988,7 @@ keywordsUsedAsNames          : (ABSOLUTE | ABSTRACT | ALIGN | ASSEMBLER | ASSEMB
                              | (NEAR | NODEFAULT | ON | OPERATOR | OUT | OVERLOAD | OVERRIDE | PACKAGE | PASCAL | PLATFORM)
                              | (PRIVATE | PROTECTED | PUBLIC | PUBLISHED | READ | READONLY | REFERENCE | REGISTER | REINTRODUCE)
                              | (REQUIRES | RESIDENT | SAFECALL | SEALED | STATIC | STDCALL | STORED | STRICT | UNSAFE)
-                             | (VARARGS | VIRTUAL | WRITE | WRITEONLY)
+                             | (VARARGS | VIRTUAL | WINAPI | WRITE | WRITEONLY)
                              ;
 keywords                     : (ABSOLUTE | ABSTRACT | AND | ALIGN | ARRAY | AS | ASM | ASSEMBLER | ASSEMBLY)
                              | (AT | AUTOMATED | BEGIN | CASE | CDECL | CLASS | CONST | CONSTRUCTOR | CONTAINS| DEFAULT)
@@ -1001,7 +1002,7 @@ keywords                     : (ABSOLUTE | ABSTRACT | AND | ALIGN | ARRAY | AS |
                              | (RECORD | REFERENCE | REGISTER | REINTRODUCE | REPEAT | REQUIRES | RESIDENT)
                              | (RESOURCESTRING | SAFECALL | SEALED | SET | SHL | SHR | STATIC | STDCALL | STORED | STRICT)
                              | (STRING | THEN | THREADVAR | TO | TRY | TYPE | UNIT | UNSAFE | UNTIL | USES | VAR | VARARGS)
-                             | (VIRTUAL | WHILE | WITH | WRITE | WRITEONLY | XOR)
+                             | (VIRTUAL | WHILE | WINAPI | WITH | WRITE | WRITEONLY | XOR)
                              ;
 nameDeclarationList          : nameDeclaration (',' nameDeclaration)* -> ^(TkNameDeclarationList<NameDeclarationListNodeImpl> nameDeclaration nameDeclaration*)
                              ;
@@ -1171,6 +1172,7 @@ VAR               : V A R                       ;
 VARARGS           : V A R A R G S               ;
 VIRTUAL           : V I R T U A L               ;
 WHILE             : W H I L E                   ;
+WINAPI            : W I N A P I                 ;
 WITH              : W I T H                     ;
 WRITE             : W R I T E                   ;
 WRITEONLY         : W R I T E O N L Y           ;

--- a/delphi-frontend/src/main/java/org/sonar/plugins/communitydelphi/api/symbol/declaration/RoutineDirective.java
+++ b/delphi-frontend/src/main/java/org/sonar/plugins/communitydelphi/api/symbol/declaration/RoutineDirective.java
@@ -42,6 +42,7 @@ public enum RoutineDirective {
   REGISTER(DelphiTokenType.REGISTER),
   SAFECALL(DelphiTokenType.SAFECALL),
   STDCALL(DelphiTokenType.STDCALL),
+  WINAPI(DelphiTokenType.WINAPI),
   EXPORT(DelphiTokenType.EXPORT),
   FAR(DelphiTokenType.FAR),
   LOCAL(DelphiTokenType.LOCAL),

--- a/delphi-frontend/src/test/java/au/com/integradev/delphi/antlr/GrammarTest.java
+++ b/delphi-frontend/src/test/java/au/com/integradev/delphi/antlr/GrammarTest.java
@@ -196,6 +196,11 @@ class GrammarTest {
   }
 
   @Test
+  void testWinapiCallingConvention() {
+    assertParsed("WinapiCallingConvention.pas");
+  }
+
+  @Test
   void testOptionalFunctionReturnType() {
     assertParsed("OptionalFunctionReturnType.pas");
   }

--- a/delphi-frontend/src/test/resources/au/com/integradev/delphi/grammar/WinapiCallingConvention.pas
+++ b/delphi-frontend/src/test/resources/au/com/integradev/delphi/grammar/WinapiCallingConvention.pas
@@ -1,0 +1,12 @@
+unit WinapiCallingConvention;
+
+interface
+
+uses
+  Winapi.Windows;
+
+procedure SetThreadExecutionState(ESFlags: DWORD); winapi; external 'kernel32.dll' name 'SetThreadExecutionState';
+
+implementation
+
+end.


### PR DESCRIPTION
This PR fixes an accidental omission in the SonarDelphi grammar by adding support for the `winapi` calling convention.

Fixes #217