### PR TITLE
Fix cast exception when parsing fully qualified attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Exception when parsing fully qualified attribute references.
+
 ## [1.4.0] - 2024-04-02
 
 ### Added


### PR DESCRIPTION
This PR fixes a `ClassCastException` that occurs when parsing fully qualified attribute references.

Fixes #213 