### PR TITLE
Improve CheckVerifier testing

### DIFF
--- a/delphi-checks-testkit/src/test/java/au/com/integradev/delphi/checks/verifier/CheckVerifierImplTest.java
+++ b/delphi-checks-testkit/src/test/java/au/com/integradev/delphi/checks/verifier/CheckVerifierImplTest.java
@@ -26,13 +26,12 @@ import org.sonar.check.Rule;
 import org.sonar.plugins.communitydelphi.api.ast.ArgumentListNode;
 import org.sonar.plugins.communitydelphi.api.ast.DelphiAst;
 import org.sonar.plugins.communitydelphi.api.ast.DelphiNode;
-import org.sonar.plugins.communitydelphi.api.ast.FileHeaderNode;
-import org.sonar.plugins.communitydelphi.api.ast.ImplementationSectionNode;
 import org.sonar.plugins.communitydelphi.api.ast.NameReferenceNode;
 import org.sonar.plugins.communitydelphi.api.check.DelphiCheck;
 import org.sonar.plugins.communitydelphi.api.check.DelphiCheckContext;
 import org.sonar.plugins.communitydelphi.api.reporting.QuickFix;
 import org.sonar.plugins.communitydelphi.api.reporting.QuickFixEdit;
+import org.sonar.plugins.communitydelphi.api.symbol.declaration.TypeNameDeclaration;
 
 class CheckVerifierImplTest {
   private static final String MESSAGE = "Test message";
@@ -55,6 +54,48 @@ class CheckVerifierImplTest {
     assertThatThrownBy(verifier::verifyIssueOnFile).isInstanceOf(AssertionError.class);
     assertThatThrownBy(verifier::verifyIssueOnProject).isInstanceOf(AssertionError.class);
     assertThatThrownBy(verifier::verifyNoIssues).isInstanceOf(AssertionError.class);
+  }
+
+  @Test
+  void testMustSetCheckBeforeVerify() {
+    CheckVerifier verifier =
+        CheckVerifier.newVerifier()
+            .onFile(
+                new DelphiTestUnitBuilder()
+                    .appendDecl("const")
+                    .appendDecl("  Foo = 0;")
+                    .appendDecl("  Bar = Foo; // Noncompliant"));
+
+    assertThatThrownBy(verifier::verifyIssues)
+        .isInstanceOf(AssertionError.class)
+        .hasMessage("Set check before calling any verification method!");
+    assertThatThrownBy(verifier::verifyNoIssues)
+        .isInstanceOf(AssertionError.class)
+        .hasMessage("Set check before calling any verification method!");
+    assertThatThrownBy(verifier::verifyIssueOnFile)
+        .isInstanceOf(AssertionError.class)
+        .hasMessage("Set check before calling any verification method!");
+    assertThatThrownBy(verifier::verifyIssueOnProject)
+        .isInstanceOf(AssertionError.class)
+        .hasMessage("Set check before calling any verification method!");
+  }
+
+  @Test
+  void testMustSetFileBeforeVerify() {
+    CheckVerifier verifier = CheckVerifier.newVerifier().withCheck(new WillRaiseIssueOnFooCheck());
+
+    assertThatThrownBy(verifier::verifyIssues)
+        .isInstanceOf(AssertionError.class)
+        .hasMessage("Set file before calling any verification method!");
+    assertThatThrownBy(verifier::verifyNoIssues)
+        .isInstanceOf(AssertionError.class)
+        .hasMessage("Set file before calling any verification method!");
+    assertThatThrownBy(verifier::verifyIssueOnFile)
+        .isInstanceOf(AssertionError.class)
+        .hasMessage("Set file before calling any verification method!");
+    assertThatThrownBy(verifier::verifyIssueOnProject)
+        .isInstanceOf(AssertionError.class)
+        .hasMessage("Set file before calling any verification method!");
   }
 
   @Test
@@ -85,6 +126,60 @@ class CheckVerifierImplTest {
                     .appendDecl("  Bar = Foo; // Noncompliant"));
 
     assertThatThrownBy(verifier::verifyIssues).isInstanceOf(AssertionError.class);
+  }
+
+  @Test
+  void testMismatchingQuickFix() {
+    CheckVerifier verifier =
+        CheckVerifier.newVerifier()
+            .withCheck(new WillRaiseQuickFixOnFooCheck())
+            .onFile(
+                new DelphiTestUnitBuilder()
+                    .appendDecl("const")
+                    .appendDecl("  Foo = 0;")
+                    .appendDecl("// Fix@[+1:2 to +1:5] <<BarBaz>>")
+                    .appendDecl("  Bar = Foo; // Noncompliant"));
+
+    assertThatThrownBy(verifier::verifyIssues)
+        .isInstanceOf(AssertionError.class)
+        .hasMessageContainingAll("Expected:", "Found 1 non-matching quick fixes:");
+  }
+
+  @Test
+  void testTwoMismatchingQuickFixes() {
+    CheckVerifier verifier =
+        CheckVerifier.newVerifier()
+            .withCheck(new WillRaiseQuickFixOnFooCheck())
+            .onFile(
+                new DelphiTestUnitBuilder()
+                    .appendDecl("const")
+                    .appendDecl("  Foo = 0;")
+                    .appendDecl("// Fix qf1@[+1:2 to +1:5] <<BarBaz>>")
+                    .appendDecl("  Bar = Foo; // Noncompliant")
+                    .appendDecl("// Fix qf2@[+1:2 to +1:5] <<BarBaz>>")
+                    .appendDecl("  Baz = Foo; // Noncompliant"));
+
+    assertThatThrownBy(verifier::verifyIssues)
+        .isInstanceOf(AssertionError.class)
+        .hasMessageContainingAll("Expected:", "Found 2 non-matching quick fixes:");
+  }
+
+  @Test
+  void testWrongNumberOfQuickFixes() {
+    CheckVerifier verifier =
+        CheckVerifier.newVerifier()
+            .withCheck(new WillRaiseQuickFixOnFooCheck())
+            .onFile(
+                new DelphiTestUnitBuilder()
+                    .appendDecl("const")
+                    .appendDecl("  Foo = 0;")
+                    .appendDecl("// Fix qf1@[+2:8 to +2:11] <<BarBaz>>")
+                    .appendDecl("// Fix qf2@[+1:2 to +1:5] <<BarBaz>>")
+                    .appendDecl("  Bar = Foo; // Noncompliant"));
+
+    assertThatThrownBy(verifier::verifyIssues)
+        .isInstanceOf(AssertionError.class)
+        .hasMessage("2 quick fixes expected, found 1");
   }
 
   @Test
@@ -253,6 +348,26 @@ class CheckVerifierImplTest {
   }
 
   @Test
+  void testImpliedAndNotImpliedIssue() {
+    CheckVerifier verifier =
+        CheckVerifier.newVerifier()
+            .withCheck(new WillRaiseIssueOnFooCheck())
+            .onFile(
+                new DelphiTestUnitBuilder()
+                    .appendDecl("const")
+                    .appendDecl("  Foo = 42;")
+                    .appendDecl("  Baz = 0; // Noncompliant")
+                    .appendDecl("  Bar = Foo;"));
+
+    assertThatThrownBy(verifier::verifyIssues)
+        .isInstanceOf(AssertionError.class)
+        .hasMessageContainingAll("Issues were expected at", "unexpected at");
+    assertThatThrownBy(verifier::verifyNoIssues).isInstanceOf(AssertionError.class);
+    assertThatThrownBy(verifier::verifyIssueOnFile).isInstanceOf(AssertionError.class);
+    assertThatThrownBy(verifier::verifyIssueOnProject).isInstanceOf(AssertionError.class);
+  }
+
+  @Test
   void testFileIssue() {
     CheckVerifier verifier =
         CheckVerifier.newVerifier()
@@ -264,6 +379,44 @@ class CheckVerifierImplTest {
     assertThatThrownBy(verifier::verifyIssues).isInstanceOf(AssertionError.class);
     assertThatThrownBy(verifier::verifyIssueOnProject).isInstanceOf(AssertionError.class);
     assertThatThrownBy(verifier::verifyNoIssues).isInstanceOf(AssertionError.class);
+  }
+
+  DelphiTestUnitBuilder unitWithTFlorp(String name) {
+    return new DelphiTestUnitBuilder()
+        .unitName(name)
+        .appendDecl("type")
+        .appendDecl("  TFlorp = class(TObject)")
+        .appendDecl("  public")
+        .appendDecl("    procedure Bonk;")
+        .appendDecl("  end;");
+  }
+
+  @Test
+  void testAddStandardLibraryUnit() {
+    CheckVerifier verifier =
+        CheckVerifier.newVerifier()
+            .withCheck(new WillRaiseIssueOnTFlorpUsagesCheck("System.SysUtils"))
+            .withStandardLibraryUnit(unitWithTFlorp("System.SysUtils"))
+            .onFile(
+                new DelphiTestUnitBuilder()
+                    .appendImpl("uses System.SysUtils;")
+                    .appendImpl("var Boop: TFlorp; // Noncompliant"));
+
+    assertThatCode(verifier::verifyIssues).doesNotThrowAnyException();
+  }
+
+  @Test
+  void testAddSearchPathUnit() {
+    CheckVerifier verifier =
+        CheckVerifier.newVerifier()
+            .withCheck(new WillRaiseIssueOnTFlorpUsagesCheck("BlimpBlomp"))
+            .withStandardLibraryUnit(unitWithTFlorp("BlimpBlomp"))
+            .onFile(
+                new DelphiTestUnitBuilder()
+                    .appendImpl("uses BlimpBlomp;")
+                    .appendImpl("var Boop: TFlorp; // Noncompliant"));
+
+    assertThatCode(verifier::verifyIssues).doesNotThrowAnyException();
   }
 
   @Rule(key = "WillRaiseIssueOnFoo")
@@ -322,28 +475,23 @@ class CheckVerifierImplTest {
     }
   }
 
-  @Rule(key = "WillRaiseLineIssueOnFileHeader")
-  public static class WillRaiseLineIssueOnFileHeaderCheck extends DelphiCheck {
-    @Override
-    public DelphiCheckContext visit(FileHeaderNode fileHeader, DelphiCheckContext context) {
-      reportIssue(context, fileHeader, MESSAGE);
-      return super.visit(fileHeader, context);
-    }
-  }
+  @Rule(key = "WillRaiseIssueOnTFlorpUsages")
+  public static class WillRaiseIssueOnTFlorpUsagesCheck extends DelphiCheck {
 
-  @Rule(key = "WillRaiseLineIssueOnFileHeaderAndImplementation")
-  public static class WillRaiseLineIssueOnFileHeaderAndImplementationCheck extends DelphiCheck {
-    @Override
-    public DelphiCheckContext visit(FileHeaderNode fileHeader, DelphiCheckContext context) {
-      reportIssue(context, fileHeader, MESSAGE);
-      return super.visit(fileHeader, context);
+    private final String unitName;
+
+    public WillRaiseIssueOnTFlorpUsagesCheck(String unitName) {
+      this.unitName = unitName;
     }
 
     @Override
-    public DelphiCheckContext visit(
-        ImplementationSectionNode implementationSection, DelphiCheckContext context) {
-      reportIssue(context, implementationSection, MESSAGE);
-      return super.visit(implementationSection, context);
+    public DelphiCheckContext visit(NameReferenceNode nameReference, DelphiCheckContext context) {
+      var declaration = nameReference.getNameDeclaration();
+      if (declaration instanceof TypeNameDeclaration
+          && ((TypeNameDeclaration) declaration).getType().is(unitName + ".TFlorp")) {
+        reportIssue(context, nameReference, MESSAGE);
+      }
+      return super.visit(nameReference, context);
     }
   }
 

--- a/delphi-checks/src/main/java/au/com/integradev/delphi/checks/AbstractGroupedDeclarationCheck.java
+++ b/delphi-checks/src/main/java/au/com/integradev/delphi/checks/AbstractGroupedDeclarationCheck.java
@@ -37,7 +37,7 @@ public abstract class AbstractGroupedDeclarationCheck extends DelphiCheck {
       DelphiIssueBuilder newIssue =
           context.newIssue().onNode(declarationList).withMessage(getIssueMessage());
 
-      QuickFix quickFix = createQuickFix(declarationList, context);
+      QuickFix quickFix = createQuickFix(declarationList);
       if (quickFix != null) {
         newIssue.withQuickFixes(quickFix);
       }
@@ -47,8 +47,14 @@ public abstract class AbstractGroupedDeclarationCheck extends DelphiCheck {
     return super.visit(declarationList, context);
   }
 
-  protected QuickFix createQuickFix(
-      NameDeclarationListNode declarationList, DelphiCheckContext context) {
+  /**
+   * Stub for implementing a quick fix that separates the grouped declarations. Does nothing by
+   * default, but can be overridden to implement behaviour.
+   *
+   * @param declarationList the node containing the grouped declarations.
+   * @return a quick fix to associate with the raised issue, or null.
+   */
+  protected QuickFix createQuickFix(NameDeclarationListNode declarationList) {
     return null;
   }
 }

--- a/delphi-checks/src/main/java/au/com/integradev/delphi/checks/GroupedParameterDeclarationCheck.java
+++ b/delphi-checks/src/main/java/au/com/integradev/delphi/checks/GroupedParameterDeclarationCheck.java
@@ -27,7 +27,6 @@ import org.sonar.plugins.communitydelphi.api.ast.NameDeclarationListNode;
 import org.sonar.plugins.communitydelphi.api.ast.NameDeclarationNode;
 import org.sonar.plugins.communitydelphi.api.ast.RoutineParametersNode;
 import org.sonar.plugins.communitydelphi.api.ast.TypeNode;
-import org.sonar.plugins.communitydelphi.api.check.DelphiCheckContext;
 import org.sonar.plugins.communitydelphi.api.reporting.QuickFix;
 import org.sonar.plugins.communitydelphi.api.reporting.QuickFixEdit;
 import org.sonar.plugins.communitydelphi.api.token.DelphiTokenType;
@@ -59,8 +58,7 @@ public class GroupedParameterDeclarationCheck extends AbstractGroupedDeclaration
   }
 
   @Override
-  protected QuickFix createQuickFix(
-      NameDeclarationListNode declarationList, DelphiCheckContext context) {
+  protected QuickFix createQuickFix(NameDeclarationListNode declarationList) {
     FormalParameterNode formalParameter = (FormalParameterNode) declarationList.getParent();
 
     TypeNode typeNode = formalParameter.getTypeNode();


### PR DESCRIPTION
This PR adds a number of new test cases to CheckVerifier, improving test coverage around

- Messages in different situations
- Verifying parameters have been correctly set
- More quick fix cases

I've also fixed a Sonar issue in AbstractGroupedDeclaration.