### PR TITLE
Improve usage of local scopes in the symbol table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,14 +22,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - "Separate grouped parameters" quick fix for `GroupedParameterDeclaration`.
 - "Remove (n) unused formatting arguments" quick fix for `FormatArgumentCount`.
 - "Use string value directly" quick fix for `FormatArgumentCount`.
+- **API:** `TryStatementNode::getExceptBlock` method.
+- **API:** `WhileStatementNode::getGuardExpression` method.
+- **API:** `WhileStatementNode::getStatement` method.
 - **API:** `DelphiTokenType.WINAPI` token type.
 - **API:** `DelphiIssueBuilder` type, which is returned by `DelphiCheckContext::newIssue`.
 - **API:** `QuickFix` type, which is accepted by `DelphiIssueBuilder::withQuickFixes`.
 - **API:** `QuickFixEdit` type, which is accepted by `QuickFix::addEdits`.
 
+### Deprecated
+
+- **API:** `TryStatementNode::getExpectBlock` method, use `getExceptBlock` instead.
+
 ### Fixed
 
 - Exception when parsing fully qualified attribute references.
+- `DuplicatedDeclarationException` errors caused by some local scopes being modeled incorrectly.
 
 ## [1.4.0] - 2024-04-02
 

--- a/delphi-frontend/src/main/java/au/com/integradev/delphi/antlr/ast/node/TryStatementNodeImpl.java
+++ b/delphi-frontend/src/main/java/au/com/integradev/delphi/antlr/ast/node/TryStatementNodeImpl.java
@@ -53,8 +53,14 @@ public final class TryStatementNodeImpl extends DelphiNodeImpl implements TrySta
     return getChild(1) instanceof FinallyBlockNode;
   }
 
+  @SuppressWarnings("removal")
   @Override
   public ExceptBlockNode getExpectBlock() {
+    return getExceptBlock();
+  }
+
+  @Override
+  public ExceptBlockNode getExceptBlock() {
     if (exceptBlock == null && hasExceptBlock()) {
       exceptBlock = (ExceptBlockNode) getChild(1);
     }

--- a/delphi-frontend/src/main/java/au/com/integradev/delphi/antlr/ast/node/WhileStatementNodeImpl.java
+++ b/delphi-frontend/src/main/java/au/com/integradev/delphi/antlr/ast/node/WhileStatementNodeImpl.java
@@ -19,7 +19,10 @@
 package au.com.integradev.delphi.antlr.ast.node;
 
 import au.com.integradev.delphi.antlr.ast.visitors.DelphiParserVisitor;
+import javax.annotation.Nullable;
 import org.antlr.runtime.Token;
+import org.sonar.plugins.communitydelphi.api.ast.ExpressionNode;
+import org.sonar.plugins.communitydelphi.api.ast.StatementNode;
 import org.sonar.plugins.communitydelphi.api.ast.WhileStatementNode;
 
 public final class WhileStatementNodeImpl extends DelphiNodeImpl implements WhileStatementNode {
@@ -30,5 +33,16 @@ public final class WhileStatementNodeImpl extends DelphiNodeImpl implements Whil
   @Override
   public <T> T accept(DelphiParserVisitor<T> visitor, T data) {
     return visitor.visit(this, data);
+  }
+
+  @Override
+  public ExpressionNode getGuardExpression() {
+    return (ExpressionNode) getChild(0);
+  }
+
+  @Override
+  @Nullable
+  public StatementNode getStatement() {
+    return (StatementNode) getChild(2);
   }
 }

--- a/delphi-frontend/src/main/java/org/sonar/plugins/communitydelphi/api/ast/TryStatementNode.java
+++ b/delphi-frontend/src/main/java/org/sonar/plugins/communitydelphi/api/ast/TryStatementNode.java
@@ -18,14 +18,49 @@
  */
 package org.sonar.plugins.communitydelphi.api.ast;
 
+/** {@code try} statement. */
 public interface TryStatementNode extends StatementNode {
+  /**
+   * Returns the list of statements from within this {@code try} statement.
+   *
+   * @return statement list from within this {@code try} statement
+   */
   StatementListNode getStatementList();
 
+  /**
+   * Returns whether this {@code try} statement has an {@code except} block.
+   *
+   * @return true if this {@code try} statement has an {@code except} block
+   */
   boolean hasExceptBlock();
 
+  /**
+   * Returns whether this {@code try} statement has a {@code finally} block.
+   *
+   * @return true if this {@code try} statement has a {@code finally} block
+   */
   boolean hasFinallyBlock();
 
+  /**
+   * Returns the {@code except} block for this {@code try} statement.
+   *
+   * @return the {@code except} block for this {@code try} statement
+   * @deprecated Use {@link TryStatementNode#getExceptBlock()} instead
+   */
+  @Deprecated(forRemoval = true)
   ExceptBlockNode getExpectBlock();
 
+  /**
+   * Returns the {@code except} block for this {@code try} statement.
+   *
+   * @return the {@code except} block for this {@code try} statement
+   */
+  ExceptBlockNode getExceptBlock();
+
+  /**
+   * Returns the {@code finally} block for this {@code try} statement.
+   *
+   * @return the {@code finally} block for this {@code try} statement
+   */
   FinallyBlockNode getFinallyBlock();
 }

--- a/delphi-frontend/src/main/java/org/sonar/plugins/communitydelphi/api/ast/WhileStatementNode.java
+++ b/delphi-frontend/src/main/java/org/sonar/plugins/communitydelphi/api/ast/WhileStatementNode.java
@@ -18,4 +18,23 @@
  */
 package org.sonar.plugins.communitydelphi.api.ast;
 
-public interface WhileStatementNode extends StatementNode {}
+import javax.annotation.Nullable;
+
+/** {@code while} loop statement. */
+public interface WhileStatementNode extends StatementNode {
+  /**
+   * Returns the guard expression for this {@code while} loop.
+   *
+   * @return the guard expression for this {@code while} loop
+   */
+  ExpressionNode getGuardExpression();
+
+  /**
+   * Returns the statement that will be executed in this {@code while} loop, also known as the loop
+   * body.
+   *
+   * @return the statement that will be executed in this {@code while} loop
+   */
+  @Nullable
+  StatementNode getStatement();
+}

--- a/delphi-frontend/src/test/java/au/com/integradev/delphi/executor/DelphiSymbolTableExecutorTest.java
+++ b/delphi-frontend/src/test/java/au/com/integradev/delphi/executor/DelphiSymbolTableExecutorTest.java
@@ -381,6 +381,13 @@ class DelphiSymbolTableExecutorTest {
   }
 
   @Test
+  void testLocalScopes() {
+    execute("LocalScopes.pas");
+    verifyUsages(68, 8, reference(69, 10));
+    verifyUsages(73, 10, reference(74, 12));
+  }
+
+  @Test
   void testClassReferenceMethodResolution() {
     execute("classReferences/MethodResolution.pas");
     verifyUsages(9, 14, reference(18, 6));

--- a/delphi-frontend/src/test/resources/au/com/integradev/delphi/symbol/LocalScopes.pas
+++ b/delphi-frontend/src/test/resources/au/com/integradev/delphi/symbol/LocalScopes.pas
@@ -1,0 +1,78 @@
+unit LocalScopes;
+
+interface
+
+implementation
+
+procedure TestNoDuplicatedDeclarationException;
+label Baz;
+begin
+  begin
+    var Foo := 'bar';
+  end;
+
+  if True then
+     var Foo := 'bar'
+  else
+    var Foo := 'bar';
+
+  case True of
+    True: var Foo := 'bar';
+    False: var Foo := 'bar';
+    else var Foo := 'bar';
+  end;
+
+  repeat
+     var Foo := 'bar';
+  until False;
+
+  while False do begin
+      var Foo := 'bar';
+  end;
+
+  try
+    var Foo := 'bar';
+  finally
+    var Foo := 'bar';
+  end;
+
+  try
+    var Foo := 'bar';
+  except
+    var Foo := 'bar';
+  end;
+
+  try
+    var Foo := 'bar';
+  except
+    on TObject do begin
+      var Foo := 'bar';
+    end
+    else
+      var Foo := 'bar';
+  end;
+
+  while True do
+    var Foo := 'bar';
+
+  Baz:
+    var Foo := 'bar';
+
+  var Foo := 'bar';
+end;
+
+procedure TestLabelScopeFlatteningBehavior;
+label Baz, Flarp;
+begin
+  Baz:
+    var Foo := 'bar';
+  WriteLn(Foo);
+
+  begin
+    Flarp:
+      var Boop := 'beep';
+    WriteLn(Boop);
+  end;
+end;
+
+end.


### PR DESCRIPTION
This PR improves the modeling of local scopes in the symbol table, which fixes #220.