### PR TITLE
Fix if guard expressions being incorrectly resolved

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Exception when parsing fully qualified attribute references.
 - `DuplicatedDeclarationException` errors caused by some local scopes being modeled incorrectly.
+- Name resolution issues around `if`, `else`, `for`, and `with` constructs when the body contains a single statement.
 
 ## [1.4.0] - 2024-04-02
 

--- a/delphi-frontend/src/main/java/au/com/integradev/delphi/antlr/ast/visitors/SymbolTableVisitor.java
+++ b/delphi-frontend/src/main/java/au/com/integradev/delphi/antlr/ast/visitors/SymbolTableVisitor.java
@@ -557,18 +557,18 @@ public abstract class SymbolTableVisitor implements DelphiParserVisitor<Data> {
 
   @Override
   public Data visit(IfStatementNode node, Data data) {
-    DelphiParserVisitor.super.visit(node.getGuardExpression(), data);
+    node.getGuardExpression().accept(this, data);
 
     StatementNode thenStatement = node.getThenStatement();
     if (thenStatement instanceof CompoundStatementNode) {
-      DelphiParserVisitor.super.visit(thenStatement, data);
+      thenStatement.accept(this, data);
     } else if (thenStatement != null) {
       createLocalScope(thenStatement, data);
     }
 
     StatementNode elseStatement = node.getElseStatement();
     if (elseStatement instanceof CompoundStatementNode) {
-      DelphiParserVisitor.super.visit(elseStatement, data);
+      elseStatement.accept(this, data);
     } else if (elseStatement != null) {
       createLocalScope(elseStatement, data);
     }


### PR DESCRIPTION
This PR fixes a regression introduced by #223, which causes `if` guard expressions to be skipped over by the name resolver. 

This was manifesting in QA as large numbers of erroneous UnusedRoutine, UnusedLocalVariable, and VariableInitialization issues, and I have re-run a subset of the QA checks on this PR and found these issues are no longer cropping up.