### PR TITLE
Correctly handle uppercase format specifiers in format strings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [1.5.0] - 2024-05-02
 
+### Fixed
+
+- False positive `FormatStringValid` issues on strings containing uppercase format specifiers.
+
 ### Added
 
 - Support for the `winapi` calling convention.

--- a/delphi-checks/src/main/java/au/com/integradev/delphi/utils/format/FormatStringParser.java
+++ b/delphi-checks/src/main/java/au/com/integradev/delphi/utils/format/FormatStringParser.java
@@ -112,8 +112,10 @@ public class FormatStringParser {
   }
 
   private Optional<FormatSpecifierType> parseFormatSpecifierType() {
+    char specifierChar = Character.toLowerCase(current());
+
     for (FormatSpecifierType type : FormatSpecifierType.values()) {
-      if (type.getImage() == current()) {
+      if (type.getImage() == specifierChar) {
         return Optional.of(type);
       }
     }

--- a/delphi-checks/src/test/java/au/com/integradev/delphi/checks/FormatArgumentTypeCheckTest.java
+++ b/delphi-checks/src/test/java/au/com/integradev/delphi/checks/FormatArgumentTypeCheckTest.java
@@ -69,8 +69,8 @@ class FormatArgumentTypeCheckTest {
   @CsvSource(
       value = {
         "%d,5000", "%d,-5000", "%d,0",
-        "%u,5000", "%d,-5000", "%u,0",
-        "%x,5000", "%d,-5000", "%x,0",
+        "%u,5000", "%u,-5000", "%u,0",
+        "%x,5000", "%x,-5000", "%x,0",
         "%e,25.5", "%e,-25.5", "%e,0.0",
         "%f,25.5", "%f,-25.5", "%f,0.0",
         "%g,25.5", "%g,-25.5", "%g,0.0",
@@ -135,6 +135,23 @@ class FormatArgumentTypeCheckTest {
                 .appendImpl("uses System.SysUtils;")
                 .appendImpl("initialization")
                 .appendImpl("  Format('I got %*.*f and I am %0:d years old', [")
+                .appendImpl("    5,")
+                .appendImpl("    2,")
+                .appendImpl("    67.455")
+                .appendImpl("  ]);"))
+        .verifyNoIssues();
+  }
+
+  @Test
+  void testMultipleUppercaseValidTypesShouldNotAddIssue() {
+    CheckVerifier.newVerifier()
+        .withCheck(new FormatArgumentTypeCheck())
+        .withStandardLibraryUnit(sysUtils())
+        .onFile(
+            new DelphiTestUnitBuilder()
+                .appendImpl("uses System.SysUtils;")
+                .appendImpl("initialization")
+                .appendImpl("  Format('I got %*.*F and I am %0:D years old', [")
                 .appendImpl("    5,")
                 .appendImpl("    2,")
                 .appendImpl("    67.455")

--- a/delphi-checks/src/test/java/au/com/integradev/delphi/checks/FormatStringValidCheckTest.java
+++ b/delphi-checks/src/test/java/au/com/integradev/delphi/checks/FormatStringValidCheckTest.java
@@ -31,7 +31,13 @@ class FormatStringValidCheckTest {
   }
 
   @ParameterizedTest
-  @ValueSource(strings = {"%s %d %*.*f %0:e %*.f", "I have no specifiers", ""})
+  @ValueSource(
+      strings = {
+        "%s %d %*.*f %0:e %*.f",
+        "I have no specifiers",
+        "",
+        "Uppercase %S and %D and %X as well %%"
+      })
   void testValidFormatStringShouldNotAddIssue(String formatString) {
     CheckVerifier.newVerifier()
         .withCheck(new FormatStringValidCheck())

--- a/delphi-checks/src/test/java/au/com/integradev/delphi/utils/format/FormatStringParserTest.java
+++ b/delphi-checks/src/test/java/au/com/integradev/delphi/utils/format/FormatStringParserTest.java
@@ -165,6 +165,29 @@ class FormatStringParserTest {
     assertThat(specifiers.get(0).getType()).isEqualTo(expectedType);
   }
 
+  @ParameterizedTest(name = "[{index}] {0} parsed as {1}")
+  @CsvSource(
+      value = {
+        "%D,DECIMAL",
+        "%U,UNSIGNED_DECIMAL",
+        "%E,SCIENTIFIC",
+        "%F,FIXED",
+        "%G,GENERAL",
+        "%N,NUMBER",
+        "%M,MONEY",
+        "%P,POINTER",
+        "%S,STRING",
+        "%X,HEXADECIMAL"
+      })
+  void testParseUppercaseFormatSpecifierType(
+      String formatString, FormatSpecifierType expectedType) {
+    List<FormatSpecifier> specifiers =
+        new FormatStringParser(formatString).parse().getFormatSpecifiers();
+
+    assertThat(specifiers).hasSize(1);
+    assertThat(specifiers.get(0).getType()).isEqualTo(expectedType);
+  }
+
   @Test
   void testParseStringWithNoSpecifiers() {
     assertThat(new FormatStringParser("Hello world").parse().getFormatSpecifiers()).isEmpty();


### PR DESCRIPTION
This PR modifies the format string parser to match format specifiers case-insensitively, as specified in the Delphi documentation.

Fixes #228