### PR TITLE
Correct ordering of GroupedParameterDeclaration quick fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Incorrect ordering of edits in the "Separate grouped parameters" quick fix for `GroupedParameterDeclaration`.
+
 ## [1.5.0] - 2024-05-02
 
 ### Fixed

--- a/delphi-checks/src/main/java/au/com/integradev/delphi/checks/GroupedParameterDeclarationCheck.java
+++ b/delphi-checks/src/main/java/au/com/integradev/delphi/checks/GroupedParameterDeclarationCheck.java
@@ -79,8 +79,8 @@ public class GroupedParameterDeclarationCheck extends AbstractGroupedDeclaration
         fixEdits.add(QuickFixEdit.replace(commaNode, ";"));
       }
 
-      fixEdits.add(QuickFixEdit.copyAfter(typeNode, first));
       fixEdits.add(QuickFixEdit.insertAfter(": ", first));
+      fixEdits.add(QuickFixEdit.copyAfter(typeNode, first));
 
       String prefix = getFormalParameterTextPrefix(formalParameter);
       if (!prefix.isEmpty()) {


### PR DESCRIPTION
This PR fixes a sequencing bug in the GroupedParameterDeclaration quick fix, in which text edits would be applied out of order.