### PR TITLE
Add quick fixes for ImportSpecificity and UnusedImport

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- "Move to implementation section" quick fix for `ImportSpecificity`.
+- "Remove unused import" quick fix for `UnusedImport`.
 - **API:** `UsesClauseNode::getImports` method.
 - **API:** `InterfaceSectionNode::getUsesClause` method.
 - **API:** `ImplementationSectionNode::getUsesClause` method.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **API:** `UsesClauseNode::getImports` method.
+
 ### Fixed
 
 - Incorrect ordering of edits in the "Separate grouped parameters" quick fix for `GroupedParameterDeclaration`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - **API:** `UsesClauseNode::getImports` method.
+- **API:** `InterfaceSectionNode::getUsesClause` method.
+- **API:** `ImplementationSectionNode::getUsesClause` method.
 
 ### Fixed
 

--- a/delphi-checks-testkit/src/main/java/au/com/integradev/delphi/checks/verifier/Expectations.java
+++ b/delphi-checks-testkit/src/main/java/au/com/integradev/delphi/checks/verifier/Expectations.java
@@ -119,7 +119,7 @@ class Expectations {
 
     return new TextEditExpectation(
         fixId == null ? "(unnamed)" : fixId,
-        replacementStr,
+        replacementStr.replace("\\n", "\n").replace("\\r", "\r"),
         beginLine + offset,
         endLine + offset,
         Integer.parseInt(beginColumnStr),

--- a/delphi-checks/src/main/java/au/com/integradev/delphi/checks/UnusedImportCheck.java
+++ b/delphi-checks/src/main/java/au/com/integradev/delphi/checks/UnusedImportCheck.java
@@ -20,6 +20,7 @@ package au.com.integradev.delphi.checks;
 
 import org.sonar.check.Rule;
 import org.sonar.plugins.communitydelphi.api.ast.UnitImportNode;
+import org.sonar.plugins.communitydelphi.api.reporting.QuickFix;
 import org.sonar.plugins.communitydelphi.api.symbol.declaration.UnitNameDeclaration;
 import org.sonarsource.analyzer.commons.annotations.DeprecatedRuleKey;
 
@@ -35,5 +36,10 @@ public class UnusedImportCheck extends AbstractImportCheck {
   @Override
   protected String getIssueMessage() {
     return "Review this potentially unnecessary import.";
+  }
+
+  @Override
+  protected QuickFix getQuickFix(UnitImportNode unitImport) {
+    return QuickFix.newFix("Remove unused import").withEdit(deleteImportEdit(unitImport));
   }
 }

--- a/delphi-checks/src/test/java/au/com/integradev/delphi/checks/ImportSpecificityCheckTest.java
+++ b/delphi-checks/src/test/java/au/com/integradev/delphi/checks/ImportSpecificityCheckTest.java
@@ -74,6 +74,81 @@ class ImportSpecificityCheckTest {
         .verifyNoIssues();
   }
 
+  @Test
+  void testImportUsedInImplementationShouldAddQuickFix() {
+    CheckVerifier.newVerifier()
+        .withCheck(new ImportSpecificityCheck())
+        .withSearchPathUnit(createSystemUITypes())
+        .onFile(
+            new DelphiTestUnitBuilder()
+                .appendDecl("// Fix@[+1:0 to +2:17] <<>>")
+                .appendDecl("uses")
+                .appendDecl("  System.UITypes; // Noncompliant")
+                .appendImpl("// Fix@[+2:20 to +2:20] <<, >>")
+                .appendImpl("// Fix@[+1:20 to +1:20] <<System.UITypes>>")
+                .appendImpl("uses System.SysUtils;")
+                .appendImpl("type")
+                .appendImpl("  Alias = System.UITypes.TMsgDlgType;"))
+        .verifyIssues();
+  }
+
+  @Test
+  void testSingleImportUsedInImplementationWithNoUsesClauseShouldAddQuickFix() {
+    CheckVerifier.newVerifier()
+        .withCheck(new ImportSpecificityCheck())
+        .withSearchPathUnit(createSystemUITypes())
+        .onFile(
+            new DelphiTestUnitBuilder()
+                .appendDecl("// Fix@[+1:0 to +2:17] <<>>")
+                .appendDecl("uses")
+                .appendDecl("  System.UITypes; // Noncompliant")
+                .appendImpl("// Fix@[-2:14 to -2:14] <<\\r\\n\\r\\nuses >>")
+                .appendImpl("// Fix@[-3:14 to -3:14] <<System.UITypes>>")
+                .appendImpl("// Fix@[-4:14 to -4:14] <<;>>")
+                .appendImpl("type")
+                .appendImpl("  Alias = System.UITypes.TMsgDlgType;"))
+        .verifyIssues();
+  }
+
+  @Test
+  void testFirstImportUsedInImplementationWithNoUsesClauseShouldAddQuickFix() {
+    CheckVerifier.newVerifier()
+        .withCheck(new ImportSpecificityCheck())
+        .withSearchPathUnit(createSystemUITypes())
+        .onFile(
+            new DelphiTestUnitBuilder()
+                .appendDecl("// Fix@[+2:2 to +3:2] <<>>")
+                .appendDecl("uses")
+                .appendDecl("  System.UITypes, // Noncompliant")
+                .appendDecl("  System.SysUtils;")
+                .appendImpl("// Fix@[-2:14 to -2:14] <<\\r\\n\\r\\nuses >>")
+                .appendImpl("// Fix@[-3:14 to -3:14] <<System.UITypes>>")
+                .appendImpl("// Fix@[-4:14 to -4:14] <<;>>")
+                .appendImpl("type")
+                .appendImpl("  Alias = System.UITypes.TMsgDlgType;"))
+        .verifyIssues();
+  }
+
+  @Test
+  void testNthImportUsedInImplementationWithNoUsesClauseShouldAddQuickFix() {
+    CheckVerifier.newVerifier()
+        .withCheck(new ImportSpecificityCheck())
+        .withSearchPathUnit(createSystemUITypes())
+        .onFile(
+            new DelphiTestUnitBuilder()
+                .appendDecl("uses")
+                .appendDecl("// Fix@[+1:16 to +2:16] <<>>")
+                .appendDecl("  System.Contnrs,")
+                .appendDecl("  System.UITypes, // Noncompliant")
+                .appendDecl("  System.SysUtils;")
+                .appendImpl("// Fix@[-2:14 to -2:14] <<\\r\\n\\r\\nuses >>")
+                .appendImpl("// Fix@[-3:14 to -3:14] <<System.UITypes>>")
+                .appendImpl("// Fix@[-4:14 to -4:14] <<;>>")
+                .appendImpl("type")
+                .appendImpl("  Alias = System.UITypes.TMsgDlgType;"))
+        .verifyIssues();
+  }
+
   private static DelphiTestUnitBuilder createSystemUITypes() {
     return new DelphiTestUnitBuilder()
         .unitName("System.UITypes")

--- a/delphi-checks/src/test/java/au/com/integradev/delphi/checks/UnusedImportCheckTest.java
+++ b/delphi-checks/src/test/java/au/com/integradev/delphi/checks/UnusedImportCheckTest.java
@@ -134,6 +134,67 @@ class UnusedImportCheckTest {
         .verifyNoIssues();
   }
 
+  @Test
+  void testSingleUnusedImportShouldAddQuickFix() {
+    CheckVerifier.newVerifier()
+        .withCheck(createCheck())
+        .withSearchPathUnit(createSysUtils())
+        .onFile(
+            new DelphiTestUnitBuilder()
+                .appendImpl("// Fix@[+1:0 to +2:18] <<>>")
+                .appendImpl("uses")
+                .appendImpl("  System.SysUtils; // Noncompliant")
+                .appendImpl("procedure Test;")
+                .appendImpl("var")
+                .appendImpl("  Obj: TObject;")
+                .appendImpl("begin")
+                .appendImpl("  Obj := TObject.Create;")
+                .appendImpl("end;"))
+        .verifyIssues();
+  }
+
+  @Test
+  void testFirstUnusedImportShouldAddQuickFix() {
+    CheckVerifier.newVerifier()
+        .withCheck(createCheck())
+        .withSearchPathUnit(createSysUtils())
+        .onFile(
+            new DelphiTestUnitBuilder()
+                .appendImpl("uses")
+                .appendImpl("// Fix@[+1:2 to +2:2] <<>>")
+                .appendImpl("  System.Classes, // Noncompliant")
+                .appendImpl("  System.SysUtils;")
+                .appendImpl("procedure Test;")
+                .appendImpl("var")
+                .appendImpl("  Obj: TObject;")
+                .appendImpl("begin")
+                .appendImpl("  Obj := TObject.Create;")
+                .appendImpl("  FreeAndNil(Obj);")
+                .appendImpl("end;"))
+        .verifyIssues();
+  }
+
+  @Test
+  void testNthUnusedImportShouldAddQuickFix() {
+    CheckVerifier.newVerifier()
+        .withCheck(createCheck())
+        .withSearchPathUnit(createSysUtils())
+        .onFile(
+            new DelphiTestUnitBuilder()
+                .appendImpl("uses")
+                .appendImpl("// Fix@[+1:17 to +2:16] <<>>")
+                .appendImpl("  System.SysUtils,")
+                .appendImpl("  System.Classes; // Noncompliant")
+                .appendImpl("procedure Test;")
+                .appendImpl("var")
+                .appendImpl("  Obj: TObject;")
+                .appendImpl("begin")
+                .appendImpl("  Obj := TObject.Create;")
+                .appendImpl("  FreeAndNil(Obj);")
+                .appendImpl("end;"))
+        .verifyIssues();
+  }
+
   private static DelphiTestUnitBuilder createSysUtils() {
     return new DelphiTestUnitBuilder()
         .unitName("System.SysUtils")

--- a/delphi-frontend/src/main/antlr3/au/com/integradev/delphi/antlr/Delphi.g
+++ b/delphi-frontend/src/main/antlr3/au/com/integradev/delphi/antlr/Delphi.g
@@ -300,9 +300,9 @@ usesClause                   : USES<UsesClauseNodeImpl>^ unitImportList
                              ;
 usesFileClause               : USES<UsesClauseNodeImpl>^ unitInFileImportList
                              ;
-unitInFileImportList         : unitInFileImport (','! unitInFileImport)* ';'!
+unitInFileImportList         : unitInFileImport (',' unitInFileImport)* ';'
                              ;
-unitImportList               : unitImport (','! unitImport)* ';'!
+unitImportList               : unitImport (',' unitImport)* ';'
                              ;
 unitImport                   : qualifiedNameDeclaration
                              -> ^(TkUnitImport<UnitImportNodeImpl> qualifiedNameDeclaration)

--- a/delphi-frontend/src/main/java/au/com/integradev/delphi/antlr/ast/node/ImplementationSectionNodeImpl.java
+++ b/delphi-frontend/src/main/java/au/com/integradev/delphi/antlr/ast/node/ImplementationSectionNodeImpl.java
@@ -20,7 +20,9 @@ package au.com.integradev.delphi.antlr.ast.node;
 
 import au.com.integradev.delphi.antlr.ast.visitors.DelphiParserVisitor;
 import org.antlr.runtime.Token;
+import org.sonar.plugins.communitydelphi.api.ast.DelphiNode;
 import org.sonar.plugins.communitydelphi.api.ast.ImplementationSectionNode;
+import org.sonar.plugins.communitydelphi.api.ast.UsesClauseNode;
 
 public final class ImplementationSectionNodeImpl extends DelphiNodeImpl
     implements ImplementationSectionNode {
@@ -31,5 +33,11 @@ public final class ImplementationSectionNodeImpl extends DelphiNodeImpl
   @Override
   public <T> T accept(DelphiParserVisitor<T> visitor, T data) {
     return visitor.visit(this, data);
+  }
+
+  @Override
+  public UsesClauseNode getUsesClause() {
+    DelphiNode child = getChild(0);
+    return child instanceof UsesClauseNode ? (UsesClauseNode) child : null;
   }
 }

--- a/delphi-frontend/src/main/java/au/com/integradev/delphi/antlr/ast/node/InterfaceSectionNodeImpl.java
+++ b/delphi-frontend/src/main/java/au/com/integradev/delphi/antlr/ast/node/InterfaceSectionNodeImpl.java
@@ -20,7 +20,9 @@ package au.com.integradev.delphi.antlr.ast.node;
 
 import au.com.integradev.delphi.antlr.ast.visitors.DelphiParserVisitor;
 import org.antlr.runtime.Token;
+import org.sonar.plugins.communitydelphi.api.ast.DelphiNode;
 import org.sonar.plugins.communitydelphi.api.ast.InterfaceSectionNode;
+import org.sonar.plugins.communitydelphi.api.ast.UsesClauseNode;
 
 public final class InterfaceSectionNodeImpl extends DelphiNodeImpl implements InterfaceSectionNode {
   public InterfaceSectionNodeImpl(Token token) {
@@ -30,5 +32,11 @@ public final class InterfaceSectionNodeImpl extends DelphiNodeImpl implements In
   @Override
   public <T> T accept(DelphiParserVisitor<T> visitor, T data) {
     return visitor.visit(this, data);
+  }
+
+  @Override
+  public UsesClauseNode getUsesClause() {
+    DelphiNode child = getChild(0);
+    return child instanceof UsesClauseNode ? (UsesClauseNode) child : null;
   }
 }

--- a/delphi-frontend/src/main/java/au/com/integradev/delphi/antlr/ast/node/UsesClauseNodeImpl.java
+++ b/delphi-frontend/src/main/java/au/com/integradev/delphi/antlr/ast/node/UsesClauseNodeImpl.java
@@ -19,7 +19,9 @@
 package au.com.integradev.delphi.antlr.ast.node;
 
 import au.com.integradev.delphi.antlr.ast.visitors.DelphiParserVisitor;
+import java.util.List;
 import org.antlr.runtime.Token;
+import org.sonar.plugins.communitydelphi.api.ast.UnitImportNode;
 import org.sonar.plugins.communitydelphi.api.ast.UsesClauseNode;
 
 public final class UsesClauseNodeImpl extends ImportClauseNodeImpl implements UsesClauseNode {
@@ -30,5 +32,10 @@ public final class UsesClauseNodeImpl extends ImportClauseNodeImpl implements Us
   @Override
   public <T> T accept(DelphiParserVisitor<T> visitor, T data) {
     return visitor.visit(this, data);
+  }
+
+  @Override
+  public List<UnitImportNode> getImports() {
+    return findChildrenOfType(UnitImportNode.class);
   }
 }

--- a/delphi-frontend/src/main/java/org/sonar/plugins/communitydelphi/api/ast/ImplementationSectionNode.java
+++ b/delphi-frontend/src/main/java/org/sonar/plugins/communitydelphi/api/ast/ImplementationSectionNode.java
@@ -18,4 +18,6 @@
  */
 package org.sonar.plugins.communitydelphi.api.ast;
 
-public interface ImplementationSectionNode extends DelphiNode {}
+public interface ImplementationSectionNode extends DelphiNode {
+  UsesClauseNode getUsesClause();
+}

--- a/delphi-frontend/src/main/java/org/sonar/plugins/communitydelphi/api/ast/InterfaceSectionNode.java
+++ b/delphi-frontend/src/main/java/org/sonar/plugins/communitydelphi/api/ast/InterfaceSectionNode.java
@@ -18,4 +18,6 @@
  */
 package org.sonar.plugins.communitydelphi.api.ast;
 
-public interface InterfaceSectionNode extends DelphiNode {}
+public interface InterfaceSectionNode extends DelphiNode {
+  UsesClauseNode getUsesClause();
+}

--- a/delphi-frontend/src/main/java/org/sonar/plugins/communitydelphi/api/ast/UsesClauseNode.java
+++ b/delphi-frontend/src/main/java/org/sonar/plugins/communitydelphi/api/ast/UsesClauseNode.java
@@ -18,4 +18,8 @@
  */
 package org.sonar.plugins.communitydelphi.api.ast;
 
-public interface UsesClauseNode extends ImportClauseNode {}
+import java.util.List;
+
+public interface UsesClauseNode extends ImportClauseNode {
+  List<UnitImportNode> getImports();
+}


### PR DESCRIPTION
This PR adds the following quick fixes:

* "Move to implementation section" for `ImportSpecificity`
* "Remove unused import" for `UnusedImport`

This included adding a couple of new API methods:

* `ImplementationSectionNode::getUsesClause`
* `UsesClauseNode::getImports`