### PR TITLE
Improve support for program files omitting the `program` header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Symbol table construction errors for program files omitting the `program` header.
 - Incorrect ordering of edits in the "Separate grouped parameters" quick fix for `GroupedParameterDeclaration`.
 
 ## [1.5.0] - 2024-05-02

--- a/delphi-frontend/src/main/java/au/com/integradev/delphi/antlr/ast/DelphiAstImpl.java
+++ b/delphi-frontend/src/main/java/au/com/integradev/delphi/antlr/ast/DelphiAstImpl.java
@@ -28,6 +28,7 @@ import au.com.integradev.delphi.antlr.ast.visitors.DelphiParserVisitor;
 import au.com.integradev.delphi.file.DelphiFile;
 import java.util.List;
 import java.util.stream.Collectors;
+import javax.annotation.Nullable;
 import org.sonar.plugins.communitydelphi.api.ast.DelphiAst;
 import org.sonar.plugins.communitydelphi.api.ast.DelphiNode;
 import org.sonar.plugins.communitydelphi.api.ast.FileHeaderNode;
@@ -91,24 +92,27 @@ public class DelphiAstImpl extends DelphiNodeImpl implements DelphiAst {
     return delphiFile;
   }
 
+  @Nullable
   @Override
   public FileHeaderNode getFileHeader() {
-    return (FileHeaderNode) getChild(0);
+    DelphiNode fileHeader = getChild(0);
+    return fileHeader instanceof FileHeaderNode ? (FileHeaderNode) fileHeader : null;
   }
 
   @Override
   public boolean isProgram() {
-    return !getChildren().isEmpty() && getFileHeader() instanceof ProgramDeclarationNode;
+    FileHeaderNode fileHeader = getFileHeader();
+    return fileHeader instanceof ProgramDeclarationNode || fileHeader == null;
   }
 
   @Override
   public boolean isUnit() {
-    return !getChildren().isEmpty() && getFileHeader() instanceof UnitDeclarationNode;
+    return getFileHeader() instanceof UnitDeclarationNode;
   }
 
   @Override
   public boolean isPackage() {
-    return !getChildren().isEmpty() && getFileHeader() instanceof PackageDeclarationNode;
+    return getFileHeader() instanceof PackageDeclarationNode;
   }
 
   public List<DelphiToken> getCommentsInsideNode(DelphiNode node) {

--- a/delphi-frontend/src/main/java/au/com/integradev/delphi/antlr/ast/visitors/SonarSymbolTableVisitor.java
+++ b/delphi-frontend/src/main/java/au/com/integradev/delphi/antlr/ast/visitors/SonarSymbolTableVisitor.java
@@ -45,6 +45,11 @@ public class SonarSymbolTableVisitor implements DelphiParserVisitor<NewSymbolTab
     Node location = declaration.getNode();
     String symbolUnit = location.getUnitName();
 
+    if (location.getTokenType() == DelphiTokenType.INVALID) {
+      // imaginary node
+      return;
+    }
+
     if (location instanceof SymbolicNode && ((SymbolicNode) location).isIncludedNode()) {
       // Symbols from include files may overlap with both their own
       // references and other symbols from the same file.

--- a/delphi-frontend/src/main/java/au/com/integradev/delphi/antlr/ast/visitors/SymbolAssociationVisitor.java
+++ b/delphi-frontend/src/main/java/au/com/integradev/delphi/antlr/ast/visitors/SymbolAssociationVisitor.java
@@ -59,10 +59,9 @@ public class SymbolAssociationVisitor implements DelphiParserVisitor<Data> {
     String filePath = node.getDelphiFile().getSourceCodeFile().getAbsolutePath();
 
     UnitNameDeclaration declaration = data.symbolTable.getUnitByPath(filePath);
-    String unitName = node.getFileHeader().getName();
 
     Preconditions.checkNotNull(
-        declaration, "Expected unit '%s' to exist in global scope.", unitName);
+        declaration, "Expected unit '%s' to exist in global scope.", declaration.getName());
 
     data.fileScope = (FileScopeImpl) declaration.getFileScope();
     ((DelphiAstImpl) node).setScope(data.fileScope);

--- a/delphi-frontend/src/main/java/au/com/integradev/delphi/symbol/declaration/QualifiedNameDeclarationImpl.java
+++ b/delphi-frontend/src/main/java/au/com/integradev/delphi/symbol/declaration/QualifiedNameDeclarationImpl.java
@@ -18,6 +18,8 @@
  */
 package au.com.integradev.delphi.symbol.declaration;
 
+import au.com.integradev.delphi.symbol.QualifiedNameImpl;
+import au.com.integradev.delphi.symbol.SymbolicNode;
 import java.util.Objects;
 import org.sonar.plugins.communitydelphi.api.ast.QualifiedNameDeclarationNode;
 import org.sonar.plugins.communitydelphi.api.symbol.Qualifiable;
@@ -31,12 +33,17 @@ public abstract class QualifiedNameDeclarationImpl extends NameDeclarationImpl
 
   protected QualifiedNameDeclarationImpl(QualifiedNameDeclarationNode node) {
     super(node);
-    qualifiedName = node.getQualifiedName();
+    this.qualifiedName = node.getQualifiedName();
   }
 
   protected QualifiedNameDeclarationImpl(QualifiedNameDeclarationNode node, DelphiScope scope) {
     super(node, scope);
-    qualifiedName = node.getQualifiedName();
+    this.qualifiedName = node.getQualifiedName();
+  }
+
+  protected QualifiedNameDeclarationImpl(SymbolicNode node) {
+    super(node);
+    this.qualifiedName = QualifiedNameImpl.of(node.getImage());
   }
 
   @Override

--- a/delphi-frontend/src/main/java/au/com/integradev/delphi/symbol/declaration/UnitNameDeclarationImpl.java
+++ b/delphi-frontend/src/main/java/au/com/integradev/delphi/symbol/declaration/UnitNameDeclarationImpl.java
@@ -18,6 +18,7 @@
  */
 package au.com.integradev.delphi.symbol.declaration;
 
+import au.com.integradev.delphi.symbol.SymbolicNode;
 import java.nio.file.Path;
 import java.util.HashSet;
 import java.util.Objects;
@@ -38,11 +39,20 @@ public final class UnitNameDeclarationImpl extends QualifiedNameDeclarationImpl
   private final Set<UnitNameDeclaration> implementationDependencies;
   private int hashCode;
 
-  public UnitNameDeclarationImpl(FileHeaderNode node, FileScope fileScope) {
+  public UnitNameDeclarationImpl(FileHeaderNode node, FileScope fileScope, Path path) {
     super(node.getNameNode(), fileScope);
     this.fileScope = fileScope;
     this.namespace = node.getNamespace();
-    this.path = Path.of(node.getAst().getDelphiFile().getSourceCodeFile().getAbsolutePath());
+    this.path = path;
+    this.interfaceDependencies = new HashSet<>();
+    this.implementationDependencies = new HashSet<>();
+  }
+
+  public UnitNameDeclarationImpl(String image, FileScope fileScope, Path path) {
+    super(SymbolicNode.imaginary(image, fileScope));
+    this.fileScope = fileScope;
+    this.namespace = "";
+    this.path = path;
     this.interfaceDependencies = new HashSet<>();
     this.implementationDependencies = new HashSet<>();
   }

--- a/delphi-frontend/src/main/java/org/sonar/plugins/communitydelphi/api/ast/DelphiAst.java
+++ b/delphi-frontend/src/main/java/org/sonar/plugins/communitydelphi/api/ast/DelphiAst.java
@@ -19,10 +19,12 @@
 package org.sonar.plugins.communitydelphi.api.ast;
 
 import au.com.integradev.delphi.file.DelphiFile;
+import javax.annotation.Nullable;
 
 public interface DelphiAst extends DelphiNode {
   DelphiFile getDelphiFile();
 
+  @Nullable
   FileHeaderNode getFileHeader();
 
   boolean isProgram();

--- a/delphi-frontend/src/test/java/au/com/integradev/delphi/executor/DelphiSymbolTableExecutorTest.java
+++ b/delphi-frontend/src/test/java/au/com/integradev/delphi/executor/DelphiSymbolTableExecutorTest.java
@@ -388,6 +388,12 @@ class DelphiSymbolTableExecutorTest {
   }
 
   @Test
+  void testDefaultProgramName() {
+    execute("DefaultProgramName.dpr");
+    verifyUsages(2, 2, reference(5, 19));
+  }
+
+  @Test
   void testClassReferenceMethodResolution() {
     execute("classReferences/MethodResolution.pas");
     verifyUsages(9, 14, reference(18, 6));

--- a/delphi-frontend/src/test/java/au/com/integradev/delphi/symbol/declaration/UnitImportNameDeclarationTest.java
+++ b/delphi-frontend/src/test/java/au/com/integradev/delphi/symbol/declaration/UnitImportNameDeclarationTest.java
@@ -28,6 +28,7 @@ import au.com.integradev.delphi.antlr.ast.node.QualifiedNameDeclarationNodeImpl;
 import au.com.integradev.delphi.antlr.ast.node.UnitImportNodeImpl;
 import au.com.integradev.delphi.file.DelphiFile;
 import java.io.File;
+import java.nio.file.Path;
 import org.antlr.runtime.CommonToken;
 import org.junit.jupiter.api.Test;
 import org.sonar.plugins.communitydelphi.api.ast.DelphiAst;
@@ -74,8 +75,9 @@ class UnitImportNameDeclarationTest {
   }
 
   private static UnitNameDeclaration createUnit(String name) {
+    String path = name + ".pas";
     File file = mock(File.class);
-    when(file.getAbsolutePath()).thenReturn(name + ".pas");
+    when(file.getAbsolutePath()).thenReturn(path);
 
     DelphiFile delphiFile = mock(DelphiFile.class);
     when(delphiFile.getSourceCodeFile()).thenReturn(file);
@@ -88,7 +90,7 @@ class UnitImportNameDeclarationTest {
     when(location.getNamespace()).thenReturn("");
     when(location.getAst()).thenReturn(ast);
 
-    return new UnitNameDeclarationImpl(location, null);
+    return new UnitNameDeclarationImpl(location, null, Path.of(path));
   }
 
   private static QualifiedNameDeclarationNode createNameNode(String name) {

--- a/delphi-frontend/src/test/java/au/com/integradev/delphi/symbol/declaration/UnitNameDeclarationTest.java
+++ b/delphi-frontend/src/test/java/au/com/integradev/delphi/symbol/declaration/UnitNameDeclarationTest.java
@@ -27,6 +27,7 @@ import au.com.integradev.delphi.antlr.ast.node.IdentifierNodeImpl;
 import au.com.integradev.delphi.antlr.ast.node.QualifiedNameDeclarationNodeImpl;
 import au.com.integradev.delphi.file.DelphiFile;
 import java.io.File;
+import java.nio.file.Path;
 import org.antlr.runtime.CommonToken;
 import org.junit.jupiter.api.Test;
 import org.sonar.plugins.communitydelphi.api.ast.DelphiAst;
@@ -82,6 +83,6 @@ class UnitNameDeclarationTest {
     when(location.getNamespace()).thenReturn("");
     when(location.getAst()).thenReturn(ast);
 
-    return new UnitNameDeclarationImpl(location, null);
+    return new UnitNameDeclarationImpl(location, null, Path.of(path));
   }
 }

--- a/delphi-frontend/src/test/resources/au/com/integradev/delphi/symbol/DefaultProgramName.dpr
+++ b/delphi-frontend/src/test/resources/au/com/integradev/delphi/symbol/DefaultProgramName.dpr
@@ -1,0 +1,6 @@
+const
+  HelloWorld = 'Hello, World!';
+
+begin
+  WriteLn(&PROGRAM.HelloWorld);
+end.


### PR DESCRIPTION
This was partially implemented in #159, but stopped at the parsing level.

Throughout the analyzer, there were unsafe assumptions about the presence of a file header. The major area that needed extra consideration was symbol table construction.

It turns out that the default name of a Delphi program is `PROGRAM`, so this name ends up being used if the header is omitted. See `DefaultProgramName.dpr` for an example of a valid Delphi program that relies on this behavior.

Fixes #227