### PR TITLE
Exclude `@SonarLintUnsupported` rules in a SonarLint context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Symbol table construction errors for program files omitting the `program` header.
 - Incorrect ordering of edits in the "Separate grouped parameters" quick fix for `GroupedParameterDeclaration`.
+- SonarLint registration of rules that don't support execution in a SonarLint context.
 
 ## [1.5.0] - 2024-05-02
 


### PR DESCRIPTION
This PR excludes checks annotated with `@SonarLintUnsupported` from being registered in the rule repository (i.e. in `DelphiRulesDefinition`. This fixes unsupported rules being defined and reported in a SonarLint context.