### PR TITLE
Promote anonymous methods to pure expressions in the grammar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Symbol table construction errors for program files omitting the `program` header.
+- Parsing errors on parenthesised anonymous methods.
 - Incorrect ordering of edits in the "Separate grouped parameters" quick fix for `GroupedParameterDeclaration`.
 
 ## [1.5.0] - 2024-05-02

--- a/delphi-frontend/src/test/resources/au/com/integradev/delphi/grammar/AnonymousMethods.pas
+++ b/delphi-frontend/src/test/resources/au/com/integradev/delphi/grammar/AnonymousMethods.pas
@@ -24,4 +24,12 @@ begin
     end);
 end;
 
+function IsStringEmptyImmediateInvocation(const aValue : string) : Boolean;
+begin
+  Result := (function(const aValue : string) : Boolean
+    begin
+      Result := aValue = '';
+    end)(aValue);
+end;
+
 end.


### PR DESCRIPTION
This PR makes parsing more permissive around anonymous methods, treating them more like pure expressions.

Fixes #226