### PR TITLE
Ensure BOM is not present in `DelphiCheckContext::getFileLines`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- File pointer errors when an issue is raised on the first line of a file with a byte order mark.
 - Symbol table construction errors for program files omitting the `program` header.
 - Parsing errors on parenthesised anonymous methods.
 - Incorrect ordering of edits in the "Separate grouped parameters" quick fix for `GroupedParameterDeclaration`.

--- a/delphi-checks-testkit/src/main/java/au/com/integradev/delphi/builders/AbstractDelphiTestFile.java
+++ b/delphi-checks-testkit/src/main/java/au/com/integradev/delphi/builders/AbstractDelphiTestFile.java
@@ -55,6 +55,8 @@ abstract class AbstractDelphiTestFile<T extends AbstractDelphiTestFile<T>>
       file.deleteOnExit();
 
       try (FileWriter fileWriter = new FileWriter(file, UTF_8)) {
+        // Prepend UTF-8 BOM
+        fileWriter.write('\ufeff');
         fileWriter.write(sourceCode());
         fileWriter.flush();
       }

--- a/delphi-checks-testkit/src/main/java/au/com/integradev/delphi/checks/verifier/DelphiCheckContextTester.java
+++ b/delphi-checks-testkit/src/main/java/au/com/integradev/delphi/checks/verifier/DelphiCheckContextTester.java
@@ -70,7 +70,7 @@ class DelphiCheckContextTester implements DelphiCheckContext {
 
   @Override
   public List<String> getFileLines() {
-    return delphiFile.getSourceCodeFilesLines();
+    return delphiFile.getSourceCodeFileLines();
   }
 
   @Override

--- a/delphi-checks/src/main/java/au/com/integradev/delphi/utils/IndentationUtils.java
+++ b/delphi-checks/src/main/java/au/com/integradev/delphi/utils/IndentationUtils.java
@@ -33,7 +33,7 @@ public final class IndentationUtils {
    */
   public static String getLineIndentation(DelphiNode node) {
     return getLineIndentation(
-        node.getAst().getDelphiFile().getSourceCodeFilesLines().get(node.getBeginLine() - 1));
+        node.getAst().getDelphiFile().getSourceCodeFileLines().get(node.getBeginLine() - 1));
   }
 
   /**

--- a/delphi-frontend/src/main/java/au/com/integradev/delphi/check/DelphiCheckContextImpl.java
+++ b/delphi-frontend/src/main/java/au/com/integradev/delphi/check/DelphiCheckContextImpl.java
@@ -63,7 +63,7 @@ public class DelphiCheckContextImpl implements DelphiCheckContext {
 
   @Override
   public List<String> getFileLines() {
-    return delphiFile.getSourceCodeFilesLines();
+    return delphiFile.getSourceCodeFileLines();
   }
 
   @Override

--- a/delphi-frontend/src/main/java/au/com/integradev/delphi/file/DefaultDelphiFile.java
+++ b/delphi-frontend/src/main/java/au/com/integradev/delphi/file/DefaultDelphiFile.java
@@ -47,7 +47,7 @@ class DefaultDelphiFile implements DelphiFile {
   }
 
   @Override
-  public List<String> getSourceCodeFilesLines() {
+  public List<String> getSourceCodeFileLines() {
     return sourceCodeLines;
   }
 

--- a/delphi-frontend/src/main/java/au/com/integradev/delphi/file/DelphiFile.java
+++ b/delphi-frontend/src/main/java/au/com/integradev/delphi/file/DelphiFile.java
@@ -18,8 +18,6 @@
  */
 package au.com.integradev.delphi.file;
 
-import static org.apache.commons.io.FileUtils.readLines;
-
 import au.com.integradev.delphi.antlr.DelphiFileStream;
 import au.com.integradev.delphi.antlr.DelphiLexer;
 import au.com.integradev.delphi.antlr.DelphiLexer.LexerException;
@@ -33,6 +31,7 @@ import au.com.integradev.delphi.preprocessor.DelphiPreprocessorFactory;
 import au.com.integradev.delphi.preprocessor.TextBlockLineEndingModeRegistry;
 import au.com.integradev.delphi.preprocessor.search.SearchPath;
 import au.com.integradev.delphi.utils.DelphiUtils;
+import com.google.common.base.Splitter;
 import java.io.File;
 import java.io.IOException;
 import java.util.List;
@@ -151,7 +150,7 @@ public interface DelphiFile {
       delphiFile.setCompilerSwitchRegistry(preprocessor.getCompilerSwitchRegistry());
       delphiFile.setTextBlockLineEndingModeRegistry(
           preprocessor.getTextBlockLineEndingModeRegistry());
-      delphiFile.setSourceCodeLines(readLines(sourceFile, fileStream.getEncoding()));
+      delphiFile.setSourceCodeLines(getSourceCodeLines(fileStream));
       delphiFile.setTokens(preprocessor.getRawTokens());
       delphiFile.setComments(extractComments(delphiFile.getTokens()));
     } catch (IOException
@@ -198,6 +197,10 @@ public interface DelphiFile {
     }
 
     return new DelphiAstImpl(delphiFile, root);
+  }
+
+  private static List<String> getSourceCodeLines(DelphiFileStream fileStream) {
+    return Splitter.onPattern("\\R").splitToList(fileStream.substring(0, fileStream.size() - 1));
   }
 
   private static List<DelphiToken> extractComments(List<DelphiToken> tokenList) {

--- a/delphi-frontend/src/main/java/au/com/integradev/delphi/file/DelphiFile.java
+++ b/delphi-frontend/src/main/java/au/com/integradev/delphi/file/DelphiFile.java
@@ -52,7 +52,7 @@ import org.sonar.plugins.communitydelphi.api.type.TypeFactory;
 public interface DelphiFile {
   File getSourceCodeFile();
 
-  List<String> getSourceCodeFilesLines();
+  List<String> getSourceCodeFileLines();
 
   String getSourceCodeFileEncoding();
 

--- a/delphi-frontend/src/test/java/au/com/integradev/delphi/file/DelphiFileTest.java
+++ b/delphi-frontend/src/test/java/au/com/integradev/delphi/file/DelphiFileTest.java
@@ -71,7 +71,7 @@ class DelphiFileTest {
             Collections.emptySet());
 
     DelphiFile delphiFile = DelphiInputFile.from(inputFile, config);
-    assertThat(delphiFile.getSourceCodeFilesLines().get(4)).isEqualTo("// €†šŸÀÿ");
+    assertThat(delphiFile.getSourceCodeFileLines().get(4)).isEqualTo("// €†šŸÀÿ");
   }
 
   @Test
@@ -87,6 +87,6 @@ class DelphiFileTest {
             Collections.emptySet());
 
     DelphiFile delphiFile = DelphiFile.from(file, config);
-    assertThat(delphiFile.getSourceCodeFilesLines().get(4)).hasSize(120);
+    assertThat(delphiFile.getSourceCodeFileLines().get(4)).hasSize(120);
   }
 }

--- a/delphi-frontend/src/test/java/au/com/integradev/delphi/file/DelphiFileTest.java
+++ b/delphi-frontend/src/test/java/au/com/integradev/delphi/file/DelphiFileTest.java
@@ -89,4 +89,21 @@ class DelphiFileTest {
     DelphiFile delphiFile = DelphiFile.from(file, config);
     assertThat(delphiFile.getSourceCodeFileLines().get(4)).hasSize(120);
   }
+
+  @Test
+  void testByteOrderMarkShouldBeStripped() {
+    File file = DelphiUtils.getResource("/au/com/integradev/delphi/file/Utf8.pas");
+
+    DelphiFileConfig config =
+        DelphiFile.createConfig(
+            StandardCharsets.UTF_8.name(),
+            new DelphiPreprocessorFactory(Platform.WINDOWS),
+            TypeFactoryUtils.defaultFactory(),
+            SearchPath.create(Collections.emptyList()),
+            Collections.emptySet());
+
+    DelphiFile delphiFile = DelphiFile.from(file, config);
+    String firstLine = delphiFile.getSourceCodeFileLines().get(0);
+    assertThat(firstLine).doesNotStartWith("\ufeff");
+  }
 }

--- a/delphi-frontend/src/test/resources/au/com/integradev/delphi/file/Utf8.pas
+++ b/delphi-frontend/src/test/resources/au/com/integradev/delphi/file/Utf8.pas
@@ -1,0 +1,7 @@
+﻿unit Utf8;
+
+interface
+
+implementation
+
+end.


### PR DESCRIPTION
This PR fixes file pointer errors caused by an inconsistency in the 2 ways source files are read during `DelphiFile` construction.
* `DelphiFileStream` recognizes BOMs and strips them before passing the string data forward to the preprocessor
* `FileUtils.readLines` has no handling for BOMs and persists them into the string data

This inconsistency means that the length of the first line is incorrect according to `DelphiCheckContext::getFileLines`, and any rule relying on this API may accidentally report issues with positions that run over the end of the line. 

Fixes #234