### PR TITLE
Enhance PointerName rule analysis and documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - "Move to implementation section" quick fix for `ImportSpecificity`.
 - "Remove unused import" quick fix for `UnusedImport`.
+- More comprehensive analysis and more detailed documentation for the `PointerName` rule.
 - **API:** `UsesClauseNode::getImports` method.
 - **API:** `InterfaceSectionNode::getUsesClause` method.
 - **API:** `ImplementationSectionNode::getUsesClause` method.

--- a/delphi-checks/src/main/resources/org/sonar/l10n/delphi/rules/community-delphi/PointerName.html
+++ b/delphi-checks/src/main/resources/org/sonar/l10n/delphi/rules/community-delphi/PointerName.html
@@ -1,13 +1,37 @@
 <h2>Why is this an issue?</h2>
 <p>
   Code that follows a consistent naming convention is self-documenting. In Delphi, all pointer names
-  should be named identically to the dereferenced type, with the type prefix swapped for
-  <code>P</code>.
+  should be named identically to the dereferenced type, with the type prefix swapped for <code>P</code>.
+</p>
+<p>
+  For example, the pointer types for <code>TMyType</code>, 
+  <code>EMyType</code>, and <code>IMyType</code> should be named <code>PMyType</code>.
+</p>
+<p>
+  Custom prefixes for dereferenced types are also supported, 
+  provided they also start with <code>T</code>, <code>E</code> or <code>I</code>.
+</p>
+<p>
+  For example, the pointer types for <code>TxyMyType</code>, 
+  <code>ExyMyType</code>, and <code>IxyMyType</code> should be named <code>PxyMyType</code>.
+</p>
+<p>
+  If dereferenced type is in PascalCase but does not have a valid prefix, 
+  the pointer name is expected to be the same as the type name but with the addition of the prefix <code>P</code>.
 </p>
 <p>For example:</p>
 <ul>
-  <li><code>^TObject</code> should be named <code>PObject</code></li>
-  <li><code>^TMyType</code> should be named <code>PMyType</code></li>
+  <li><code>^MyObject</code> should be named <code>PMyObject</code></li>
+  <li><code>^MyType</code> should be named <code>PMyType</code></li>
+</ul>
+<p>
+  Note that pointers to types that do not follow the naming standard are valid 
+  as long as they are in PascalCase with the prefix <code>P</code>.
+</p>
+<p>For example:</p>
+<ul>
+  <li><code>^my_object</code> will be valid if named <code>PMyObject</code></li>
+  <li><code>^my_object</code> will not be valid if named <code>Pmy_object</code></li>
 </ul>
 <h2>How to fix it</h2>
 <p>Rename the pointer type to follow the convention.</p>

--- a/delphi-checks/src/test/java/au/com/integradev/delphi/checks/PointerNameCheckTest.java
+++ b/delphi-checks/src/test/java/au/com/integradev/delphi/checks/PointerNameCheckTest.java
@@ -31,6 +31,12 @@ class PointerNameCheckTest {
         .onFile(
             new DelphiTestUnitBuilder()
                 .appendDecl("type")
+                .appendDecl("  PCompliesWithPrefixT = ^TCompliesWithPrefixT;")
+                .appendDecl("  PCompliesWithPrefixE = ^ECompliesWithPrefixE;")
+                .appendDecl("  PCompliesWithPrefixI = ^ICompliesWithPrefixI;")
+                .appendDecl("  PCompliesWithPascalCase = ^CompliesWithPascalCase;")
+                .appendDecl("  PCompliantPointer = ^noncompliant_type;")
+                .appendDecl("  PxyMyClass = ^TxyMyClass;")
                 .appendDecl("  PInteger = ^Integer;")
                 .appendDecl("  PFooInteger = ^TFooInteger;"))
         .verifyNoIssues();
@@ -43,6 +49,13 @@ class PointerNameCheckTest {
         .onFile(
             new DelphiTestUnitBuilder()
                 .appendDecl("type")
+                .appendDecl("  CompliesWithPrefixT = ^TCompliesWithPrefixT; // Noncompliant")
+                .appendDecl("  CompliesWithPrefixE = ^ECompliesWithPrefixE; // Noncompliant")
+                .appendDecl("  CompliesWithPrefixI = ^ICompliesWithPrefixI; // Noncompliant")
+                .appendDecl("  AnotherPascalCase = ^CompliesWithPascalCase; // Noncompliant")
+                .appendDecl("  Pmy_object = ^my_object; // Noncompliant")
+                .appendDecl("  PMyClass = ^TxyMyClass; // Noncompliant")
+                .appendDecl("  PxyMyClass = ^TMyClass; // Noncompliant")
                 .appendDecl("  pMyPointer = ^Integer; // Noncompliant")
                 .appendDecl("  PInteger = ^TFooInteger; // Noncompliant"))
         .verifyIssues();


### PR DESCRIPTION
This PR improves the behavior of the PointerName rule for types that do not follow naming conventions. It also allows pointers to types with the prefix E and I, in addition to the already supported T.

Fixes https://github.com/integrated-application-development/sonar-delphi/issues/238