### PR TITLE
Improve support for labels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **API:** `UsesClauseNode::getImports` method.
 - **API:** `InterfaceSectionNode::getUsesClause` method.
 - **API:** `ImplementationSectionNode::getUsesClause` method.
+- **API:** `LabelNameDeclaration` symbol declaration type.
+- **API:** `DelphiScope::getLabelDeclarations` method.
+- **API:** `LabelDeclarationNode` node type.
+- **API:** `LabelStatementNode::getNameReference` method.
+- **API:** `LabelStatementNode::getStatement` method.
+- **API:** `GotoStatementNode::getNameReference` method.
+
+### Changed
+
+- Improve semantic analysis around `label` and `goto` statements.
 
 ### Fixed
 

--- a/delphi-frontend/src/main/java/au/com/integradev/delphi/antlr/ast/node/LabelDeclarationNodeImpl.java
+++ b/delphi-frontend/src/main/java/au/com/integradev/delphi/antlr/ast/node/LabelDeclarationNodeImpl.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Delphi Plugin
- * Copyright (C) 2019 Integrated Application Development
+ * Copyright (C) 2024 Integrated Application Development
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -19,13 +19,18 @@
 package au.com.integradev.delphi.antlr.ast.node;
 
 import au.com.integradev.delphi.antlr.ast.visitors.DelphiParserVisitor;
+import java.util.List;
 import org.antlr.runtime.Token;
-import org.sonar.plugins.communitydelphi.api.ast.GotoStatementNode;
-import org.sonar.plugins.communitydelphi.api.ast.NameReferenceNode;
+import org.sonar.plugins.communitydelphi.api.ast.LabelDeclarationNode;
+import org.sonar.plugins.communitydelphi.api.ast.NameDeclarationNode;
 
-public final class GotoStatementNodeImpl extends DelphiNodeImpl implements GotoStatementNode {
-  public GotoStatementNodeImpl(Token token) {
+public final class LabelDeclarationNodeImpl extends DelphiNodeImpl implements LabelDeclarationNode {
+  public LabelDeclarationNodeImpl(Token token) {
     super(token);
+  }
+
+  public LabelDeclarationNodeImpl(int tokenType) {
+    super(tokenType);
   }
 
   @Override
@@ -34,7 +39,7 @@ public final class GotoStatementNodeImpl extends DelphiNodeImpl implements GotoS
   }
 
   @Override
-  public NameReferenceNode getNameReference() {
-    return (NameReferenceNode) getChild(0);
+  public List<NameDeclarationNode> getDeclarations() {
+    return findChildrenOfType(NameDeclarationNode.class);
   }
 }

--- a/delphi-frontend/src/main/java/au/com/integradev/delphi/antlr/ast/node/LabelStatementNodeImpl.java
+++ b/delphi-frontend/src/main/java/au/com/integradev/delphi/antlr/ast/node/LabelStatementNodeImpl.java
@@ -19,8 +19,11 @@
 package au.com.integradev.delphi.antlr.ast.node;
 
 import au.com.integradev.delphi.antlr.ast.visitors.DelphiParserVisitor;
+import javax.annotation.Nullable;
 import org.antlr.runtime.Token;
 import org.sonar.plugins.communitydelphi.api.ast.LabelStatementNode;
+import org.sonar.plugins.communitydelphi.api.ast.NameReferenceNode;
+import org.sonar.plugins.communitydelphi.api.ast.StatementNode;
 
 public final class LabelStatementNodeImpl extends DelphiNodeImpl implements LabelStatementNode {
   public LabelStatementNodeImpl(Token token) {
@@ -34,5 +37,16 @@ public final class LabelStatementNodeImpl extends DelphiNodeImpl implements Labe
   @Override
   public <T> T accept(DelphiParserVisitor<T> visitor, T data) {
     return visitor.visit(this, data);
+  }
+
+  @Override
+  public NameReferenceNode getNameReference() {
+    return (NameReferenceNode) getChild(0);
+  }
+
+  @Override
+  @Nullable
+  public StatementNode getStatement() {
+    return (StatementNode) getChild(2);
   }
 }

--- a/delphi-frontend/src/main/java/au/com/integradev/delphi/antlr/ast/node/NameDeclarationNodeImpl.java
+++ b/delphi-frontend/src/main/java/au/com/integradev/delphi/antlr/ast/node/NameDeclarationNodeImpl.java
@@ -87,6 +87,7 @@ public abstract class NameDeclarationNodeImpl extends DelphiNodeImpl
     IMPORT,
     INLINE_CONST,
     INLINE_VAR,
+    LABEL,
     LOOP_VAR,
     ROUTINE,
     PARAMETER,

--- a/delphi-frontend/src/main/java/au/com/integradev/delphi/antlr/ast/node/SimpleNameDeclarationNodeImpl.java
+++ b/delphi-frontend/src/main/java/au/com/integradev/delphi/antlr/ast/node/SimpleNameDeclarationNodeImpl.java
@@ -19,6 +19,7 @@
 package au.com.integradev.delphi.antlr.ast.node;
 
 import au.com.integradev.delphi.antlr.ast.visitors.DelphiParserVisitor;
+import com.google.common.collect.ImmutableMap;
 import java.util.Map;
 import java.util.Objects;
 import org.antlr.runtime.Token;
@@ -29,17 +30,19 @@ import org.sonar.plugins.communitydelphi.api.ast.SimpleNameDeclarationNode;
 public final class SimpleNameDeclarationNodeImpl extends NameDeclarationNodeImpl
     implements SimpleNameDeclarationNode {
   private static final Map<Class<?>, DeclarationKind> PARENT_NODE_KIND_MAP =
-      Map.of(
-          ConstDeclarationNodeImpl.class, DeclarationKind.CONST,
-          ConstStatementNodeImpl.class, DeclarationKind.INLINE_CONST,
-          EnumElementNodeImpl.class, DeclarationKind.ENUM_ELEMENT,
-          ExceptItemNodeImpl.class, DeclarationKind.EXCEPT_ITEM,
-          ForLoopVarDeclarationNodeImpl.class, DeclarationKind.LOOP_VAR,
-          RoutineNameNodeImpl.class, DeclarationKind.ROUTINE,
-          PropertyNodeImpl.class, DeclarationKind.PROPERTY,
-          RecordVariantTagNodeImpl.class, DeclarationKind.RECORD_VARIANT_TAG,
-          TypeDeclarationNodeImpl.class, DeclarationKind.TYPE,
-          TypeParameterNodeImpl.class, DeclarationKind.TYPE_PARAMETER);
+      ImmutableMap.<Class<?>, DeclarationKind>builder()
+          .put(ConstDeclarationNodeImpl.class, DeclarationKind.CONST)
+          .put(ConstStatementNodeImpl.class, DeclarationKind.INLINE_CONST)
+          .put(EnumElementNodeImpl.class, DeclarationKind.ENUM_ELEMENT)
+          .put(ExceptItemNodeImpl.class, DeclarationKind.EXCEPT_ITEM)
+          .put(LabelDeclarationNodeImpl.class, DeclarationKind.LABEL)
+          .put(ForLoopVarDeclarationNodeImpl.class, DeclarationKind.LOOP_VAR)
+          .put(RoutineNameNodeImpl.class, DeclarationKind.ROUTINE)
+          .put(PropertyNodeImpl.class, DeclarationKind.PROPERTY)
+          .put(RecordVariantTagNodeImpl.class, DeclarationKind.RECORD_VARIANT_TAG)
+          .put(TypeDeclarationNodeImpl.class, DeclarationKind.TYPE)
+          .put(TypeParameterNodeImpl.class, DeclarationKind.TYPE_PARAMETER)
+          .build();
 
   private static final Map<Class<?>, DeclarationKind> GRANDPARENT_NODE_KIND_MAP =
       Map.of(

--- a/delphi-frontend/src/main/java/au/com/integradev/delphi/antlr/ast/visitors/DelphiParserVisitor.java
+++ b/delphi-frontend/src/main/java/au/com/integradev/delphi/antlr/ast/visitors/DelphiParserVisitor.java
@@ -85,6 +85,7 @@ import org.sonar.plugins.communitydelphi.api.ast.IntegerLiteralNode;
 import org.sonar.plugins.communitydelphi.api.ast.InterfaceGuidNode;
 import org.sonar.plugins.communitydelphi.api.ast.InterfaceSectionNode;
 import org.sonar.plugins.communitydelphi.api.ast.InterfaceTypeNode;
+import org.sonar.plugins.communitydelphi.api.ast.LabelDeclarationNode;
 import org.sonar.plugins.communitydelphi.api.ast.LabelStatementNode;
 import org.sonar.plugins.communitydelphi.api.ast.LibraryDeclarationNode;
 import org.sonar.plugins.communitydelphi.api.ast.LocalDeclarationSectionNode;
@@ -309,6 +310,10 @@ public interface DelphiParserVisitor<T> {
   }
 
   default T visit(InterfaceSectionNode node, T data) {
+    return visit((DelphiNode) node, data);
+  }
+
+  default T visit(LabelDeclarationNode node, T data) {
     return visit((DelphiNode) node, data);
   }
 

--- a/delphi-frontend/src/main/java/au/com/integradev/delphi/symbol/declaration/LabelNameDeclarationImpl.java
+++ b/delphi-frontend/src/main/java/au/com/integradev/delphi/symbol/declaration/LabelNameDeclarationImpl.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Delphi Plugin
- * Copyright (C) 2019 Integrated Application Development
+ * Copyright (C) 2024 Integrated Application Development
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -16,25 +16,13 @@
  * License along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02
  */
-package au.com.integradev.delphi.antlr.ast.node;
+package au.com.integradev.delphi.symbol.declaration;
 
-import au.com.integradev.delphi.antlr.ast.visitors.DelphiParserVisitor;
-import org.antlr.runtime.Token;
-import org.sonar.plugins.communitydelphi.api.ast.GotoStatementNode;
-import org.sonar.plugins.communitydelphi.api.ast.NameReferenceNode;
+import org.sonar.plugins.communitydelphi.api.ast.NameDeclarationNode;
+import org.sonar.plugins.communitydelphi.api.symbol.declaration.LabelNameDeclaration;
 
-public final class GotoStatementNodeImpl extends DelphiNodeImpl implements GotoStatementNode {
-  public GotoStatementNodeImpl(Token token) {
-    super(token);
-  }
-
-  @Override
-  public <T> T accept(DelphiParserVisitor<T> visitor, T data) {
-    return visitor.visit(this, data);
-  }
-
-  @Override
-  public NameReferenceNode getNameReference() {
-    return (NameReferenceNode) getChild(0);
+public class LabelNameDeclarationImpl extends NameDeclarationImpl implements LabelNameDeclaration {
+  public LabelNameDeclarationImpl(NameDeclarationNode node) {
+    super(node);
   }
 }

--- a/delphi-frontend/src/main/java/au/com/integradev/delphi/symbol/scope/DelphiScopeImpl.java
+++ b/delphi-frontend/src/main/java/au/com/integradev/delphi/symbol/scope/DelphiScopeImpl.java
@@ -36,6 +36,7 @@ import javax.annotation.Nullable;
 import org.sonar.plugins.communitydelphi.api.symbol.Invocable;
 import org.sonar.plugins.communitydelphi.api.symbol.NameOccurrence;
 import org.sonar.plugins.communitydelphi.api.symbol.declaration.GenerifiableDeclaration;
+import org.sonar.plugins.communitydelphi.api.symbol.declaration.LabelNameDeclaration;
 import org.sonar.plugins.communitydelphi.api.symbol.declaration.NameDeclaration;
 import org.sonar.plugins.communitydelphi.api.symbol.declaration.PropertyNameDeclaration;
 import org.sonar.plugins.communitydelphi.api.symbol.declaration.RoutineDirective;
@@ -60,6 +61,7 @@ public class DelphiScopeImpl implements DelphiScope {
   private final Set<PropertyNameDeclaration> propertyDeclarations;
   private final Set<RoutineNameDeclaration> routineDeclarations;
   private final Set<VariableNameDeclaration> variableDeclarations;
+  private final Set<LabelNameDeclaration> labelDeclarations;
   private final Map<String, HelperType> helpersByType;
 
   private DelphiScope parent;
@@ -74,6 +76,7 @@ public class DelphiScopeImpl implements DelphiScope {
     propertyDeclarations = new HashSet<>();
     routineDeclarations = new HashSet<>();
     variableDeclarations = new HashSet<>();
+    labelDeclarations = new HashSet<>();
     helpersByType = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
   }
 
@@ -105,6 +108,8 @@ public class DelphiScopeImpl implements DelphiScope {
       typeDeclarations.add((TypeNameDeclaration) declaration);
     } else if (declaration instanceof UnitNameDeclaration) {
       unitDeclarations.add((UnitNameDeclaration) declaration);
+    } else if (declaration instanceof LabelNameDeclaration) {
+      labelDeclarations.add((LabelNameDeclaration) declaration);
     }
   }
 
@@ -412,5 +417,10 @@ public class DelphiScopeImpl implements DelphiScope {
   @Override
   public Set<VariableNameDeclaration> getVariableDeclarations() {
     return Collections.unmodifiableSet(variableDeclarations);
+  }
+
+  @Override
+  public Set<LabelNameDeclaration> getLabelDeclarations() {
+    return Collections.unmodifiableSet(labelDeclarations);
   }
 }

--- a/delphi-frontend/src/main/java/org/sonar/plugins/communitydelphi/api/ast/GotoStatementNode.java
+++ b/delphi-frontend/src/main/java/org/sonar/plugins/communitydelphi/api/ast/GotoStatementNode.java
@@ -18,4 +18,6 @@
  */
 package org.sonar.plugins.communitydelphi.api.ast;
 
-public interface GotoStatementNode extends StatementNode {}
+public interface GotoStatementNode extends StatementNode {
+  NameReferenceNode getNameReference();
+}

--- a/delphi-frontend/src/main/java/org/sonar/plugins/communitydelphi/api/ast/LabelDeclarationNode.java
+++ b/delphi-frontend/src/main/java/org/sonar/plugins/communitydelphi/api/ast/LabelDeclarationNode.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Delphi Plugin
- * Copyright (C) 2019 Integrated Application Development
+ * Copyright (C) 2024 Integrated Application Development
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -16,25 +16,10 @@
  * License along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02
  */
-package au.com.integradev.delphi.antlr.ast.node;
+package org.sonar.plugins.communitydelphi.api.ast;
 
-import au.com.integradev.delphi.antlr.ast.visitors.DelphiParserVisitor;
-import org.antlr.runtime.Token;
-import org.sonar.plugins.communitydelphi.api.ast.GotoStatementNode;
-import org.sonar.plugins.communitydelphi.api.ast.NameReferenceNode;
+import java.util.List;
 
-public final class GotoStatementNodeImpl extends DelphiNodeImpl implements GotoStatementNode {
-  public GotoStatementNodeImpl(Token token) {
-    super(token);
-  }
-
-  @Override
-  public <T> T accept(DelphiParserVisitor<T> visitor, T data) {
-    return visitor.visit(this, data);
-  }
-
-  @Override
-  public NameReferenceNode getNameReference() {
-    return (NameReferenceNode) getChild(0);
-  }
+public interface LabelDeclarationNode extends DelphiNode {
+  List<NameDeclarationNode> getDeclarations();
 }

--- a/delphi-frontend/src/main/java/org/sonar/plugins/communitydelphi/api/ast/LabelStatementNode.java
+++ b/delphi-frontend/src/main/java/org/sonar/plugins/communitydelphi/api/ast/LabelStatementNode.java
@@ -18,4 +18,11 @@
  */
 package org.sonar.plugins.communitydelphi.api.ast;
 
-public interface LabelStatementNode extends StatementNode {}
+import javax.annotation.Nullable;
+
+public interface LabelStatementNode extends StatementNode {
+  NameReferenceNode getNameReference();
+
+  @Nullable
+  StatementNode getStatement();
+}

--- a/delphi-frontend/src/main/java/org/sonar/plugins/communitydelphi/api/symbol/declaration/LabelNameDeclaration.java
+++ b/delphi-frontend/src/main/java/org/sonar/plugins/communitydelphi/api/symbol/declaration/LabelNameDeclaration.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Delphi Plugin
- * Copyright (C) 2019 Integrated Application Development
+ * Copyright (C) 2024 Integrated Application Development
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -16,25 +16,6 @@
  * License along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02
  */
-package au.com.integradev.delphi.antlr.ast.node;
+package org.sonar.plugins.communitydelphi.api.symbol.declaration;
 
-import au.com.integradev.delphi.antlr.ast.visitors.DelphiParserVisitor;
-import org.antlr.runtime.Token;
-import org.sonar.plugins.communitydelphi.api.ast.GotoStatementNode;
-import org.sonar.plugins.communitydelphi.api.ast.NameReferenceNode;
-
-public final class GotoStatementNodeImpl extends DelphiNodeImpl implements GotoStatementNode {
-  public GotoStatementNodeImpl(Token token) {
-    super(token);
-  }
-
-  @Override
-  public <T> T accept(DelphiParserVisitor<T> visitor, T data) {
-    return visitor.visit(this, data);
-  }
-
-  @Override
-  public NameReferenceNode getNameReference() {
-    return (NameReferenceNode) getChild(0);
-  }
-}
+public interface LabelNameDeclaration extends NameDeclaration {}

--- a/delphi-frontend/src/main/java/org/sonar/plugins/communitydelphi/api/symbol/scope/DelphiScope.java
+++ b/delphi-frontend/src/main/java/org/sonar/plugins/communitydelphi/api/symbol/scope/DelphiScope.java
@@ -23,6 +23,7 @@ import java.util.List;
 import java.util.Set;
 import javax.annotation.Nullable;
 import org.sonar.plugins.communitydelphi.api.symbol.NameOccurrence;
+import org.sonar.plugins.communitydelphi.api.symbol.declaration.LabelNameDeclaration;
 import org.sonar.plugins.communitydelphi.api.symbol.declaration.NameDeclaration;
 import org.sonar.plugins.communitydelphi.api.symbol.declaration.PropertyNameDeclaration;
 import org.sonar.plugins.communitydelphi.api.symbol.declaration.RoutineNameDeclaration;
@@ -71,6 +72,8 @@ public interface DelphiScope {
   Set<RoutineNameDeclaration> getRoutineDeclarations();
 
   Set<VariableNameDeclaration> getVariableDeclarations();
+
+  Set<LabelNameDeclaration> getLabelDeclarations();
 
   static DelphiScope unknownScope() {
     return UnknownScopeImpl.instance();

--- a/delphi-frontend/src/test/java/au/com/integradev/delphi/executor/DelphiSymbolTableExecutorTest.java
+++ b/delphi-frontend/src/test/java/au/com/integradev/delphi/executor/DelphiSymbolTableExecutorTest.java
@@ -394,6 +394,15 @@ class DelphiSymbolTableExecutorTest {
   }
 
   @Test
+  void testLabels() {
+    execute("Labels.pas");
+    verifyUsages(8, 6, reference(10, 7), reference(11, 2));
+    verifyUsages(15, 6, reference(17, 7), reference(18, 2));
+    verifyUsages(22, 6, reference(24, 7), reference(25, 2));
+    verifyUsages(29, 6, reference(31, 7), reference(32, 2));
+  }
+
+  @Test
   void testClassReferenceMethodResolution() {
     execute("classReferences/MethodResolution.pas");
     verifyUsages(9, 14, reference(18, 6));

--- a/delphi-frontend/src/test/java/au/com/integradev/delphi/symbol/scope/DelphiScopeImplTest.java
+++ b/delphi-frontend/src/test/java/au/com/integradev/delphi/symbol/scope/DelphiScopeImplTest.java
@@ -180,7 +180,7 @@ class DelphiScopeImplTest {
   }
 
   @Test
-  void testGenericTypesWithSameNumberofTypeParametersAreNotDuplicates() {
+  void testGenericTypesWithSameNumberOfTypeParametersAreNotDuplicates() {
     scope.addDeclaration(createClassType("Foo", List.of(createType("Bar"))));
     assertThatCode(() -> scope.addDeclaration(createClassType("Foo", List.of(createType("Bar")))))
         .doesNotThrowAnyException();

--- a/delphi-frontend/src/test/java/au/com/integradev/delphi/symbol/scope/UnknownScopeImplTest.java
+++ b/delphi-frontend/src/test/java/au/com/integradev/delphi/symbol/scope/UnknownScopeImplTest.java
@@ -127,6 +127,11 @@ class UnknownScopeImplTest {
     assertThat(unknownScope.getVariableDeclarations()).isEmpty();
   }
 
+  @Test
+  void testGetLabelDeclarations() {
+    assertThat(unknownScope.getLabelDeclarations()).isEmpty();
+  }
+
   private static NameOccurrence makeNameOccurrence() {
     DelphiToken token = mock(DelphiToken.class);
     when(token.isIncludedToken()).thenReturn(false);

--- a/delphi-frontend/src/test/resources/au/com/integradev/delphi/symbol/Labels.pas
+++ b/delphi-frontend/src/test/resources/au/com/integradev/delphi/symbol/Labels.pas
@@ -1,0 +1,36 @@
+unit Labels;
+
+interface
+
+implementation
+
+procedure Identifier;
+label Foo;
+begin
+  goto Foo;
+  Foo:
+end;
+
+procedure Decimal;
+label 12345;
+begin
+  goto 12345;
+  12345:
+end;
+
+procedure Hex;
+label $3039;
+begin
+  goto $3039;
+  $3039:
+end;
+
+procedure Binary;
+label %11000000111001;
+begin
+  goto %11000000111001;
+  %11000000111001:
+end;
+
+
+end.


### PR DESCRIPTION
This PR generally improves analysis of goto and labels:
- model `label` identifiers properly in the AST
  - special handling for numeric label identifiers
- model `label` declarations properly in the AST
  - new node type
- add labels to the symbol table
  - new symbol declaration type
- ensure name resolution occurs for label references in `label` & `goto` statements
- expand the API around labels & goto in the AST and symbol APIs
