### PR TITLE
Tidy the changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -629,7 +629,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Remove `MemoryManagementRule` from the Sonar Way quality profile.
 - Improve handling of constructor calls in `RedundantCastRule`.
 - Improve handling of multi-variable declarations in `TooManyVariablesRule`.
-- Improved handling of `else` blocks (within `case` statements and `except` blocks) in
+- Improve handling of `else` blocks (within `case` statements and `except` blocks) in
   `BeginEndRequiredRule`.
 
 ## [0.28.0] - 2021-02-02
@@ -815,9 +815,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Improve type comparisons between text-literal arguments and character pointer parameters.
 - Improve type comparisons involving `nil` literals.
 - Improve support for the `High` and `Low` intrinsics.
-- Improved primary expression type resolution around constructor invocations.
-- Improved primary expression type resolution around hard casts.
-- Improved primary expression type resolution around array properties.
+- Improve primary expression type resolution around constructor invocations.
+- Improve primary expression type resolution around hard casts.
+- Improve primary expression type resolution around array properties.
 - Types nested within the `testSuiteType` will now be treated as test code.
 - `Char` is now treated as an alias to `WideChar`.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - "Move to implementation section" quick fix for `ImportSpecificity`.
 - "Remove unused import" quick fix for `UnusedImport`.
-- More comprehensive analysis and more detailed documentation for the `PointerName` rule.
 - **API:** `UsesClauseNode::getImports` method.
 - **API:** `InterfaceSectionNode::getUsesClause` method.
 - **API:** `ImplementationSectionNode::getUsesClause` method.
@@ -25,6 +24,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Improve semantic analysis around `label` and `goto` statements.
+- Improve handling for dereferenced types starting with `E` and `I` in `PointerName`.
+- Improve handling for dereferenced types that don't comply with naming conventions in `PointerName`.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,10 +37,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [1.5.0] - 2024-05-02
 
-### Fixed
-
-- False positive `FormatStringValid` issues on strings containing uppercase format specifiers.
-
 ### Added
 
 - Support for the `winapi` calling convention.
@@ -70,6 +66,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- False positive `FormatStringValid` issues on strings containing uppercase format specifiers.
 - Exception when parsing fully qualified attribute references.
 - `DuplicatedDeclarationException` errors caused by some local scopes being modeled incorrectly.
 - Name resolution issues around `if`, `else`, `for`, and `with` constructs when the body contains a single statement.


### PR DESCRIPTION
This PR fixes a couple of minor issues in the changelog.
- Duplicate section in the 1.5.0 changelog
- Past-tense verb usage

It also adjusts the changelog from the recent `PointerName` improvements.