### PR TITLE
Allow `Label` keyword as an identifier

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - File pointer errors when an issue is raised on the first line of a file with a byte order mark.
 - Symbol table construction errors for program files omitting the `program` header.
 - Parsing errors on parenthesised anonymous methods.
+- Parsing errors on identifiers named `Label`, which was allowed in Delphi.NET.
 - Scan failures on invalid paths in dproj files.
 - Incorrect ordering of edits in the "Separate grouped parameters" quick fix for `GroupedParameterDeclaration`.
 - SonarLint registration of rules that don't support execution in a SonarLint context.

--- a/delphi-frontend/src/main/antlr3/au/com/integradev/delphi/antlr/Delphi.g
+++ b/delphi-frontend/src/main/antlr3/au/com/integradev/delphi/antlr/Delphi.g
@@ -982,6 +982,7 @@ keywordsUsedAsNames          : (ABSOLUTE | ABSTRACT | ALIGN | ASSEMBLER | ASSEMB
                              | (PRIVATE | PROTECTED | PUBLIC | PUBLISHED | READ | READONLY | REFERENCE | REGISTER | REINTRODUCE)
                              | (REQUIRES | RESIDENT | SAFECALL | SEALED | STATIC | STDCALL | STORED | STRICT | UNSAFE)
                              | (VARARGS | VIRTUAL | WINAPI | WRITE | WRITEONLY)
+                             | (LABEL) // Used to be allowed in Delphi.NET.
                              ;
 keywords                     : (ABSOLUTE | ABSTRACT | AND | ALIGN | ARRAY | AS | ASM | ASSEMBLER | ASSEMBLY)
                              | (AT | AUTOMATED | BEGIN | CASE | CDECL | CLASS | CONST | CONSTRUCTOR | CONTAINS| DEFAULT)

--- a/delphi-frontend/src/test/resources/au/com/integradev/delphi/grammar/KeyWordsAsIdentifier.pas
+++ b/delphi-frontend/src/test/resources/au/com/integradev/delphi/grammar/KeyWordsAsIdentifier.pas
@@ -31,6 +31,7 @@ var
   HELPER: Boolean;
   IMPLEMENTS: Boolean;
   INDEX: Boolean;
+  LABEL: Boolean; // Allowed in Delphi.NET
   LOCAL: Boolean;
   MESSAGE: Boolean;
   NAME: Boolean;


### PR DESCRIPTION
This apparently used to be allowed in Delphi.NET.