### PR TITLE
Remove warning about Delphi Community Edition being unsupported

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,11 +84,6 @@ In addition to template rules, SonarDelphi can be extended with custom rules plu
 4. View analysis results:
     * Visit the link provided at the end of the scan to view analysis results on SonarQube.
 
-> [!WARNING]
-> Unfortunately, Delphi Community Edition is **not** supported.
->
-> SonarDelphi requires source code for all dependencies, including the standard library.
-
 ## Read the Manual
 
 The [SonarDelphi Manual](docs/MANUAL.md) provides a comprehensive guide to SonarDelphi and the Sonar ecosystem,


### PR DESCRIPTION
Good news!
It turns out that current versions of Delphi CE actually do include the standard library source code.