### PR TITLE
Improve analysis and modeling around property specifiers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Improve AST modeling around property specifiers.
 - Improve semantic analysis around property specifiers.
+- Exclude properties with `implements` specifiers in `UnusedProperty`.
 
 ## [1.7.0] - 2024-07-02
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **API:** `PropertyNameDeclaration::getImplementedTypes` method.
+- **API:** `PropertyNode::getDefaultSpecifier` method.
+- **API:** `PropertyNode::getImplementsSpecifier` method.
+- **API:** `PropertyNode::getIndexSpecifier` method.
+- **API:** `PropertyNode::getStoredSpecifier` method.
+- **API:** `PropertyDefaultSpecifierNode` node type.
+- **API:** `PropertyImplementsSpecifierNode` node type.
+- **API:** `PropertyIndexSpecifierNode` node type.
+- **API:** `PropertyStoredSpecifierNode` node type.
+
+### Changed
+
+- Improve AST modeling around property specifiers.
+- Improve semantic analysis around property specifiers.
+
 ## [1.7.0] - 2024-07-02
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Improve semantic analysis around property specifiers.
 - Exclude properties with `implements` specifiers in `UnusedProperty`.
 
+### Fixed
+
+- Overly permissive parsing rules around `string` and `file` types.
+
 ## [1.7.0] - 2024-07-02
 
 ### Added

--- a/delphi-checks/src/main/java/au/com/integradev/delphi/checks/UnusedPropertyCheck.java
+++ b/delphi-checks/src/main/java/au/com/integradev/delphi/checks/UnusedPropertyCheck.java
@@ -56,6 +56,10 @@ public class UnusedPropertyCheck extends DelphiCheck {
       return false;
     }
 
+    if (!declaration.getImplementedTypes().isEmpty()) {
+      return false;
+    }
+
     if (excludeApi && declaration.isPublic() && !declaration.isImplementationDeclaration()) {
       return false;
     }

--- a/delphi-checks/src/test/java/au/com/integradev/delphi/checks/UnusedPropertyCheckTest.java
+++ b/delphi-checks/src/test/java/au/com/integradev/delphi/checks/UnusedPropertyCheckTest.java
@@ -190,6 +190,28 @@ class UnusedPropertyCheckTest {
   }
 
   @Test
+  void testUnusedPropertyImplementingInterfaceShouldNotAddIssue() {
+    CheckVerifier.newVerifier()
+        .withCheck(new UnusedPropertyCheck())
+        .onFile(
+            new DelphiTestUnitBuilder()
+                .appendDecl("type")
+                .appendDecl("  IBar = interface")
+                .appendDecl("  end;")
+                .appendDecl("")
+                .appendDecl("  TBar = class")
+                .appendDecl("  end;")
+                .appendDecl("")
+                .appendDecl("  TFoo = class(IBar)")
+                .appendDecl("  private")
+                .appendDecl("    FBar: TBar;")
+                .appendDecl("  public")
+                .appendDecl("    property Bar: TBar implements IBar;")
+                .appendDecl("end;"))
+        .verifyNoIssues();
+  }
+
+  @Test
   void testUnusedApiPropertyWithExcludeApiShouldNotAddIssue() {
     var check = new UnusedPropertyCheck();
     check.excludeApi = true;
@@ -239,7 +261,7 @@ class UnusedPropertyCheckTest {
                 .appendImpl("private")
                 .appendImpl("  FBar: Integer;")
                 .appendImpl("public")
-                .appendImpl("  property Bar: Integer read FBar; //Noncompliant")
+                .appendImpl("  property Bar: Integer read FBar; // Noncompliant")
                 .appendImpl("end;"))
         .verifyIssues();
   }

--- a/delphi-frontend/src/main/antlr3/au/com/integradev/delphi/antlr/Delphi.g
+++ b/delphi-frontend/src/main/antlr3/au/com/integradev/delphi/antlr/Delphi.g
@@ -650,16 +650,26 @@ property                     : attributeList? CLASS? PROPERTY nameDeclaration pr
                              ;
 propertyArray                : lbrack! formalParameterList rbrack!
                              ;
-propertyDirective            : ';' DEFAULT
-                             | DEFAULT expression
+propertyDirective            : ';' propertyDefaultNoExpression
+                             | propertyDefault
                              | propertyReadWrite
                              | propertyDispInterface
-                             | IMPLEMENTS typeReference (',' typeReference)*
-                             | INDEX expression
+                             | propertyImplements
+                             | propertyIndex
+                             | propertyStored
                              | NODEFAULT
-                             | STORED expression
+                             ;
+propertyDefaultNoExpression  : DEFAULT<PropertyDefaultSpecifierNodeImpl>^
+                             ;
+propertyDefault              : DEFAULT<PropertyDefaultSpecifierNodeImpl>^ expression
                              ;
 propertyReadWrite            : (READ<PropertyReadSpecifierNodeImpl>^ | WRITE<PropertyWriteSpecifierNodeImpl>^) primaryExpression
+                             ;
+propertyImplements           : IMPLEMENTS<PropertyImplementsSpecifierNodeImpl>^ typeReference (',' typeReference)*
+                             ;
+propertyIndex                : INDEX<PropertyIndexSpecifierNodeImpl>^ expression
+                             ;
+propertyStored               : STORED<PropertyStoredSpecifierNodeImpl>^ expression
                              ;
 propertyDispInterface        : READONLY
                              | WRITEONLY

--- a/delphi-frontend/src/main/java/au/com/integradev/delphi/antlr/ast/node/PropertyDefaultSpecifierNodeImpl.java
+++ b/delphi-frontend/src/main/java/au/com/integradev/delphi/antlr/ast/node/PropertyDefaultSpecifierNodeImpl.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Delphi Plugin
- * Copyright (C) 2023 Integrated Application Development
+ * Copyright (C) 2024 Integrated Application Development
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -16,30 +16,28 @@
  * License along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02
  */
-package org.sonar.plugins.communitydelphi.api.symbol.declaration;
+package au.com.integradev.delphi.antlr.ast.node;
 
-import java.util.List;
+import au.com.integradev.delphi.antlr.ast.visitors.DelphiParserVisitor;
 import javax.annotation.Nullable;
-import org.sonar.plugins.communitydelphi.api.ast.Visibility;
-import org.sonar.plugins.communitydelphi.api.symbol.Invocable;
-import org.sonar.plugins.communitydelphi.api.type.Type;
+import org.antlr.runtime.Token;
+import org.sonar.plugins.communitydelphi.api.ast.ExpressionNode;
+import org.sonar.plugins.communitydelphi.api.ast.PropertyDefaultSpecifierNode;
 
-public interface PropertyNameDeclaration extends TypedDeclaration, Invocable, Visibility {
-  String fullyQualifiedName();
+public final class PropertyDefaultSpecifierNodeImpl extends DelphiNodeImpl
+    implements PropertyDefaultSpecifierNode {
+  public PropertyDefaultSpecifierNodeImpl(Token token) {
+    super(token);
+  }
+
+  @Override
+  public <T> T accept(DelphiParserVisitor<T> visitor, T data) {
+    return visitor.visit(this, data);
+  }
 
   @Nullable
-  NameDeclaration getReadDeclaration();
-
-  @Nullable
-  NameDeclaration getWriteDeclaration();
-
-  List<Type> getImplementedTypes();
-
-  boolean isArrayProperty();
-
-  boolean isDefaultProperty();
-
-  List<PropertyNameDeclaration> getRedeclarations();
-
-  List<Type> getAttributeTypes();
+  @Override
+  public ExpressionNode getExpression() {
+    return (ExpressionNode) getChild(0);
+  }
 }

--- a/delphi-frontend/src/main/java/au/com/integradev/delphi/antlr/ast/node/PropertyImplementsSpecifierNodeImpl.java
+++ b/delphi-frontend/src/main/java/au/com/integradev/delphi/antlr/ast/node/PropertyImplementsSpecifierNodeImpl.java
@@ -1,0 +1,42 @@
+/*
+ * Sonar Delphi Plugin
+ * Copyright (C) 2024 Integrated Application Development
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02
+ */
+package au.com.integradev.delphi.antlr.ast.node;
+
+import au.com.integradev.delphi.antlr.ast.visitors.DelphiParserVisitor;
+import java.util.List;
+import org.antlr.runtime.Token;
+import org.sonar.plugins.communitydelphi.api.ast.PropertyImplementsSpecifierNode;
+import org.sonar.plugins.communitydelphi.api.ast.TypeReferenceNode;
+
+public final class PropertyImplementsSpecifierNodeImpl extends DelphiNodeImpl
+    implements PropertyImplementsSpecifierNode {
+  public PropertyImplementsSpecifierNodeImpl(Token token) {
+    super(token);
+  }
+
+  @Override
+  public <T> T accept(DelphiParserVisitor<T> visitor, T data) {
+    return visitor.visit(this, data);
+  }
+
+  @Override
+  public List<TypeReferenceNode> getTypeReferences() {
+    return findChildrenOfType(TypeReferenceNode.class);
+  }
+}

--- a/delphi-frontend/src/main/java/au/com/integradev/delphi/antlr/ast/node/PropertyIndexSpecifierNodeImpl.java
+++ b/delphi-frontend/src/main/java/au/com/integradev/delphi/antlr/ast/node/PropertyIndexSpecifierNodeImpl.java
@@ -1,0 +1,41 @@
+/*
+ * Sonar Delphi Plugin
+ * Copyright (C) 2024 Integrated Application Development
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02
+ */
+package au.com.integradev.delphi.antlr.ast.node;
+
+import au.com.integradev.delphi.antlr.ast.visitors.DelphiParserVisitor;
+import org.antlr.runtime.Token;
+import org.sonar.plugins.communitydelphi.api.ast.ExpressionNode;
+import org.sonar.plugins.communitydelphi.api.ast.PropertyIndexSpecifierNode;
+
+public final class PropertyIndexSpecifierNodeImpl extends DelphiNodeImpl
+    implements PropertyIndexSpecifierNode {
+  public PropertyIndexSpecifierNodeImpl(Token token) {
+    super(token);
+  }
+
+  @Override
+  public <T> T accept(DelphiParserVisitor<T> visitor, T data) {
+    return visitor.visit(this, data);
+  }
+
+  @Override
+  public ExpressionNode getExpression() {
+    return (ExpressionNode) getChild(0);
+  }
+}

--- a/delphi-frontend/src/main/java/au/com/integradev/delphi/antlr/ast/node/PropertyNodeImpl.java
+++ b/delphi-frontend/src/main/java/au/com/integradev/delphi/antlr/ast/node/PropertyNodeImpl.java
@@ -28,8 +28,12 @@ import org.sonar.plugins.communitydelphi.api.ast.DelphiNode;
 import org.sonar.plugins.communitydelphi.api.ast.FormalParameterListNode;
 import org.sonar.plugins.communitydelphi.api.ast.FormalParameterNode.FormalParameterData;
 import org.sonar.plugins.communitydelphi.api.ast.NameDeclarationNode;
+import org.sonar.plugins.communitydelphi.api.ast.PropertyDefaultSpecifierNode;
+import org.sonar.plugins.communitydelphi.api.ast.PropertyImplementsSpecifierNode;
+import org.sonar.plugins.communitydelphi.api.ast.PropertyIndexSpecifierNode;
 import org.sonar.plugins.communitydelphi.api.ast.PropertyNode;
 import org.sonar.plugins.communitydelphi.api.ast.PropertyReadSpecifierNode;
+import org.sonar.plugins.communitydelphi.api.ast.PropertyStoredSpecifierNode;
 import org.sonar.plugins.communitydelphi.api.ast.PropertyWriteSpecifierNode;
 import org.sonar.plugins.communitydelphi.api.ast.TypeNode;
 import org.sonar.plugins.communitydelphi.api.ast.VisibilitySectionNode;
@@ -97,6 +101,30 @@ public final class PropertyNodeImpl extends DelphiNodeImpl implements PropertyNo
   }
 
   @Override
+  @Nullable
+  public PropertyDefaultSpecifierNode getDefaultSpecifier() {
+    return getFirstChildOfType(PropertyDefaultSpecifierNode.class);
+  }
+
+  @Override
+  @Nullable
+  public PropertyImplementsSpecifierNode getImplementsSpecifier() {
+    return getFirstChildOfType(PropertyImplementsSpecifierNode.class);
+  }
+
+  @Override
+  @Nullable
+  public PropertyIndexSpecifierNode getIndexSpecifier() {
+    return getFirstChildOfType(PropertyIndexSpecifierNode.class);
+  }
+
+  @Override
+  @Nullable
+  public PropertyStoredSpecifierNode getStoredSpecifier() {
+    return getFirstChildOfType(PropertyStoredSpecifierNode.class);
+  }
+
+  @Override
   public List<FormalParameterData> getParameters() {
     FormalParameterListNode paramList = getParameterListNode();
     return (paramList == null) ? Collections.emptyList() : paramList.getParameters();
@@ -120,6 +148,6 @@ public final class PropertyNodeImpl extends DelphiNodeImpl implements PropertyNo
 
   @Override
   public boolean isDefaultProperty() {
-    return getFirstChildWithTokenType(DelphiTokenType.DEFAULT) != null;
+    return getDefaultSpecifier() != null;
   }
 }

--- a/delphi-frontend/src/main/java/au/com/integradev/delphi/antlr/ast/node/PropertyStoredSpecifierNodeImpl.java
+++ b/delphi-frontend/src/main/java/au/com/integradev/delphi/antlr/ast/node/PropertyStoredSpecifierNodeImpl.java
@@ -1,0 +1,41 @@
+/*
+ * Sonar Delphi Plugin
+ * Copyright (C) 2024 Integrated Application Development
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02
+ */
+package au.com.integradev.delphi.antlr.ast.node;
+
+import au.com.integradev.delphi.antlr.ast.visitors.DelphiParserVisitor;
+import org.antlr.runtime.Token;
+import org.sonar.plugins.communitydelphi.api.ast.ExpressionNode;
+import org.sonar.plugins.communitydelphi.api.ast.PropertyStoredSpecifierNode;
+
+public final class PropertyStoredSpecifierNodeImpl extends DelphiNodeImpl
+    implements PropertyStoredSpecifierNode {
+  public PropertyStoredSpecifierNodeImpl(Token token) {
+    super(token);
+  }
+
+  @Override
+  public <T> T accept(DelphiParserVisitor<T> visitor, T data) {
+    return visitor.visit(this, data);
+  }
+
+  @Override
+  public ExpressionNode getExpression() {
+    return (ExpressionNode) getChild(0);
+  }
+}

--- a/delphi-frontend/src/main/java/au/com/integradev/delphi/antlr/ast/node/StringTypeNodeImpl.java
+++ b/delphi-frontend/src/main/java/au/com/integradev/delphi/antlr/ast/node/StringTypeNodeImpl.java
@@ -38,7 +38,7 @@ public final class StringTypeNodeImpl extends TypeNodeImpl implements StringType
 
   @Override
   public boolean isFixedString() {
-    return getChild(0) instanceof ExpressionNode;
+    return getChild(1) instanceof ExpressionNode;
   }
 
   @Override

--- a/delphi-frontend/src/main/java/au/com/integradev/delphi/antlr/ast/visitors/DelphiParserVisitor.java
+++ b/delphi-frontend/src/main/java/au/com/integradev/delphi/antlr/ast/visitors/DelphiParserVisitor.java
@@ -105,8 +105,12 @@ import org.sonar.plugins.communitydelphi.api.ast.ProcedureReferenceTypeNode;
 import org.sonar.plugins.communitydelphi.api.ast.ProcedureTypeHeadingNode;
 import org.sonar.plugins.communitydelphi.api.ast.ProcedureTypeNode;
 import org.sonar.plugins.communitydelphi.api.ast.ProgramDeclarationNode;
+import org.sonar.plugins.communitydelphi.api.ast.PropertyDefaultSpecifierNode;
+import org.sonar.plugins.communitydelphi.api.ast.PropertyImplementsSpecifierNode;
+import org.sonar.plugins.communitydelphi.api.ast.PropertyIndexSpecifierNode;
 import org.sonar.plugins.communitydelphi.api.ast.PropertyNode;
 import org.sonar.plugins.communitydelphi.api.ast.PropertyReadSpecifierNode;
+import org.sonar.plugins.communitydelphi.api.ast.PropertyStoredSpecifierNode;
 import org.sonar.plugins.communitydelphi.api.ast.PropertyWriteSpecifierNode;
 import org.sonar.plugins.communitydelphi.api.ast.QualifiedNameDeclarationNode;
 import org.sonar.plugins.communitydelphi.api.ast.RaiseStatementNode;
@@ -353,7 +357,23 @@ public interface DelphiParserVisitor<T> {
     return visit((DelphiNode) node, data);
   }
 
+  default T visit(PropertyDefaultSpecifierNode node, T data) {
+    return visit((DelphiNode) node, data);
+  }
+
+  default T visit(PropertyIndexSpecifierNode node, T data) {
+    return visit((DelphiNode) node, data);
+  }
+
+  default T visit(PropertyImplementsSpecifierNode node, T data) {
+    return visit((DelphiNode) node, data);
+  }
+
   default T visit(PropertyReadSpecifierNode node, T data) {
+    return visit((DelphiNode) node, data);
+  }
+
+  default T visit(PropertyStoredSpecifierNode node, T data) {
     return visit((DelphiNode) node, data);
   }
 
@@ -453,6 +473,7 @@ public interface DelphiParserVisitor<T> {
   }
 
   default T visit(RoutineImplementationNode node, T data) {
+
     return visit((RoutineNode) node, data);
   }
 

--- a/delphi-frontend/src/main/java/au/com/integradev/delphi/symbol/resolve/NameResolutionHelper.java
+++ b/delphi-frontend/src/main/java/au/com/integradev/delphi/symbol/resolve/NameResolutionHelper.java
@@ -47,6 +47,7 @@ import org.sonar.plugins.communitydelphi.api.ast.MethodResolutionClauseNode;
 import org.sonar.plugins.communitydelphi.api.ast.NameReferenceNode;
 import org.sonar.plugins.communitydelphi.api.ast.Node;
 import org.sonar.plugins.communitydelphi.api.ast.PrimaryExpressionNode;
+import org.sonar.plugins.communitydelphi.api.ast.PropertyImplementsSpecifierNode;
 import org.sonar.plugins.communitydelphi.api.ast.PropertyNode;
 import org.sonar.plugins.communitydelphi.api.ast.PropertyReadSpecifierNode;
 import org.sonar.plugins.communitydelphi.api.ast.PropertyWriteSpecifierNode;
@@ -256,6 +257,11 @@ public class NameResolutionHelper {
       writeResolver.readPrimaryExpression(write.getExpression());
       writeResolver.disambiguateParameters(parameterTypes);
       writeResolver.addToSymbolTable();
+    }
+
+    PropertyImplementsSpecifierNode impl = property.getImplementsSpecifier();
+    if (impl != null) {
+      impl.getTypeReferences().stream().map(TypeReferenceNode::getNameNode).forEach(this::resolve);
     }
   }
 

--- a/delphi-frontend/src/main/java/org/sonar/plugins/communitydelphi/api/ast/PropertyDefaultSpecifierNode.java
+++ b/delphi-frontend/src/main/java/org/sonar/plugins/communitydelphi/api/ast/PropertyDefaultSpecifierNode.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Delphi Plugin
- * Copyright (C) 2023 Integrated Application Development
+ * Copyright (C) 2024 Integrated Application Development
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -16,30 +16,11 @@
  * License along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02
  */
-package org.sonar.plugins.communitydelphi.api.symbol.declaration;
+package org.sonar.plugins.communitydelphi.api.ast;
 
-import java.util.List;
 import javax.annotation.Nullable;
-import org.sonar.plugins.communitydelphi.api.ast.Visibility;
-import org.sonar.plugins.communitydelphi.api.symbol.Invocable;
-import org.sonar.plugins.communitydelphi.api.type.Type;
 
-public interface PropertyNameDeclaration extends TypedDeclaration, Invocable, Visibility {
-  String fullyQualifiedName();
-
+public interface PropertyDefaultSpecifierNode extends DelphiNode {
   @Nullable
-  NameDeclaration getReadDeclaration();
-
-  @Nullable
-  NameDeclaration getWriteDeclaration();
-
-  List<Type> getImplementedTypes();
-
-  boolean isArrayProperty();
-
-  boolean isDefaultProperty();
-
-  List<PropertyNameDeclaration> getRedeclarations();
-
-  List<Type> getAttributeTypes();
+  ExpressionNode getExpression();
 }

--- a/delphi-frontend/src/main/java/org/sonar/plugins/communitydelphi/api/ast/PropertyImplementsSpecifierNode.java
+++ b/delphi-frontend/src/main/java/org/sonar/plugins/communitydelphi/api/ast/PropertyImplementsSpecifierNode.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Delphi Plugin
- * Copyright (C) 2023 Integrated Application Development
+ * Copyright (C) 2024 Integrated Application Development
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -16,30 +16,10 @@
  * License along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02
  */
-package org.sonar.plugins.communitydelphi.api.symbol.declaration;
+package org.sonar.plugins.communitydelphi.api.ast;
 
 import java.util.List;
-import javax.annotation.Nullable;
-import org.sonar.plugins.communitydelphi.api.ast.Visibility;
-import org.sonar.plugins.communitydelphi.api.symbol.Invocable;
-import org.sonar.plugins.communitydelphi.api.type.Type;
 
-public interface PropertyNameDeclaration extends TypedDeclaration, Invocable, Visibility {
-  String fullyQualifiedName();
-
-  @Nullable
-  NameDeclaration getReadDeclaration();
-
-  @Nullable
-  NameDeclaration getWriteDeclaration();
-
-  List<Type> getImplementedTypes();
-
-  boolean isArrayProperty();
-
-  boolean isDefaultProperty();
-
-  List<PropertyNameDeclaration> getRedeclarations();
-
-  List<Type> getAttributeTypes();
+public interface PropertyImplementsSpecifierNode extends DelphiNode {
+  List<TypeReferenceNode> getTypeReferences();
 }

--- a/delphi-frontend/src/main/java/org/sonar/plugins/communitydelphi/api/ast/PropertyIndexSpecifierNode.java
+++ b/delphi-frontend/src/main/java/org/sonar/plugins/communitydelphi/api/ast/PropertyIndexSpecifierNode.java
@@ -1,0 +1,23 @@
+/*
+ * Sonar Delphi Plugin
+ * Copyright (C) 2024 Integrated Application Development
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02
+ */
+package org.sonar.plugins.communitydelphi.api.ast;
+
+public interface PropertyIndexSpecifierNode extends DelphiNode {
+  ExpressionNode getExpression();
+}

--- a/delphi-frontend/src/main/java/org/sonar/plugins/communitydelphi/api/ast/PropertyNode.java
+++ b/delphi-frontend/src/main/java/org/sonar/plugins/communitydelphi/api/ast/PropertyNode.java
@@ -38,6 +38,18 @@ public interface PropertyNode extends DelphiNode, Typed, Visibility {
   @Nullable
   PropertyWriteSpecifierNode getWriteSpecifier();
 
+  @Nullable
+  PropertyDefaultSpecifierNode getDefaultSpecifier();
+
+  @Nullable
+  PropertyImplementsSpecifierNode getImplementsSpecifier();
+
+  @Nullable
+  PropertyIndexSpecifierNode getIndexSpecifier();
+
+  @Nullable
+  PropertyStoredSpecifierNode getStoredSpecifier();
+
   List<FormalParameterData> getParameters();
 
   @Nullable

--- a/delphi-frontend/src/main/java/org/sonar/plugins/communitydelphi/api/ast/PropertyStoredSpecifierNode.java
+++ b/delphi-frontend/src/main/java/org/sonar/plugins/communitydelphi/api/ast/PropertyStoredSpecifierNode.java
@@ -1,0 +1,23 @@
+/*
+ * Sonar Delphi Plugin
+ * Copyright (C) 2024 Integrated Application Development
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02
+ */
+package org.sonar.plugins.communitydelphi.api.ast;
+
+public interface PropertyStoredSpecifierNode extends DelphiNode {
+  ExpressionNode getExpression();
+}

--- a/delphi-frontend/src/test/java/au/com/integradev/delphi/executor/DelphiSymbolTableExecutorTest.java
+++ b/delphi-frontend/src/test/java/au/com/integradev/delphi/executor/DelphiSymbolTableExecutorTest.java
@@ -826,6 +826,30 @@ class DelphiSymbolTableExecutorTest {
   }
 
   @Test
+  void testIndexProperties() {
+    execute("properties/IndexProperties.pas");
+    verifyUsages(6, 2, reference(10, 32));
+  }
+
+  @Test
+  void testStoredProperties() {
+    execute("properties/StoredProperties.pas");
+    verifyUsages(6, 2, reference(10, 33));
+  }
+
+  @Test
+  void testDefaultProperties() {
+    execute("properties/DefaultProperties.pas");
+    verifyUsages(6, 2, reference(10, 34));
+  }
+
+  @Test
+  void testImplementsProperties() {
+    execute("properties/ImplementsProperties.pas");
+    verifyUsages(6, 2, reference(13, 34));
+  }
+
+  @Test
   void testOverrideProperties() {
     execute("properties/OverrideProperties.pas");
     verifyUsages(8, 14, reference(29, 10), reference(30, 10), reference(31, 13), reference(32, 13));

--- a/delphi-frontend/src/test/resources/au/com/integradev/delphi/symbol/properties/DefaultProperties.pas
+++ b/delphi-frontend/src/test/resources/au/com/integradev/delphi/symbol/properties/DefaultProperties.pas
@@ -1,0 +1,15 @@
+unit DefaultProperties;
+
+interface
+
+const
+  C_Bar = 123;
+
+type
+  TFoo = class
+    property Bar: Integer default C_Bar;
+  end;
+
+implementation
+
+end.

--- a/delphi-frontend/src/test/resources/au/com/integradev/delphi/symbol/properties/ImplementsProperties.pas
+++ b/delphi-frontend/src/test/resources/au/com/integradev/delphi/symbol/properties/ImplementsProperties.pas
@@ -1,0 +1,18 @@
+unit ImplementsProperties;
+
+interface
+
+type
+  IBar = interface
+  end;
+
+  TBar = class(IBar)
+  end;
+
+  TFoo = class
+    property Bar: TBar implements IBar;
+  end;
+
+implementation
+
+end.

--- a/delphi-frontend/src/test/resources/au/com/integradev/delphi/symbol/properties/IndexProperties.pas
+++ b/delphi-frontend/src/test/resources/au/com/integradev/delphi/symbol/properties/IndexProperties.pas
@@ -1,0 +1,15 @@
+unit IndexProperties;
+
+interface
+
+const
+  C_Bar = 123;
+
+type
+  TFoo = class
+    property Bar: Integer index C_Bar;
+  end;
+
+implementation
+
+end.

--- a/delphi-frontend/src/test/resources/au/com/integradev/delphi/symbol/properties/StoredProperties.pas
+++ b/delphi-frontend/src/test/resources/au/com/integradev/delphi/symbol/properties/StoredProperties.pas
@@ -1,0 +1,15 @@
+unit StoredProperties;
+
+interface
+
+const
+  C_Bar = 123;
+
+type
+  TFoo = class
+    property Bar: Integer stored C_Bar;
+  end;
+
+implementation
+
+end.


### PR DESCRIPTION
The original goal of this PR was just to exclude properties with an `implements` specifier in the `UnusedProperty` rule.

It ended up doing a bit more than that:
* Modeled all of the non-trivial property specifiers as proper AST nodes (`default`, `implements`, `index`, `stored`)
* Fixed a bug where name resolution did not occur for type references in `implements` specifiers
* Excluded properties with an `implements` specifier in `UnusedProperty` (easiest part...)
* Fixed overly-permissive parsing rules where `string` and `file` were erroneously permitted **anywhere** that `typeReference` was allowed.

