### PR TITLE
Add extra exclusions for common loop counter names in `ShortIdentifier`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `RedundantInherited` analysis rule, which flags redundant `inherited` statements that can be safely removed.
 
+### Changed
+
+- Exclude `J` and `K` by default in `ShortIdentifier`.
+
 ## [1.6.0] - 2024-05-31
 
 ### Added

--- a/delphi-checks/src/main/java/au/com/integradev/delphi/checks/ShortIdentifierCheck.java
+++ b/delphi-checks/src/main/java/au/com/integradev/delphi/checks/ShortIdentifierCheck.java
@@ -35,7 +35,7 @@ import org.sonarsource.analyzer.commons.annotations.DeprecatedRuleKey;
 public class ShortIdentifierCheck extends DelphiCheck {
   private static final String MESSAGE = "Give this short identifier a more meaningful name.";
   private static final int DEFAULT_MINIMUM_LENGTH = 3;
-  private static final String DEFAULT_WHITELIST = "E,I,X,Y,ID";
+  private static final String DEFAULT_WHITELIST = "E,I,J,K,X,Y,ID";
 
   @RuleProperty(
       key = "minimumLength",


### PR DESCRIPTION
This PR updates the default exclusion list for `ShortIdentifier` to add some common loop counter names (we already had `I`):
* `II`
* `III`
* `J`
* `K`