### PR TITLE
Add found and expected value to `LowercaseKeywordCheck` message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Include "found" and "expected" values for issues messages in `LowercaseKeyword`.
 - Exclude `J` and `K` by default in `ShortIdentifier`.
 
 ## [1.6.0] - 2024-05-31

--- a/delphi-checks/src/main/java/au/com/integradev/delphi/checks/LowercaseKeywordCheck.java
+++ b/delphi-checks/src/main/java/au/com/integradev/delphi/checks/LowercaseKeywordCheck.java
@@ -34,8 +34,6 @@ import org.sonarsource.analyzer.commons.annotations.DeprecatedRuleKey;
 @DeprecatedRuleKey(ruleKey = "LowerCaseReservedWordsRule", repositoryKey = "delph")
 @Rule(key = "LowercaseKeyword")
 public class LowercaseKeywordCheck extends DelphiCheck {
-  private static final String MESSAGE = "Lowercase this keyword.";
-
   @RuleProperty(
       key = "excludedKeywords",
       description = "Comma-delimited list of keywords that this rule ignores (case-insensitive).")
@@ -53,10 +51,15 @@ public class LowercaseKeywordCheck extends DelphiCheck {
   @Override
   public DelphiCheckContext visit(DelphiNode node, DelphiCheckContext context) {
     if (isIssueNode(node)) {
+      String actual = node.getToken().getImage();
+      String expected = actual.toLowerCase();
+
       context
           .newIssue()
           .onFilePosition(FilePosition.from(node.getToken()))
-          .withMessage(MESSAGE)
+          .withMessage(
+              String.format(
+                  "Lowercase this keyword (found: \"%s\" expected: \"%s\").", actual, expected))
           .report();
     }
     return super.visit(node, context);


### PR DESCRIPTION
A small improvement to the `LowercaseKeywordCheck` rule, now the issue message shows the current value and the expected value, making it easier for users to understand what needs to be fixed.

In addition to making the problem even more intuitive, this change makes it possible to know what the problem is directly from the issues list.