### PR TITLE
Treat `result` attribute as case-insensitive in NUnit test reports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Include "found" and "expected" values for issues messages in `LowercaseKeyword`.
 - Exclude `J` and `K` by default in `ShortIdentifier`.
 
+### Fixed
+
+- The `result` attribute in NUnit test reports was not being treated as case-insensitive.
+
 ## [1.6.0] - 2024-05-31
 
 ### Added

--- a/delphi-frontend/src/main/java/au/com/integradev/delphi/nunit/NUnit2FileParser.java
+++ b/delphi-frontend/src/main/java/au/com/integradev/delphi/nunit/NUnit2FileParser.java
@@ -38,13 +38,13 @@ public class NUnit2FileParser extends NUnitFileParser {
   }
 
   private TestResult.Status parseTestCaseStatus(String statusText) {
-    switch (statusText) {
-      case "Success":
+    switch (statusText.toLowerCase()) {
+      case "success":
         return Status.PASSED;
-      case "Ignored":
+      case "ignored":
         return Status.SKIPPED;
-      case "Failure":
-      case "Error":
+      case "failure":
+      case "error":
         return Status.FAILED;
       default:
         LOG.warn("Unexpected test result status: '{}'. Treating as Failure.", statusText);

--- a/delphi-frontend/src/main/java/au/com/integradev/delphi/nunit/NUnit3FileParser.java
+++ b/delphi-frontend/src/main/java/au/com/integradev/delphi/nunit/NUnit3FileParser.java
@@ -38,13 +38,13 @@ public class NUnit3FileParser extends NUnitFileParser {
   }
 
   private static TestResult.Status parseTestCaseStatus(String statusText) {
-    switch (statusText) {
-      case "Passed":
+    switch (statusText.toLowerCase()) {
+      case "passed":
         return Status.PASSED;
-      case "Skipped":
-      case "Inconclusive":
+      case "skipped":
+      case "inconclusive":
         return Status.SKIPPED;
-      case "Failed":
+      case "failed":
         return Status.FAILED;
       default:
         LOG.warn("Unexpected test result status: '{}'. Treating as Failure.", statusText);

--- a/delphi-frontend/src/test/java/au/com/integradev/delphi/nunit/DelphiNUnitParserTest.java
+++ b/delphi-frontend/src/test/java/au/com/integradev/delphi/nunit/DelphiNUnitParserTest.java
@@ -45,13 +45,24 @@ class DelphiNUnitParserTest {
     ResultsAggregator results = getResults(getPath("v3"));
 
     assertThat(results).isNotNull();
-    assertThat(results.getTestsRun()).isEqualTo(12);
+    assertThat(results.getTestsRun()).isEqualTo(20);
   }
 
   @ParameterizedTest
   @ValueSource(strings = {"v2", "v3"})
   void testParseReport(String version) {
     ResultsAggregator results = getResults(getPath(version) + "/normal");
+
+    assertThat(results).isNotNull();
+    assertThat(results.getTestsRun()).isEqualTo(8);
+    assertThat(results.getSkipped()).isEqualTo(1);
+    assertThat(results.getFailures()).isEqualTo(3);
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {"v2", "v3"})
+  void testParseReportWithUnusualStatusCasing(String version) {
+    ResultsAggregator results = getResults(getPath(version) + "/unusualStatusCasing");
 
     assertThat(results).isNotNull();
     assertThat(results.getTestsRun()).isEqualTo(8);

--- a/delphi-frontend/src/test/resources/au/com/integradev/delphi/nunit/reports/v2/unusualStatusCasing/results.xml
+++ b/delphi-frontend/src/test/resources/au/com/integradev/delphi/nunit/reports/v2/unusualStatusCasing/results.xml
@@ -1,0 +1,70 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes" ?>
+<test-results name="path\to\executable.exe" total="5" errors="1" failures="1" ignored="1" inconclusive="0" not-run="1" skipped="0" invalid="0" date="2023-11-30" time="0.017">
+  <culture-info current-culture="en" current-uiculture="en" />
+  <test-suite type="Assembly" name="executable.exe" executed="true" result="failure" success="False" time="0.017" asserts="0">
+    <results>
+      <test-suite type="Namespace" name="MyTests" executed="true" result="success" success="True" time="0.016" asserts="0" >
+        <results>
+          <test-suite type="Fixture" name="PassingAndSkippedSuite" executed="True" result="SuCCesS" success="True" time="0.016" >
+            <results>
+              <test-case name="SkippedTest" executed="False" result="ignored"  time="0.000" asserts="0" >
+                <reason>
+                  <message>
+                    <![CDATA[ This is my reason for skipping ]]>
+                  </message>
+                </reason>
+              </test-case>
+              <test-case name="PassedTest." executed="True" result="SUCCESS" success="True" time="0.000" asserts="0" />
+            </results>
+          </test-suite>
+        </results>
+      </test-suite>
+      <test-suite type="Fixture" name="ErrorSuite" executed="True" result="SUccESS" success="True" time="0.016" >
+        <results>
+          <test-case name="ErrorCase." executed="True" result="ERROR" success="False" time="0.000" asserts="0" >
+            <failure>
+              <message>
+                <![CDATA[ This is my exception message ]]>
+              </message>
+              <stack-trace>
+                <![CDATA[  ]]>
+              </stack-trace>
+            </failure>
+          </test-case>
+        </results>
+      </test-suite>
+      <test-suite type="Fixture" name="PassingSuite" executed="True" result="Success" success="True" time="0.012" >
+        <results>
+          <test-case name="TestCase1." executed="True" result="success" success="True" time="0.000" asserts="0" />
+          <test-case name="TestCase2." executed="True" result="SUCCESS" success="True" time="0.000" asserts="0" />
+          <test-case name="TestCase3." executed="True" result="sUcCeSs" success="True" time="0.000" asserts="0" />
+          <test-case name="TestCase4." executed="True" result="SuCcEsS" success="True" time="0.000" asserts="0" />
+        </results>
+      </test-suite>
+      <test-suite type="Fixture" name="FailingSuite" executed="True" result="Failure" success="False" time="0.005" >
+        <results>
+          <test-case name="FailedCase1." executed="True" result="fAiLuRe" success="False" time="0.000" asserts="0" >
+            <failure>
+              <message>
+                <![CDATA[ This is my failure message ]]>
+              </message>
+              <stack-trace>
+                <![CDATA[  ]]>
+              </stack-trace>
+            </failure>
+          </test-case>
+          <test-case name="FailedCase2." executed="True" result="failure" success="False" time="0.000" asserts="0" >
+            <failure>
+              <message>
+                <![CDATA[ This is my failure message ]]>
+              </message>
+              <stack-trace>
+                <![CDATA[  ]]>
+              </stack-trace>
+            </failure>
+          </test-case>
+        </results>
+      </test-suite>
+    </results>
+  </test-suite>
+</test-results>

--- a/delphi-frontend/src/test/resources/au/com/integradev/delphi/nunit/reports/v3/unusualStatusCasing/results.xml
+++ b/delphi-frontend/src/test/resources/au/com/integradev/delphi/nunit/reports/v3/unusualStatusCasing/results.xml
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<test-run testcasecount="9" result="passed" total="8" passed="5" failed="3" inconclusive="0" skipped="1"
+          duration="1.561">
+    <test-suite type="TestSuite" name="TopLevelParentSuite"
+                testcasecount="6" runstate="Runnable" result="passed"
+                duration="1.235" total="5" passed="5" failed="0" skipped="1" inconclusive="0">
+        <test-suite type="TestSuite" name="PassingAndSkippedSuite"
+                    testcasecount="4" runstate="Runnable" result="PASSED"
+                    duration="1.234" total="3" passed="3" failed="0" skipped="1" inconclusive="0">
+            <test-case name="Setup" classname="PassingAndSkippedClass"
+                       runstate="Runnable" result="passed"
+                       duration="0.704">
+            </test-case>
+            <test-case name="SkippedTest"
+                       classname="PassingAndSkippedClass" runstate="Skipped" result="sKiPpEd"
+                       duration="0.185">
+            </test-case>
+            <test-case name="PassedTest"
+                       classname="PassingAndSkippedClass" runstate="Runnable" result="pAsSeD"
+                       duration="0.076">
+            </test-case>
+            <test-case name="Teardown" classname="PassingAndSkippedClass"
+                       runstate="Runnable" result="PaSsEd" duration="0.269">
+            </test-case>
+        </test-suite>
+        <test-suite type="TestSuite" name="PassingSuite"
+                    testcasecount="2" runstate="Runnable" result="passed"
+                    duration="0.001" total="2" passed="2" failed="0" skipped="0" inconclusive="0">
+            <test-case name="TestCase1"
+                       classname="TTestClass2" runstate="Runnable" result="passed"
+                       duration="0.000">
+            </test-case>
+            <test-case name="TestCase1"
+                       classname="TTestClass2" runstate="Runnable" result="passed"
+                       duration="0.001">
+            </test-case>
+        </test-suite>
+        <test-suite type="TestSuite" name="FailingSuite"
+                    testcasecount="3" runstate="Runnable" result="FAILED"
+                    duration="0.326" total="3" passed="0" failed="3" skipped="0" inconclusive="0">
+            <test-case name="Setup" classname="FailingClass"
+                       runstate="Runnable" result="failed"
+                       duration="0.102">
+            </test-case>
+            <test-case name="FailedCase"
+                       classname="FailingClass" runstate="Runnable" result="FaIlEd"
+                       duration="0.092">
+            </test-case>
+            <test-case name="Teardown" classname="FailingClass"
+                       runstate="Runnable" result="fAiLeD" duration="0.132">
+            </test-case>
+        </test-suite>
+    </test-suite>
+</test-run>


### PR DESCRIPTION
This PR fixes a bug where the `result` attribute was treated as a case-sensitive string in NUnit test reports, causing unusual casings to be erroneously reported as `TestResult.Status.FAILURE`.