### PR TITLE
Add quick fixes for `LowercaseKeywordCheck`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- "Correct to (correct case)" quick fix for `LowercaseKeyword`.
 - **API:** `PropertyNameDeclaration::getImplementedTypes` method.
 - **API:** `PropertyNode::getDefaultSpecifier` method.
 - **API:** `PropertyNode::getImplementsSpecifier` method.

--- a/delphi-checks/src/main/java/au/com/integradev/delphi/checks/LowercaseKeywordCheck.java
+++ b/delphi-checks/src/main/java/au/com/integradev/delphi/checks/LowercaseKeywordCheck.java
@@ -29,6 +29,8 @@ import org.sonar.plugins.communitydelphi.api.ast.DelphiNode;
 import org.sonar.plugins.communitydelphi.api.check.DelphiCheck;
 import org.sonar.plugins.communitydelphi.api.check.DelphiCheckContext;
 import org.sonar.plugins.communitydelphi.api.check.FilePosition;
+import org.sonar.plugins.communitydelphi.api.reporting.QuickFix;
+import org.sonar.plugins.communitydelphi.api.reporting.QuickFixEdit;
 import org.sonarsource.analyzer.commons.annotations.DeprecatedRuleKey;
 
 @DeprecatedRuleKey(ruleKey = "LowerCaseReservedWordsRule", repositoryKey = "delph")
@@ -54,12 +56,15 @@ public class LowercaseKeywordCheck extends DelphiCheck {
       String actual = node.getToken().getImage();
       String expected = actual.toLowerCase();
 
+      FilePosition issuePosition = FilePosition.from(node.getToken());
+
       context
           .newIssue()
-          .onFilePosition(FilePosition.from(node.getToken()))
-          .withMessage(
-              String.format(
-                  "Lowercase this keyword (found: \"%s\" expected: \"%s\").", actual, expected))
+          .onFilePosition(issuePosition)
+          .withMessage("Lowercase this keyword (found: \"%s\" expected: \"%s\").", actual, expected)
+          .withQuickFixes(
+              QuickFix.newFix("Correct to \"%s\"", expected)
+                  .withEdit(QuickFixEdit.replace(issuePosition, expected)))
           .report();
     }
     return super.visit(node, context);

--- a/delphi-checks/src/test/java/au/com/integradev/delphi/checks/LowercaseKeywordCheckTest.java
+++ b/delphi-checks/src/test/java/au/com/integradev/delphi/checks/LowercaseKeywordCheckTest.java
@@ -37,8 +37,10 @@ class LowercaseKeywordCheckTest {
         .onFile(
             new DelphiTestUnitBuilder()
                 .appendImpl("procedure Foo;")
+                .appendImpl("// Fix qf1@[+1:0 to +1:5] <<begin>>")
                 .appendImpl("Begin // Noncompliant")
                 .appendImpl("  MyVar := True;")
+                .appendImpl("// Fix qf2@[+1:0 to +1:3] <<end>>")
                 .appendImpl("END; // Noncompliant"))
         .verifyIssues();
   }
@@ -70,5 +72,21 @@ class LowercaseKeywordCheckTest {
                 .appendImpl("  Result := VarA + VarB;")
                 .appendImpl("end;"))
         .verifyNoIssues();
+  }
+
+  @Test
+  void testUppercaseKeywordShouldAddQuickFixOnToken() {
+    CheckVerifier.newVerifier()
+        .withCheck(createCheck())
+        .onFile(
+            new DelphiTestUnitBuilder()
+                .appendImpl("procedure Foo;")
+                .appendImpl("begin")
+                .appendImpl("  // Fix@[+1:2 to +1:5] <<for>>")
+                .appendImpl("  FOR I := 0 to 5 do // Noncompliant")
+                .appendImpl("  begin")
+                .appendImpl("  end;")
+                .appendImpl("end;"))
+        .verifyIssues();
   }
 }


### PR DESCRIPTION
This PR add "Correct to %s" quick fix for `LowercaseKeywordCheck` rule, in a similar way to what already exists for the `MixedNamesCheck` rule.