### PR TITLE
Add support for the library path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Include the global library path in unit import resolution.
 - Improve AST modeling around property specifiers.
 - Improve semantic analysis around property specifiers.
 - Exclude properties with `implements` specifiers in `UnusedProperty`.

--- a/delphi-frontend/src/main/java/au/com/integradev/delphi/msbuild/DelphiProjectParser.java
+++ b/delphi-frontend/src/main/java/au/com/integradev/delphi/msbuild/DelphiProjectParser.java
@@ -81,11 +81,26 @@ final class DelphiProjectParser {
   }
 
   private List<Path> createSearchDirectories(Path dprojDirectory, ProjectProperties properties) {
-    List<Path> explicitPaths = createPathList(properties, "DCC_UnitSearchPath");
+    /*
+     We manually append the library paths here, even though it's not strictly correct to do so.
 
-    List<Path> allPaths = new ArrayList<>(explicitPaths.size() + 1);
+     CodeGear.Delphi.Targets appends the library paths to DCC_UnitSearchPath to create a new
+     property called UnitSearchPath, which then gets passed through to the compiler.
+
+     However, there are some good reasons not to just read the UnitSearchPath property:
+
+     - It would tie us to an implementation detail of the MSBuild glue in CodeGear.Delphi.Targets.
+     - If the UnitSearchPath property were ever renamed, we'd fall out of compatibility.
+     - Relying on CodeGear.Delphi.Targets details would require us to mock it up in testing.
+    */
+
+    List<Path> allPaths = new ArrayList<>();
+
     allPaths.add(dprojDirectory);
-    allPaths.addAll(explicitPaths);
+    allPaths.addAll(createPathList(properties, "DCC_UnitSearchPath"));
+    allPaths.addAll(createPathList(properties, "DelphiLibraryPath"));
+    allPaths.addAll(createPathList(properties, "DelphiTranslatedLibraryPath"));
+
     return Collections.unmodifiableList(allPaths);
   }
 

--- a/delphi-frontend/src/test/java/au/com/integradev/delphi/msbuild/DelphiProjectParserTest.java
+++ b/delphi-frontend/src/test/java/au/com/integradev/delphi/msbuild/DelphiProjectParserTest.java
@@ -54,6 +54,9 @@ class DelphiProjectParserTest {
   private static final String BAD_SOURCE_FILE_PROJECT =
       "/au/com/integradev/delphi/msbuild/BadSourceFile.dproj";
 
+  private static final String LIBRARY_PATH_PROJECT =
+      "/au/com/integradev/delphi/msbuild/LibraryPath.dproj";
+
   private EnvironmentVariableProvider environmentVariableProvider;
   private Path environmentProj;
 
@@ -152,5 +155,17 @@ class DelphiProjectParserTest {
 
     assertThat(project.getSourceFiles())
         .containsOnly(DelphiUtils.getResource("/au/com/integradev/delphi/file/Empty.pas").toPath());
+  }
+
+  @Test
+  void testLibraryPathShouldBeAppendedToSearchDirectories() {
+    DelphiProject project = parse(LIBRARY_PATH_PROJECT);
+
+    assertThat(project.getSearchDirectories())
+        .containsExactly(
+            DelphiUtils.getResource("/au/com/integradev/delphi/msbuild").toPath(),
+            DelphiUtils.getResource("/au/com/integradev/delphi").toPath(),
+            DelphiUtils.getResource("/au/com/integradev").toPath(),
+            DelphiUtils.getResource("/au/com").toPath());
   }
 }

--- a/delphi-frontend/src/test/resources/au/com/integradev/delphi/msbuild/LibraryPath.dproj
+++ b/delphi-frontend/src/test/resources/au/com/integradev/delphi/msbuild/LibraryPath.dproj
@@ -1,0 +1,7 @@
+﻿<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+    <PropertyGroup>
+        <DelphiLibraryPath>../../</DelphiLibraryPath>
+        <DelphiTranslatedLibraryPath>../../../</DelphiTranslatedLibraryPath>
+        <DCC_UnitSearchPath>../</DCC_UnitSearchPath>
+    </PropertyGroup>
+</Project>


### PR DESCRIPTION
This PR adds support for the global library path.

All we had to do was grab the `DelphiLibraryPath` and `DelphiTranslatedLibraryPath` properties and append them to the `DCC_UnitSearchPath` to complete the search path.
These properties are reflected from the registry to `EnvOptions.proj` by the IDE, which is how they become available to MSBuild and by extension the analyzer.

The nice thing is that 95% of the work for this was done a long time ago when we implemented comprehensive support for MSBuild project files.

Closes #254.