### PR TITLE
Fix bug in CheckVerifier quick fix text edit assertions

### DIFF
--- a/delphi-checks-testkit/src/main/java/au/com/integradev/delphi/checks/verifier/CheckVerifierImpl.java
+++ b/delphi-checks-testkit/src/main/java/au/com/integradev/delphi/checks/verifier/CheckVerifierImpl.java
@@ -285,10 +285,6 @@ public class CheckVerifierImpl implements CheckVerifier {
 
   private boolean textEditsMatch(
       List<QuickFixEdit> textEdits, List<TextEditExpectation> expectedTextEdits) {
-    if (expectedTextEdits.size() != textEdits.size()) {
-      return false;
-    }
-
     Supplier<DelphiFileStream> fileStreamSupplier = newFileStreamSupplier(testFile.delphiFile());
 
     List<TextRangeReplacement> unmatchedActuals =
@@ -297,6 +293,10 @@ public class CheckVerifierImpl implements CheckVerifier {
             .map(e -> e.toTextEdits(fileStreamSupplier))
             .flatMap(Collection::stream)
             .collect(Collectors.toCollection(ArrayList::new));
+
+    if (expectedTextEdits.size() != unmatchedActuals.size()) {
+      return false;
+    }
 
     for (TextEditExpectation expected : expectedTextEdits) {
       Optional<TextRangeReplacement> matchingTextEdit =


### PR DESCRIPTION
This PR fixes a bug in the CheckVerifier implementation that causes tests to fail when the number of Sonar-level text replacements does not match the number of SonarDelphi-level quick fix edits. Because one `QuickFixEdit` can correspond to multiple text replacements (e.g. `QuickFixEdit.move`, which replaces two ranges), this test could cause valid quick fixes to fail.

We don't currently have any quick fixes that encounter this problem in tests.