### PR TITLE
Fix ArrayConstructorNode image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Overly permissive parsing rules around `string` and `file` types.
+- **API:** `ArrayConstructorNode::getImage` returned an incorrect image containing `[` as an element.
 
 ## [1.7.0] - 2024-07-02
 

--- a/delphi-frontend/src/main/java/au/com/integradev/delphi/antlr/ast/node/ArrayConstructorNodeImpl.java
+++ b/delphi-frontend/src/main/java/au/com/integradev/delphi/antlr/ast/node/ArrayConstructorNodeImpl.java
@@ -24,6 +24,7 @@ import java.util.stream.Collectors;
 import javax.annotation.Nonnull;
 import org.antlr.runtime.Token;
 import org.sonar.plugins.communitydelphi.api.ast.ArrayConstructorNode;
+import org.sonar.plugins.communitydelphi.api.ast.DelphiNode;
 import org.sonar.plugins.communitydelphi.api.ast.ExpressionNode;
 import org.sonar.plugins.communitydelphi.api.type.Type;
 import org.sonar.plugins.communitydelphi.api.type.Type.ProceduralType;
@@ -53,16 +54,14 @@ public final class ArrayConstructorNodeImpl extends ExpressionNodeImpl
   @Override
   public String getImage() {
     if (image == null) {
-      StringBuilder builder = new StringBuilder();
-      builder.append("[");
-      for (int i = 0; i < getChildren().size() - 1; ++i) {
-        if (i > 0) {
-          builder.append(", ");
-        }
-        builder.append(getChild(i).getImage());
-      }
-      builder.append("]");
-      image = builder.toString();
+      image =
+          "["
+              + getChildren().stream()
+                  .skip(1)
+                  .limit(getChildren().size() - 2)
+                  .map(DelphiNode::getImage)
+                  .collect(Collectors.joining(", "))
+              + "]";
     }
     return image;
   }


### PR DESCRIPTION
Previously, the `ArrayConstructorNode` image for `['a'..'z']` looked like `[[, 'a'..'z']`. This PR corrects that behaviour.