### PR TITLE
Cast operand of subtraction to `long` in `ArrayConstructorNodeImpl`

### DIFF
--- a/delphi-frontend/src/main/java/au/com/integradev/delphi/antlr/ast/node/ArrayConstructorNodeImpl.java
+++ b/delphi-frontend/src/main/java/au/com/integradev/delphi/antlr/ast/node/ArrayConstructorNodeImpl.java
@@ -58,7 +58,7 @@ public final class ArrayConstructorNodeImpl extends ExpressionNodeImpl
           "["
               + getChildren().stream()
                   .skip(1)
-                  .limit(getChildren().size() - 2)
+                  .limit(getChildren().size() - 2L)
                   .map(DelphiNode::getImage)
                   .collect(Collectors.joining(", "))
               + "]";


### PR DESCRIPTION
This fixes https://sonarcloud.io/project/issues?open=AZEF3qlXn5xwAMRtHSB5&id=integrated-application-development_sonar-delphi