### PR TITLE
Silence noisy warnings around library path properties

### DIFF
--- a/delphi-frontend/src/main/java/au/com/integradev/delphi/msbuild/DelphiProjectParser.java
+++ b/delphi-frontend/src/main/java/au/com/integradev/delphi/msbuild/DelphiProjectParser.java
@@ -98,8 +98,8 @@ final class DelphiProjectParser {
 
     allPaths.add(dprojDirectory);
     allPaths.addAll(createPathList(properties, "DCC_UnitSearchPath"));
-    allPaths.addAll(createPathList(properties, "DelphiLibraryPath"));
-    allPaths.addAll(createPathList(properties, "DelphiTranslatedLibraryPath"));
+    allPaths.addAll(createPathList(properties, "DelphiLibraryPath", false));
+    allPaths.addAll(createPathList(properties, "DelphiTranslatedLibraryPath", false));
 
     return Collections.unmodifiableList(allPaths);
   }
@@ -109,16 +109,21 @@ final class DelphiProjectParser {
   }
 
   private List<Path> createPathList(ProjectProperties properties, String propertyName) {
+    return createPathList(properties, propertyName, true);
+  }
+
+  private List<Path> createPathList(
+      ProjectProperties properties, String propertyName, boolean emitWarnings) {
     List<Path> result = new ArrayList<>();
     propertyList(properties.get(propertyName))
         .forEach(
             pathString -> {
               Path path = resolveDirectory(pathString);
-              if (path == null) {
+              if (path != null) {
+                result.add(path);
+              } else if (emitWarnings) {
                 LOG.warn("Invalid {} directory: {}", propertyName, pathString);
-                return;
               }
-              result.add(path);
             });
     return Collections.unmodifiableList(result);
   }


### PR DESCRIPTION
In #267, we added support for the library path by manually adding `DelphiLibraryPath` and `DelphiTranslatedLibraryPath` to the search path in `DelphiProjectParser`.

This works well, but produces some noisy warnings when paths in the library path properties don't exist.
By default, the library path contains non-existent paths.

We're already special-casing the construction of the search path here, so what's one more kludge?
This PR silences warnings when constructing path lists for the `DelphiLibraryPath` and `DelphiTranslatedLibraryPath` properties.