### PR TITLE
Improve parsing around partial `asm` blocks in conditional branches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Parsing errors around partial `asm` blocks blocks in conditional branches.
+
 ## [1.8.0] - 2024-08-02
 
 ### Added

--- a/delphi-frontend/src/main/antlr3/au/com/integradev/delphi/antlr/Delphi.g
+++ b/delphi-frontend/src/main/antlr3/au/com/integradev/delphi/antlr/Delphi.g
@@ -1201,7 +1201,16 @@ ASSEMBLER         : A S S E M B L E R           ;
 ASSEMBLY          : A S S E M B L Y             ;
 AT                : A T                         ;
 AUTOMATED         : A U T O M A T E D           ;
-BEGIN             : B E G I N                   ;
+BEGIN             : B E G I N {
+                    // HACK:
+                    //  We exit asmMode in the lexer if we encounter a BEGIN token, which is a hack
+                    //  to support partial asm blocks sharing an END keyword with some other block
+                    //  due to conditional compilation.
+                    //
+                    //  For more information, see:
+                    //    https://github.com/integrated-application-development/sonar-delphi/issues/116
+                    asmMode = false;
+                  };
 CASE              : C A S E                     ;
 CDECL             : C D E C L                   ;
 CLASS             : C L A S S                   ;

--- a/delphi-frontend/src/test/java/au/com/integradev/delphi/antlr/GrammarTest.java
+++ b/delphi-frontend/src/test/java/au/com/integradev/delphi/antlr/GrammarTest.java
@@ -343,4 +343,9 @@ class GrammarTest {
   void testImmediatelyTerminatedComments() {
     assertParsed("ImmediatelyTerminatedComments.pas");
   }
+
+  @Test
+  void testConditionalAsm() {
+    assertParsed("ConditionalAsm.pas");
+  }
 }

--- a/delphi-frontend/src/test/resources/au/com/integradev/delphi/grammar/ConditionalAsm.pas
+++ b/delphi-frontend/src/test/resources/au/com/integradev/delphi/grammar/ConditionalAsm.pas
@@ -1,0 +1,16 @@
+unit ConditionalAsm;
+
+interface
+
+implementation
+
+procedure Foo;
+{$if False}
+asm
+{$else}
+begin
+  var x := @Foo;
+{$endif}
+end;
+
+end.


### PR DESCRIPTION
This PR implements a hack that exits `asmMode` when we see the `begin` keyword.

We're opting for this hack so that we can support cases where an `asm` block shares an `end` with some other block due to conditional compilation.

For example, see:
https://github.com/pleriche/FastMM5/blob/b2fc04fad7628e24901386322dbcfb0d2cbbcddf/FastMM5.pas#L5649

Fixes #269.