### PR TITLE
Fix FPs on case items with multiple values in `CaseStatementSize`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **API:** `CaseItemStatementNode::getExpressions` method.
+
 ### Changed
 
 - `out` parameters are treated as uninitialized at the start of a routine in
@@ -15,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Parsing errors around partial `asm` blocks blocks in conditional branches.
+- False positives around case items with multiple values in `CaseStatementSize`.
 
 ## [1.8.0] - 2024-08-02
 

--- a/delphi-checks/src/test/java/au/com/integradev/delphi/checks/CaseStatementSizeCheckTest.java
+++ b/delphi-checks/src/test/java/au/com/integradev/delphi/checks/CaseStatementSizeCheckTest.java
@@ -33,8 +33,8 @@ class CaseStatementSizeCheckTest {
                 .appendImpl("procedure Test;")
                 .appendImpl("begin")
                 .appendImpl("  case MyNumber of")
-                .appendImpl("    1: Break;")
-                .appendImpl("    2: Break;")
+                .appendImpl("    1: Exit;")
+                .appendImpl("    2: Exit;")
                 .appendImpl("  end;")
                 .appendImpl("end;"))
         .verifyNoIssues();
@@ -49,10 +49,10 @@ class CaseStatementSizeCheckTest {
                 .appendImpl("procedure Test;")
                 .appendImpl("begin")
                 .appendImpl("  case MyNumber of")
-                .appendImpl("    1: Break;")
-                .appendImpl("    2: Break;")
+                .appendImpl("    1: Exit;")
+                .appendImpl("    2: Exit;")
                 .appendImpl("    else begin")
-                .appendImpl("      Break;")
+                .appendImpl("      Exit;")
                 .appendImpl("    end;")
                 .appendImpl("  end;")
                 .appendImpl("end;"))
@@ -68,7 +68,7 @@ class CaseStatementSizeCheckTest {
                 .appendImpl("procedure Test;")
                 .appendImpl("begin")
                 .appendImpl("  case MyNumber of // Noncompliant")
-                .appendImpl("    1: Break;")
+                .appendImpl("    1: Exit;")
                 .appendImpl("  end;")
                 .appendImpl("end;"))
         .verifyIssues();
@@ -83,12 +83,42 @@ class CaseStatementSizeCheckTest {
                 .appendImpl("procedure Test;")
                 .appendImpl("begin")
                 .appendImpl("  case MyNumber of // Noncompliant")
-                .appendImpl("    1: Break;")
+                .appendImpl("    1: Exit;")
                 .appendImpl("    else begin")
-                .appendImpl("      Break;")
+                .appendImpl("      Exit;")
                 .appendImpl("    end;")
                 .appendImpl("  end;")
                 .appendImpl("end;"))
         .verifyIssues();
+  }
+
+  @Test
+  void testOneCaseItemWithTwoValuesShouldNotAddIssue() {
+    CheckVerifier.newVerifier()
+        .withCheck(new CaseStatementSizeCheck())
+        .onFile(
+            new DelphiTestUnitBuilder()
+                .appendImpl("procedure Test;")
+                .appendImpl("begin")
+                .appendImpl("  case MyNumber of")
+                .appendImpl("    1, 2: Exit;")
+                .appendImpl("  end;")
+                .appendImpl("end;"))
+        .verifyNoIssues();
+  }
+
+  @Test
+  void testOneCaseItemWithRangeValueShouldNotAddIssue() {
+    CheckVerifier.newVerifier()
+        .withCheck(new CaseStatementSizeCheck())
+        .onFile(
+            new DelphiTestUnitBuilder()
+                .appendImpl("procedure Test;")
+                .appendImpl("begin")
+                .appendImpl("  case MyNumber of")
+                .appendImpl("    1..3: Exit;")
+                .appendImpl("  end;")
+                .appendImpl("end;"))
+        .verifyNoIssues();
   }
 }

--- a/delphi-frontend/src/main/java/au/com/integradev/delphi/antlr/ast/node/CaseItemStatementNodeImpl.java
+++ b/delphi-frontend/src/main/java/au/com/integradev/delphi/antlr/ast/node/CaseItemStatementNodeImpl.java
@@ -19,8 +19,10 @@
 package au.com.integradev.delphi.antlr.ast.node;
 
 import au.com.integradev.delphi.antlr.ast.visitors.DelphiParserVisitor;
+import java.util.List;
 import org.antlr.runtime.Token;
 import org.sonar.plugins.communitydelphi.api.ast.CaseItemStatementNode;
+import org.sonar.plugins.communitydelphi.api.ast.ExpressionNode;
 
 public final class CaseItemStatementNodeImpl extends DelphiNodeImpl
     implements CaseItemStatementNode {
@@ -35,5 +37,10 @@ public final class CaseItemStatementNodeImpl extends DelphiNodeImpl
   @Override
   public <T> T accept(DelphiParserVisitor<T> visitor, T data) {
     return visitor.visit(this, data);
+  }
+
+  @Override
+  public List<ExpressionNode> getExpressions() {
+    return findChildrenOfType(ExpressionNode.class);
   }
 }

--- a/delphi-frontend/src/main/java/org/sonar/plugins/communitydelphi/api/ast/CaseItemStatementNode.java
+++ b/delphi-frontend/src/main/java/org/sonar/plugins/communitydelphi/api/ast/CaseItemStatementNode.java
@@ -18,4 +18,8 @@
  */
 package org.sonar.plugins.communitydelphi.api.ast;
 
-public interface CaseItemStatementNode extends StatementNode {}
+import java.util.List;
+
+public interface CaseItemStatementNode extends StatementNode {
+  List<ExpressionNode> getExpressions();
+}


### PR DESCRIPTION
This PR improves the `CaseStatementSize` rule, counting `case` items with multiple values as if they were flattened out to multiple case items.

For example, the following `case` statement will no longer raise an issue:
```pas
case Foo of
  123, 456: Bar;
end;
```