### PR TITLE
Improve type inference

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Improve type inference around unsigned integer literals.
 - `out` parameters are treated as uninitialized at the start of a routine in
   `VariableInitialization`.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Improve type inference around unsigned integer literals.
 - Improve type inference around array constructors containing integer literals.
+- Improve type inference around real expressions.
 - `out` parameters are treated as uninitialized at the start of a routine in
   `VariableInitialization`.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Improve type inference around unsigned integer literals.
+- Improve type inference around array constructors containing integer literals.
 - `out` parameters are treated as uninitialized at the start of a routine in
   `VariableInitialization`.
 

--- a/delphi-frontend/src/main/java/au/com/integradev/delphi/symbol/resolve/TypeInferrer.java
+++ b/delphi-frontend/src/main/java/au/com/integradev/delphi/symbol/resolve/TypeInferrer.java
@@ -24,10 +24,12 @@ import java.util.Comparator;
 import java.util.Set;
 import org.sonar.plugins.communitydelphi.api.ast.ArrayConstructorNode;
 import org.sonar.plugins.communitydelphi.api.ast.ExpressionNode;
+import org.sonar.plugins.communitydelphi.api.ast.IntegerLiteralNode;
 import org.sonar.plugins.communitydelphi.api.ast.Node;
 import org.sonar.plugins.communitydelphi.api.ast.utils.ExpressionNodeUtils;
 import org.sonar.plugins.communitydelphi.api.type.IntrinsicType;
 import org.sonar.plugins.communitydelphi.api.type.Type;
+import org.sonar.plugins.communitydelphi.api.type.Type.IntegerType;
 import org.sonar.plugins.communitydelphi.api.type.Type.ProceduralType;
 import org.sonar.plugins.communitydelphi.api.type.TypeFactory;
 import org.sonar.plugins.communitydelphi.api.type.Typed;
@@ -48,8 +50,15 @@ public final class TypeInferrer {
 
       if (arrayConstructor instanceof ArrayConstructorNode) {
         type = inferArrayConstructor((ArrayConstructorNode) arrayConstructor);
-      } else if (ExpressionNodeUtils.isIntegerLiteral(expression) && type.size() <= 4) {
-        type = typeFactory.getIntrinsic(IntrinsicType.INTEGER);
+      } else {
+        IntegerLiteralNode literal = ExpressionNodeUtils.unwrapInteger(expression);
+        if (literal != null) {
+          IntegerType integer = (IntegerType) typeFactory.getIntrinsic(IntrinsicType.INTEGER);
+          if (integer.min().compareTo(literal.getValue()) <= 0
+              && integer.max().compareTo(literal.getValue()) >= 0) {
+            type = typeFactory.getIntrinsic(IntrinsicType.INTEGER);
+          }
+        }
       }
     }
 

--- a/delphi-frontend/src/main/java/au/com/integradev/delphi/symbol/resolve/TypeInferrer.java
+++ b/delphi-frontend/src/main/java/au/com/integradev/delphi/symbol/resolve/TypeInferrer.java
@@ -20,7 +20,6 @@ package au.com.integradev.delphi.symbol.resolve;
 
 import au.com.integradev.delphi.type.factory.ArrayOption;
 import au.com.integradev.delphi.type.factory.TypeFactoryImpl;
-import java.util.Comparator;
 import java.util.Set;
 import org.sonar.plugins.communitydelphi.api.ast.ArrayConstructorNode;
 import org.sonar.plugins.communitydelphi.api.ast.ExpressionNode;
@@ -76,9 +75,21 @@ public final class TypeInferrer {
     Type element =
         arrayConstructor.getElements().stream()
             .map(this::infer)
-            .max(Comparator.comparingInt(Type::size))
+            .max(TypeInferrer::compareTypeSize)
             .orElse(TypeFactory.voidType());
 
     return ((TypeFactoryImpl) typeFactory).array(null, element, Set.of(ArrayOption.DYNAMIC));
+  }
+
+  private static int compareTypeSize(Type a, Type b) {
+    if (a.size() > b.size()) {
+      return 1;
+    } else if (a.size() < b.size()) {
+      return -1;
+    } else if (a instanceof IntegerType && b instanceof IntegerType) {
+      return ((IntegerType) a).max().compareTo(((IntegerType) b).max());
+    } else {
+      return 0;
+    }
   }
 }

--- a/delphi-frontend/src/test/java/au/com/integradev/delphi/symbol/resolve/TypeInferrerTest.java
+++ b/delphi-frontend/src/test/java/au/com/integradev/delphi/symbol/resolve/TypeInferrerTest.java
@@ -1,0 +1,334 @@
+/*
+ * Sonar Delphi Plugin
+ * Copyright (C) 2024 Integrated Application Development
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02
+ */
+package au.com.integradev.delphi.symbol.resolve;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.spy;
+
+import au.com.integradev.delphi.antlr.DelphiLexer;
+import au.com.integradev.delphi.antlr.ast.node.ArrayConstructorNodeImpl;
+import au.com.integradev.delphi.antlr.ast.node.CommonDelphiNodeImpl;
+import au.com.integradev.delphi.antlr.ast.node.DelphiNodeImpl;
+import au.com.integradev.delphi.antlr.ast.node.IntegerLiteralNodeImpl;
+import au.com.integradev.delphi.antlr.ast.node.ParenthesizedExpressionNodeImpl;
+import au.com.integradev.delphi.antlr.ast.node.PrimaryExpressionNodeImpl;
+import au.com.integradev.delphi.type.factory.ArrayOption;
+import au.com.integradev.delphi.type.factory.TypeFactoryImpl;
+import au.com.integradev.delphi.utils.types.TypeFactoryUtils;
+import java.util.Collections;
+import java.util.Set;
+import java.util.stream.Stream;
+import org.antlr.runtime.CommonToken;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.ArgumentsProvider;
+import org.junit.jupiter.params.provider.ArgumentsSource;
+import org.sonar.plugins.communitydelphi.api.ast.CommonDelphiNode;
+import org.sonar.plugins.communitydelphi.api.ast.ExpressionNode;
+import org.sonar.plugins.communitydelphi.api.type.IntrinsicType;
+import org.sonar.plugins.communitydelphi.api.type.Type;
+import org.sonar.plugins.communitydelphi.api.type.TypeFactory;
+
+class TypeInferrerTest {
+  private static final TypeFactoryImpl TYPE_FACTORY =
+      (TypeFactoryImpl) TypeFactoryUtils.defaultFactory();
+
+  static class ArrayConstructorArgumentsProvider implements ArgumentsProvider {
+    @Override
+    public Stream<Arguments> provideArguments(ExtensionContext context) {
+      return Stream.of(
+          Arguments.of(arrayConstructor(), dynamicArrayType(TypeFactory.voidType())),
+          Arguments.of(
+              arrayConstructor(integerLiteral("127")), dynamicArrayType(IntrinsicType.INTEGER)),
+          Arguments.of(
+              arrayConstructor(integerLiteral("127"), integerLiteral("128")),
+              dynamicArrayType(IntrinsicType.INTEGER)),
+          Arguments.of(
+              arrayConstructor(integerLiteral("127"), integerLiteral("128"), integerLiteral("255")),
+              dynamicArrayType(IntrinsicType.INTEGER)),
+          Arguments.of(
+              arrayConstructor(
+                  integerLiteral("127"),
+                  integerLiteral("128"),
+                  integerLiteral("255"),
+                  integerLiteral("256")),
+              dynamicArrayType(IntrinsicType.INTEGER)),
+          Arguments.of(
+              arrayConstructor(
+                  integerLiteral("127"),
+                  integerLiteral("128"),
+                  integerLiteral("255"),
+                  integerLiteral("256"),
+                  integerLiteral("32767")),
+              dynamicArrayType(IntrinsicType.INTEGER)),
+          Arguments.of(
+              arrayConstructor(
+                  integerLiteral("127"),
+                  integerLiteral("128"),
+                  integerLiteral("255"),
+                  integerLiteral("256"),
+                  integerLiteral("32767"),
+                  integerLiteral("32768")),
+              dynamicArrayType(IntrinsicType.INTEGER)),
+          Arguments.of(
+              arrayConstructor(
+                  integerLiteral("127"),
+                  integerLiteral("128"),
+                  integerLiteral("255"),
+                  integerLiteral("256"),
+                  integerLiteral("32767"),
+                  integerLiteral("32768"),
+                  integerLiteral("2147483647")),
+              dynamicArrayType(IntrinsicType.INTEGER)),
+          Arguments.of(
+              arrayConstructor(
+                  integerLiteral("127"),
+                  integerLiteral("128"),
+                  integerLiteral("255"),
+                  integerLiteral("256"),
+                  integerLiteral("32767"),
+                  integerLiteral("32768"),
+                  integerLiteral("2147483647"),
+                  integerLiteral("2147483648")),
+              dynamicArrayType(IntrinsicType.CARDINAL)),
+          Arguments.of(
+              arrayConstructor(
+                  integerLiteral("127"),
+                  integerLiteral("128"),
+                  integerLiteral("255"),
+                  integerLiteral("256"),
+                  integerLiteral("32767"),
+                  integerLiteral("32768"),
+                  integerLiteral("2147483647"),
+                  integerLiteral("2147483648"),
+                  integerLiteral("4294967295")),
+              dynamicArrayType(IntrinsicType.CARDINAL)),
+          Arguments.of(
+              arrayConstructor(
+                  integerLiteral("127"),
+                  integerLiteral("128"),
+                  integerLiteral("255"),
+                  integerLiteral("256"),
+                  integerLiteral("32767"),
+                  integerLiteral("32768"),
+                  integerLiteral("2147483647"),
+                  integerLiteral("2147483648"),
+                  integerLiteral("4294967295"),
+                  integerLiteral("4294967296")),
+              dynamicArrayType(IntrinsicType.INT64)),
+          Arguments.of(
+              arrayConstructor(
+                  integerLiteral("127"),
+                  integerLiteral("128"),
+                  integerLiteral("255"),
+                  integerLiteral("256"),
+                  integerLiteral("32767"),
+                  integerLiteral("32768"),
+                  integerLiteral("2147483647"),
+                  integerLiteral("2147483648"),
+                  integerLiteral("4294967295"),
+                  integerLiteral("4294967296"),
+                  integerLiteral("9223372036854775807")),
+              dynamicArrayType(IntrinsicType.INT64)),
+          Arguments.of(
+              arrayConstructor(
+                  integerLiteral("127"),
+                  integerLiteral("128"),
+                  integerLiteral("255"),
+                  integerLiteral("256"),
+                  integerLiteral("32767"),
+                  integerLiteral("32768"),
+                  integerLiteral("2147483647"),
+                  integerLiteral("2147483648"),
+                  integerLiteral("4294967295"),
+                  integerLiteral("4294967296"),
+                  integerLiteral("9223372036854775807"),
+                  integerLiteral("9223372036854775808")),
+              dynamicArrayType(IntrinsicType.UINT64)));
+    }
+  }
+
+  static class IntegerArgumentsProvider implements ArgumentsProvider {
+    @Override
+    public Stream<Arguments> provideArguments(ExtensionContext context) {
+      return Stream.of(
+          Arguments.of(integerLiteral("-2147483649"), intrinsicType(IntrinsicType.INT64)),
+          Arguments.of(integerLiteral("-2147483648"), intrinsicType(IntrinsicType.INTEGER)),
+          Arguments.of(integerLiteral("-32769"), intrinsicType(IntrinsicType.INTEGER)),
+          Arguments.of(integerLiteral("-32768"), intrinsicType(IntrinsicType.INTEGER)),
+          Arguments.of(integerLiteral("-129"), intrinsicType(IntrinsicType.INTEGER)),
+          Arguments.of(integerLiteral("-128"), intrinsicType(IntrinsicType.INTEGER)),
+          Arguments.of(integerLiteral("-127"), intrinsicType(IntrinsicType.INTEGER)),
+          Arguments.of(integerLiteral("128"), intrinsicType(IntrinsicType.INTEGER)),
+          Arguments.of(integerLiteral("255"), intrinsicType(IntrinsicType.INTEGER)),
+          Arguments.of(integerLiteral("256"), intrinsicType(IntrinsicType.INTEGER)),
+          Arguments.of(integerLiteral("32767"), intrinsicType(IntrinsicType.INTEGER)),
+          Arguments.of(integerLiteral("32768"), intrinsicType(IntrinsicType.INTEGER)),
+          Arguments.of(integerLiteral("65535"), intrinsicType(IntrinsicType.INTEGER)),
+          Arguments.of(integerLiteral("65536"), intrinsicType(IntrinsicType.INTEGER)),
+          Arguments.of(integerLiteral("2147483647"), intrinsicType(IntrinsicType.INTEGER)),
+          Arguments.of(integerLiteral("2147483648"), intrinsicType(IntrinsicType.CARDINAL)),
+          Arguments.of(integerLiteral("4294967295"), intrinsicType(IntrinsicType.CARDINAL)),
+          Arguments.of(integerLiteral("4294967296"), intrinsicType(IntrinsicType.INT64)),
+          Arguments.of(integerLiteral("9223372036854775807"), intrinsicType(IntrinsicType.INT64)),
+          Arguments.of(integerLiteral("9223372036854775808"), intrinsicType(IntrinsicType.UINT64)));
+    }
+  }
+
+  static class ProceduralArgumentsProvider implements ArgumentsProvider {
+    @Override
+    public Stream<Arguments> provideArguments(ExtensionContext context) {
+      Type integer = intrinsicType(IntrinsicType.INTEGER);
+      ExpressionNode voidProcedural = procedural(TypeFactory.voidType());
+
+      return Stream.of(
+          Arguments.of(procedural(integer), integer),
+          Arguments.of(voidProcedural, voidProcedural.getType()));
+    }
+  }
+
+  static class RealArgumentsProvider implements ArgumentsProvider {
+    @Override
+    public Stream<Arguments> provideArguments(ExtensionContext context) {
+      Type extended = intrinsicType(IntrinsicType.EXTENDED);
+      Type comp = intrinsicType(IntrinsicType.COMP);
+      Type currency = intrinsicType(IntrinsicType.CURRENCY);
+
+      return Stream.of(
+          Arguments.of(genericExpression(IntrinsicType.DOUBLE), extended),
+          Arguments.of(genericExpression(IntrinsicType.REAL48), extended),
+          Arguments.of(genericExpression(extended), extended),
+          Arguments.of(genericExpression(comp), comp),
+          Arguments.of(genericExpression(currency), currency));
+    }
+  }
+
+  @Test
+  void testInferNull() {
+    assertInferred(null, TypeFactory.unknownType());
+  }
+
+  @ParameterizedTest
+  @ArgumentsSource(ArrayConstructorArgumentsProvider.class)
+  @ArgumentsSource(IntegerArgumentsProvider.class)
+  @ArgumentsSource(ProceduralArgumentsProvider.class)
+  @ArgumentsSource(RealArgumentsProvider.class)
+  void testInfer(ExpressionNode expression, Type elementType) {
+    assertInferred(expression, elementType);
+  }
+
+  private static Type dynamicArrayType(IntrinsicType elementType) {
+    return dynamicArrayType(intrinsicType(elementType));
+  }
+
+  private static Type dynamicArrayType(Type elementType) {
+    return TYPE_FACTORY.array(null, elementType, Set.of(ArrayOption.DYNAMIC));
+  }
+
+  private static Type intrinsicType(IntrinsicType intrinsic) {
+    return TYPE_FACTORY.getIntrinsic(intrinsic);
+  }
+
+  private static ExpressionNode arrayConstructor(ExpressionNode... elements) {
+    var arrayConstructor = makeSpy(new ArrayConstructorNodeImpl(DelphiLexer.TkArrayConstructor));
+    arrayConstructor.addChild(commonDelphiNode(DelphiLexer.SQUARE_BRACKET_LEFT, "["));
+    for (ExpressionNode element : elements) {
+      arrayConstructor.addChild(element);
+    }
+    arrayConstructor.addChild(commonDelphiNode(DelphiLexer.SQUARE_BRACKET_RIGHT, "]"));
+
+    var primaryExpression = makeSpy(new PrimaryExpressionNodeImpl(DelphiLexer.TkPrimaryExpression));
+    primaryExpression.addChild(arrayConstructor);
+
+    return primaryExpression;
+  }
+
+  private static ExpressionNode integerLiteral(String image) {
+    var integerLiteralToken = new CommonToken(DelphiLexer.TkIntNumber, image);
+    var integerLiteral = makeSpy(new IntegerLiteralNodeImpl(integerLiteralToken));
+
+    var expression = makeSpy(new PrimaryExpressionNodeImpl(DelphiLexer.TkPrimaryExpression));
+    expression.addChild(integerLiteral);
+
+    return expression;
+  }
+
+  private static ExpressionNode procedural(Type returnType) {
+    return genericExpression(TYPE_FACTORY.routine(Collections.emptyList(), returnType));
+  }
+
+  private static ExpressionNode genericExpression(IntrinsicType type) {
+    return genericExpression(intrinsicType(type));
+  }
+
+  private static ExpressionNode genericExpression(Type type) {
+    var primaryExpression = makeSpy(new PrimaryExpressionNodeImpl(DelphiLexer.TkPrimaryExpression));
+    doReturn(type).when(primaryExpression).getType();
+    doReturn("<expression of type " + type.getImage() + ">").when(primaryExpression).getImage();
+    return primaryExpression;
+  }
+
+  private static ExpressionNode parenthesize(ExpressionNode expression) {
+    var parenthesized = new ParenthesizedExpressionNodeImpl(DelphiLexer.TkNestedExpression);
+    parenthesized.addChild(commonDelphiNode(DelphiLexer.PAREN_BRACKET_LEFT, "("));
+    parenthesized.addChild(expression);
+    parenthesized.addChild(commonDelphiNode(DelphiLexer.PAREN_BRACKET_RIGHT, ")"));
+    return parenthesized;
+  }
+
+  @SuppressWarnings("ObjectToString")
+  private static <T extends DelphiNodeImpl> T makeSpy(T spied) {
+    final T result = spy(spied);
+
+    doReturn(TYPE_FACTORY).when(result).getTypeFactory();
+    // This is just to improve the display string in parameterized tests
+    doAnswer(invocation -> result.getImage()).when(result).toString();
+
+    return result;
+  }
+
+  private static CommonDelphiNode commonDelphiNode(int type, String text) {
+    return new CommonDelphiNodeImpl(new CommonToken(type, text));
+  }
+
+  private static void assertInferred(ExpressionNode expression, Type type) {
+    doAssertInferred(expression, type);
+    if (expression != null) {
+      doAssertInferred(parenthesize(expression), type);
+    }
+  }
+
+  private static void doAssertInferred(ExpressionNode expression, Type type) {
+    TypeInferrer inferrer = new TypeInferrer(TYPE_FACTORY);
+    Type inferred = inferrer.infer(expression);
+
+    assertThat(inferred.is(type))
+        .withFailMessage(
+            String.format(
+                "Expected %s to be inferred to %s, but was %s",
+                expression == null ? "null" : expression.getImage(),
+                type.getImage(),
+                inferred.getImage()))
+        .isTrue();
+  }
+}


### PR DESCRIPTION
This PR generally improves type inference around:
- unsigned integer literals
- array constructor expressions containing integer literals
- real expressions (closes #123)

Additionally, I've added a `TypeInferrerTest` suite to test the `TypeInferrer` more directly, as opposed to the more limited/indirect testing we're currently getting through the `SymbolTableExecutor` tests.