### PR TITLE
Fix name resolution errors around alias ancestor types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Name resolution errors around alias ancestor types.
 - Parsing errors around partial `asm` blocks blocks in conditional branches.
 - False positives around case items with multiple values in `CaseStatementSize`.
 

--- a/delphi-frontend/src/main/java/au/com/integradev/delphi/type/factory/StructTypeImpl.java
+++ b/delphi-frontend/src/main/java/au/com/integradev/delphi/type/factory/StructTypeImpl.java
@@ -70,7 +70,7 @@ public class StructTypeImpl extends GenerifiableTypeImpl implements StructType {
     } else {
       this.parent =
           this.ancestorList.stream()
-              .filter(StructTypeImpl.class::isInstance)
+              .filter(Type::isStruct)
               .filter(not(Type::isInterface))
               .findFirst()
               .orElse(TypeFactory.unknownType());


### PR DESCRIPTION
`StructTypeImpl.parent` was not being resolved correctly when the relevant ancestor was a type alias.

This was because we did an `instanceof StructTypeImpl` check, which is incompatible with the generated type alias impl classes introduced in b3b14dd58f27e1b5b5f5b65dfb53f37aced1b012.

Fixes #288.