### PR TITLE
Exclude non-trivial `inherited` expressions in `RedundantParentheses`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Non-trivial `inherited` expressions are excluded in `RedundantParentheses`.
+
 ## [1.9.0] - 2024-09-03
 
 ### Added

--- a/delphi-checks/src/main/java/au/com/integradev/delphi/checks/RedundantParenthesesCheck.java
+++ b/delphi-checks/src/main/java/au/com/integradev/delphi/checks/RedundantParenthesesCheck.java
@@ -19,8 +19,10 @@
 package au.com.integradev.delphi.checks;
 
 import org.sonar.check.Rule;
+import org.sonar.plugins.communitydelphi.api.ast.ExpressionNode;
 import org.sonar.plugins.communitydelphi.api.ast.ParenthesizedExpressionNode;
 import org.sonar.plugins.communitydelphi.api.ast.PrimaryExpressionNode;
+import org.sonar.plugins.communitydelphi.api.ast.utils.ExpressionNodeUtils;
 import org.sonar.plugins.communitydelphi.api.check.DelphiCheck;
 import org.sonar.plugins.communitydelphi.api.check.DelphiCheckContext;
 import org.sonar.plugins.communitydelphi.api.reporting.QuickFix;
@@ -35,8 +37,7 @@ public class RedundantParenthesesCheck extends DelphiCheck {
   @Override
   public DelphiCheckContext visit(
       ParenthesizedExpressionNode expression, DelphiCheckContext context) {
-    if (expression.getExpression() instanceof ParenthesizedExpressionNode
-        || expression.getExpression() instanceof PrimaryExpressionNode) {
+    if (isRedundant(expression)) {
       context
           .newIssue()
           .onNode(expression.getChild(0))
@@ -49,5 +50,18 @@ public class RedundantParenthesesCheck extends DelphiCheck {
           .report();
     }
     return super.visit(expression, context);
+  }
+
+  private static boolean isRedundant(ParenthesizedExpressionNode expression) {
+    ExpressionNode parenthesized = expression.getExpression();
+    if (parenthesized instanceof PrimaryExpressionNode) {
+      return !isNonTrivialInherited(parenthesized);
+    }
+    return parenthesized instanceof ParenthesizedExpressionNode;
+  }
+
+  private static boolean isNonTrivialInherited(ExpressionNode expression) {
+    return ExpressionNodeUtils.isInherited(expression)
+        && !ExpressionNodeUtils.isBareInherited(expression);
   }
 }

--- a/delphi-checks/src/test/java/au/com/integradev/delphi/checks/RedundantParenthesesCheckTest.java
+++ b/delphi-checks/src/test/java/au/com/integradev/delphi/checks/RedundantParenthesesCheckTest.java
@@ -89,6 +89,19 @@ class RedundantParenthesesCheckTest {
   }
 
   @Test
+  void testParenthesesOnNonTrivialInheritedExpressionShouldAddIssue() {
+    CheckVerifier.newVerifier()
+        .withCheck(new RedundantParenthesesCheck())
+        .onFile(
+            new DelphiTestUnitBuilder()
+                .appendImpl("procedure Foo;")
+                .appendImpl("begin")
+                .appendImpl("  (inherited Bar);")
+                .appendImpl("end;"))
+        .verifyNoIssues();
+  }
+
+  @Test
   void testParenthesesOnParenthesizedExpressionShouldAddIssue() {
     CheckVerifier.newVerifier()
         .withCheck(new RedundantParenthesesCheck())
@@ -118,6 +131,21 @@ class RedundantParenthesesCheckTest {
                 .appendImpl("  // Noncompliant@+2")
                 .appendImpl("  // Noncompliant@+1")
                 .appendImpl("  Result := ((123));")
+                .appendImpl("end;"))
+        .verifyIssues();
+  }
+
+  @Test
+  void testParenthesesOnBareInheritedExpressionShouldAddIssue() {
+    CheckVerifier.newVerifier()
+        .withCheck(new RedundantParenthesesCheck())
+        .onFile(
+            new DelphiTestUnitBuilder()
+                .appendImpl("procedure Foo;")
+                .appendImpl("begin")
+                .appendImpl("  // Fix@[+2:2 to +2:3] <<>>")
+                .appendImpl("  // Fix@[+1:12 to +1:13] <<>>")
+                .appendImpl("  (inherited); // Noncompliant")
                 .appendImpl("end;"))
         .verifyIssues();
   }


### PR DESCRIPTION
This PR changes the `RedundantParentheses` rule to exclude non-trivial `inherited` expressions.
Parenthesized bare `inherited` is still flagged, but anything more complex is now ignored.