### PR TITLE
Disambiguate const array literals from parenthesized primary expressions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Non-trivial `inherited` expressions are excluded in `RedundantParentheses`.
 
+### Fixed
+
+- False positives around const array literals in `RedundantParentheses`.
+
 ## [1.9.0] - 2024-09-03
 
 ### Added

--- a/delphi-checks/src/test/java/au/com/integradev/delphi/checks/RedundantParenthesesCheckTest.java
+++ b/delphi-checks/src/test/java/au/com/integradev/delphi/checks/RedundantParenthesesCheckTest.java
@@ -89,7 +89,7 @@ class RedundantParenthesesCheckTest {
   }
 
   @Test
-  void testParenthesesOnNonTrivialInheritedExpressionShouldAddIssue() {
+  void testParenthesesOnNonTrivialInheritedExpressionShouldNotAddIssue() {
     CheckVerifier.newVerifier()
         .withCheck(new RedundantParenthesesCheck())
         .onFile(
@@ -99,6 +99,41 @@ class RedundantParenthesesCheckTest {
                 .appendImpl("  (inherited Bar);")
                 .appendImpl("end;"))
         .verifyNoIssues();
+  }
+
+  @Test
+  void testSingleElementConstArrayLiteralShouldNotAddIssue() {
+    CheckVerifier.newVerifier()
+        .withCheck(new RedundantParenthesesCheck())
+        .onFile(
+            new DelphiTestUnitBuilder()
+                .appendImpl("const")
+                .appendImpl("  CArray: array[0..0] of Integer = (123);"))
+        .verifyNoIssues();
+  }
+
+  @Test
+  void testSingleElementVarArrayLiteralShouldNotAddIssue() {
+    CheckVerifier.newVerifier()
+        .withCheck(new RedundantParenthesesCheck())
+        .onFile(
+            new DelphiTestUnitBuilder()
+                .appendImpl("var")
+                .appendImpl("  A: array[0..0] of Integer = (123);"))
+        .verifyNoIssues();
+  }
+
+  @Test
+  void testParenthesesOnPrimaryExpressionWithinSingleElementArrayLiteralShouldAddIssue() {
+    CheckVerifier.newVerifier()
+        .withCheck(new RedundantParenthesesCheck())
+        .onFile(
+            new DelphiTestUnitBuilder()
+                .appendImpl("var")
+                .appendImpl("  // Fix@[+2:31 to +2:32] <<>>")
+                .appendImpl("  // Fix@[+1:35 to +1:36] <<>>")
+                .appendImpl("  A: array[0..0] of Integer = ((123)); // Noncompliant"))
+        .verifyIssues();
   }
 
   @Test

--- a/delphi-frontend/src/main/antlr3/au/com/integradev/delphi/antlr/Delphi.g
+++ b/delphi-frontend/src/main/antlr3/au/com/integradev/delphi/antlr/Delphi.g
@@ -482,7 +482,7 @@ varSection                   : (VAR<VarSectionNodeImpl>^ | THREADVAR<VarSectionN
 varDeclaration               : attributeList? nameDeclarationList ':' varType portabilityDirective* varValueSpec? portabilityDirective* ';'
                              -> ^(TkVarDeclaration<VarDeclarationNodeImpl> nameDeclarationList varType varValueSpec? attributeList?)
                              ;
-varValueSpec                 : ABSOLUTE constExpression
+varValueSpec                 : ABSOLUTE expression
                              | '=' constExpression
                              ;
 exportsSection               : EXPORTS ident exportItem (',' ident exportItem)* ';'
@@ -643,7 +643,7 @@ interfaceItem                : routineInterface
                              ;
 objectType                   : OBJECT<ObjectTypeNodeImpl>^ classParent? visibilitySection* END // Obselete, kept for backwards compatibility with Turbo Pascal
                              ;                                                                 // See: https://www.oreilly.com/library/view/delphi-in-a/1565926595/re192.html
-recordType                   : RECORD<RecordTypeNodeImpl>^ visibilitySection* recordVariantSection? END (ALIGN constExpression)?
+recordType                   : RECORD<RecordTypeNodeImpl>^ visibilitySection* recordVariantSection? END (ALIGN expression)?
                              ;
 recordVariantSection         : CASE<RecordVariantSectionNodeImpl>^ recordVariantTag OF recordVariant+
                              ;
@@ -1105,8 +1105,8 @@ externalDirective            : EXTERNAL^ dllName? externalSpecifier*
                              ;
 dllName                      : {!input.LT(1).getText().equals("name")}? expression
                              ;
-externalSpecifier            : NAME^ constExpression
-                             | INDEX^ constExpression // specific to a platform
+externalSpecifier            : NAME^ expression
+                             | INDEX^ expression // specific to a platform
                              | DELAYED // Use delayed loading (See: http://docwiki.embarcadero.com/RADStudio/en/Libraries_and_Packages_(Delphi))
                              ;
 dispIDDirective              : DISPID expression

--- a/delphi-frontend/src/main/antlr3/au/com/integradev/delphi/antlr/Delphi.g
+++ b/delphi-frontend/src/main/antlr3/au/com/integradev/delphi/antlr/Delphi.g
@@ -467,7 +467,9 @@ constSection                 : (CONST<ConstSectionNodeImpl>^ | RESOURCESTRING<Co
                              // example: "const {$include versioninfo.inc}"
                              // Is this really the appropriate solution?
                              ;
-constDeclaration             : attributeList? nameDeclaration (':' varType)? '=' constExpression portabilityDirective* ';'
+constDeclaration             : attributeList? nameDeclaration ':' fixedArrayType '=' arrayExpression portabilityDirective* ';'
+                             -> ^(TkConstDeclaration<ConstDeclarationNodeImpl> nameDeclaration arrayExpression fixedArrayType attributeList? portabilityDirective*)
+                             | attributeList? nameDeclaration (':' varType)? '=' constExpression portabilityDirective* ';'
                              -> ^(TkConstDeclaration<ConstDeclarationNodeImpl> nameDeclaration constExpression varType? attributeList? portabilityDirective*)
                              ;
 typeSection                  : TYPE<TypeSectionNodeImpl>^ typeDeclaration+
@@ -479,8 +481,13 @@ typeDeclaration              : attributeList? genericNameDeclaration '=' typeDec
                              ;
 varSection                   : (VAR<VarSectionNodeImpl>^ | THREADVAR<VarSectionNodeImpl>^) varDeclaration varDeclaration*
                              ;
-varDeclaration               : attributeList? nameDeclarationList ':' varType portabilityDirective* varValueSpec? portabilityDirective* ';'
+varDeclaration               : attributeList? nameDeclarationList ':' fixedArrayType portabilityDirective* arrayVarValueSpec? portabilityDirective* ';'
+                             -> ^(TkVarDeclaration<VarDeclarationNodeImpl> nameDeclarationList fixedArrayType arrayVarValueSpec? attributeList?)
+                             | attributeList? nameDeclarationList ':' varType portabilityDirective* varValueSpec? portabilityDirective* ';'
                              -> ^(TkVarDeclaration<VarDeclarationNodeImpl> nameDeclarationList varType varValueSpec? attributeList?)
+                             ;
+arrayVarValueSpec            : ABSOLUTE expression
+                             | '=' arrayExpression
                              ;
 varValueSpec                 : ABSOLUTE expression
                              | '=' constExpression
@@ -530,6 +537,9 @@ parameterType                : stringType
                              | arrayType
                              | typeReference
                              | PACKED parameterType^
+                             ;
+fixedArrayType               : ARRAY arrayIndices OF arrayElementType
+                             -> ^(ARRAY<ArrayTypeNodeImpl> OF arrayElementType arrayIndices )
                              ;
 arrayType                    :  ARRAY arrayIndices? OF arrayElementType
                              -> ^(ARRAY<ArrayTypeNodeImpl> OF arrayElementType arrayIndices? )


### PR DESCRIPTION
This PR fixes a parsing bug where const array literal expressions would be confused with parenthesized primary expressions.

The official parser builds type information incrementally during parsing and relies on it to know what may appear on the right side of an assignment (which is another point in favor of #261).

With our current approach to parsing, the fix for this problem is a slightly gnarly repetition of rules in the ANTLR3 grammar.