### PR TITLE
Handle aliased imports in `FullyQualifiedImport`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `FullyQualifiedImportCheck` analysis rule, which flags non-fully qualified imports.
+- **API:** `UnitImportNameDeclaration::isAlias` method.
+
 ### Changed
 
 - Non-trivial `inherited` expressions are excluded in `RedundantParentheses`.
@@ -19,7 +24,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- `FullyQualifiedImportCheck` analysis rule, which flags non-fully qualified imports.
 - **API:** `CaseItemStatementNode::getExpressions` method.
 
 ### Changed

--- a/delphi-checks/src/test/java/au/com/integradev/delphi/checks/FullyQualifiedImportCheckTest.java
+++ b/delphi-checks/src/test/java/au/com/integradev/delphi/checks/FullyQualifiedImportCheckTest.java
@@ -83,6 +83,33 @@ class FullyQualifiedImportCheckTest {
   }
 
   @Test
+  void testUnitAliasImportShouldNotAddIssue() {
+    var testFile = new DelphiTestUnitBuilder().appendDecl("uses").appendDecl("  AliasName;");
+
+    CheckVerifier.newVerifier()
+        .withCheck(new FullyQualifiedImportCheck())
+        .withSearchPathUnit(new DelphiTestUnitBuilder().unitName("Scope.RealName"))
+        .withSearchPathUnit(new DelphiTestUnitBuilder().unitName("Scope.AliasName"))
+        .withUnitScopeName("Scope")
+        .withUnitAlias("AliasName", "Scope.RealName")
+        .onFile(testFile)
+        .verifyNoIssues();
+  }
+
+  @Test
+  void testUnitAliasImportThatLooksLikeUnqualifiedImportShouldNotAddIssue() {
+    var testFile = new DelphiTestUnitBuilder().appendDecl("uses").appendDecl("  Name;");
+
+    CheckVerifier.newVerifier()
+        .withCheck(new FullyQualifiedImportCheck())
+        .withSearchPathUnit(new DelphiTestUnitBuilder().unitName("Scope.Name"))
+        .withUnitScopeName("Scope")
+        .withUnitAlias("Name", "Scope.Name")
+        .onFile(testFile)
+        .verifyNoIssues();
+  }
+
+  @Test
   void testNotFullyQualifiedImportShouldAddIssue() {
     var importedUnit = new DelphiTestUnitBuilder().unitName("Scope.UnitU");
 

--- a/delphi-frontend/src/main/java/org/sonar/plugins/communitydelphi/api/symbol/declaration/UnitImportNameDeclaration.java
+++ b/delphi-frontend/src/main/java/org/sonar/plugins/communitydelphi/api/symbol/declaration/UnitImportNameDeclaration.java
@@ -22,6 +22,8 @@ import javax.annotation.Nullable;
 import org.sonar.plugins.communitydelphi.api.symbol.scope.FileScope;
 
 public interface UnitImportNameDeclaration extends QualifiedNameDeclaration {
+  boolean isAlias();
+
   @Nullable
   UnitNameDeclaration getOriginalDeclaration();
 

--- a/delphi-frontend/src/test/java/au/com/integradev/delphi/symbol/declaration/UnitImportNameDeclarationTest.java
+++ b/delphi-frontend/src/test/java/au/com/integradev/delphi/symbol/declaration/UnitImportNameDeclarationTest.java
@@ -40,19 +40,31 @@ import org.sonar.plugins.communitydelphi.api.symbol.declaration.UnitNameDeclarat
 
 class UnitImportNameDeclarationTest {
   @Test
+  void testIsAlias() {
+    assertThat(createImport("Foo", true).isAlias()).isTrue();
+    assertThat(createImport("Bar", false).isAlias()).isFalse();
+  }
+
+  @Test
   void testEquals() {
     UnitImportNameDeclaration foo = createImport("Foo");
     UnitImportNameDeclaration otherFoo = createImport("Foo");
+    UnitImportNameDeclaration aliasFoo = createImport("Foo", true);
     UnitImportNameDeclaration differentName = createImport("Bar");
     UnitImportNameDeclaration differentOriginalDeclaration = createImport("Foo", createUnit("Foo"));
 
     new EqualsTester()
         .addEqualityGroup(foo, otherFoo)
+        .addEqualityGroup(aliasFoo)
         .addEqualityGroup(differentName)
         .addEqualityGroup(differentOriginalDeclaration)
         .testEquals();
 
-    assertThat(foo).isEqualByComparingTo(otherFoo).isNotEqualByComparingTo(differentName);
+    assertThat(foo)
+        .isEqualByComparingTo(otherFoo)
+        .isNotEqualByComparingTo(aliasFoo)
+        .isNotEqualByComparingTo(differentName)
+        .isNotEqualByComparingTo(differentOriginalDeclaration);
   }
 
   @Test
@@ -64,11 +76,20 @@ class UnitImportNameDeclarationTest {
     return createImport(name, null);
   }
 
+  private static UnitImportNameDeclaration createImport(String name, boolean alias) {
+    return createImport(name, null, alias);
+  }
+
   private static UnitImportNameDeclaration createImport(
       String name, UnitNameDeclaration originalDeclaration) {
+    return createImport(name, originalDeclaration, false);
+  }
+
+  private static UnitImportNameDeclaration createImport(
+      String name, UnitNameDeclaration originalDeclaration, boolean alias) {
     var location = new UnitImportNodeImpl(DelphiLexer.TkUnitImport);
     location.addChild(createNameNode(name));
-    return new UnitImportNameDeclarationImpl(location, originalDeclaration);
+    return new UnitImportNameDeclarationImpl(location, alias, originalDeclaration);
   }
 
   private static UnitNameDeclaration createUnit(String name) {


### PR DESCRIPTION
This PR fixes an issue in `FullyQualifiedImport` where unit aliases weren't considered, causing false positives on aliased imports.