### PR TITLE
Add architecture tests for test classes and methods

### DIFF
--- a/delphi-checks/src/test/java/au/com/integradev/delphi/checks/BeginEndRequiredCheckTest.java
+++ b/delphi-checks/src/test/java/au/com/integradev/delphi/checks/BeginEndRequiredCheckTest.java
@@ -139,7 +139,7 @@ class BeginEndRequiredCheckTest {
   }
 
   @Test
-  void testShouldSkipAsmProcedure() {
+  void testAsmProcedureShouldNotAddIssue() {
     CheckVerifier.newVerifier()
         .withCheck(new BeginEndRequiredCheck())
         .onFile(

--- a/delphi-checks/src/test/java/au/com/integradev/delphi/checks/CheckTestNameTest.java
+++ b/delphi-checks/src/test/java/au/com/integradev/delphi/checks/CheckTestNameTest.java
@@ -1,0 +1,203 @@
+/*
+ * Sonar Delphi Plugin
+ * Copyright (C) 2024 Integrated Application Development
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02
+ */
+package au.com.integradev.delphi.checks;
+
+import static com.tngtech.archunit.base.DescribedPredicate.not;
+import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.classes;
+import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.methods;
+
+import com.tngtech.archunit.base.DescribedPredicate;
+import com.tngtech.archunit.core.domain.JavaClass;
+import com.tngtech.archunit.core.domain.JavaClasses;
+import com.tngtech.archunit.core.domain.JavaMember;
+import com.tngtech.archunit.core.domain.JavaMethod;
+import com.tngtech.archunit.core.domain.JavaModifier;
+import com.tngtech.archunit.core.domain.properties.HasName;
+import com.tngtech.archunit.core.importer.ClassFileImporter;
+import com.tngtech.archunit.lang.ArchCondition;
+import com.tngtech.archunit.lang.ConditionEvents;
+import com.tngtech.archunit.lang.SimpleConditionEvent;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.sonar.plugins.communitydelphi.api.check.DelphiCheck;
+
+class CheckTestNameTest {
+
+  private static final JavaClasses CHECKS_PACKAGE =
+      new ClassFileImporter().importPackages("au.com.integradev.delphi.checks");
+
+  private static final DescribedPredicate<JavaMethod> VERIFY_ISSUES =
+      callCheckVerifierMethod("verifyIssues")
+          .or(callCheckVerifierMethod("verifyIssueOnFile"))
+          .or(callCheckVerifierMethod("verifyIssueOnProject"));
+  private static final DescribedPredicate<JavaMethod> VERIFY_NO_ISSUES =
+      callMethod("au.com.integradev.delphi.checks.verifier.CheckVerifier.verifyNoIssues");
+  private static final DescribedPredicate<JavaMethod> CALL_ASSERT_THROW_BY =
+      callMethod("org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy");
+  private static final DescribedPredicate<JavaMethod> CALL_ASSERT_NO_EXCEPTION =
+      callMethod("org.assertj.core.api.AssertionsForClassTypes.assertThatNoException");
+  private static final String IMPLEMENTATION_DETAIL_PREFIX = "testImplementationDetail";
+  private static final DescribedPredicate<HasName> TESTING_IMPLEMENTATION_DETAILS =
+      HasName.Predicates.nameStartingWith(IMPLEMENTATION_DETAIL_PREFIX);
+
+  private static final List<Class<?>> METATEST_CLASSES =
+      List.of(CheckListTest.class, CheckMetadataTest.class, CheckTestNameTest.class);
+  private static final DescribedPredicate<JavaMember> DECLARED_IN_METATESTS =
+      new DescribedPredicate<>("declared in meta test classes") {
+        @Override
+        public boolean test(JavaMember member) {
+          return METATEST_CLASSES.contains(member.getOwner().reflect());
+        }
+      };
+
+  private static final ArchCondition<JavaClass> HAVE_ASSOCIATED_CHECK =
+      new ArchCondition<>("have an associated check") {
+        @Override
+        public void check(JavaClass item, ConditionEvents events) {
+          String subjectName = item.getName().replaceAll("Test$", "");
+          boolean hasSubject =
+              CheckList.getChecks().stream().map(Class::getName).anyMatch(subjectName::equals);
+
+          if (!hasSubject) {
+            String message =
+                String.format(
+                    "%s does not have an associated subject %s", item.getFullName(), subjectName);
+            events.add(SimpleConditionEvent.violated(item, message));
+          }
+        }
+      };
+  private static final ArchCondition<JavaClass> HAVE_ASSOCIATED_TEST =
+      new ArchCondition<>("have an associated test") {
+        @Override
+        public void check(JavaClass item, ConditionEvents events) {
+          String testName = item.getName() + "Test";
+          boolean hasTest =
+              item.getConstructorCallsToSelf().stream()
+                  .anyMatch(
+                      constructorCall ->
+                          constructorCall.getOriginOwner().getName().equals(testName));
+
+          if (!hasTest) {
+            String message =
+                String.format(
+                    "%s does not have an associated test %s", item.getFullName(), testName);
+            events.add(SimpleConditionEvent.violated(item, message));
+          }
+        }
+      };
+
+  static DescribedPredicate<JavaMethod> callMethod(String methodName) {
+    return new DescribedPredicate<>("call " + methodName) {
+      @Override
+      public boolean test(JavaMethod method) {
+        String methodPrefix = String.format("%s(", methodName);
+        return method.getCallsFromSelf().stream()
+            .anyMatch(call -> call.getTarget().getFullName().startsWith(methodPrefix));
+      }
+    };
+  }
+
+  static DescribedPredicate<JavaMethod> callCheckVerifierMethod(String methodName) {
+    return callMethod(
+        String.format("au.com.integradev.delphi.checks.verifier.CheckVerifier.%s", methodName));
+  }
+
+  @Test
+  void testCheckTestsVerifyingIssuesAreNamedCorrectly() {
+    methods()
+        .that(VERIFY_ISSUES)
+        .and(not(TESTING_IMPLEMENTATION_DETAILS))
+        .should()
+        .haveNameMatching(".*ShouldAdd(Issues?|QuickFix(es)?)$")
+        .allowEmptyShould(true)
+        .check(CHECKS_PACKAGE);
+  }
+
+  @Test
+  void testCheckTestsVerifyingNoIssuesAreNamedCorrectly() {
+    methods()
+        .that(VERIFY_NO_ISSUES)
+        .and(not(TESTING_IMPLEMENTATION_DETAILS))
+        .and(not(CALL_ASSERT_THROW_BY))
+        .should()
+        .haveNameMatching(".*ShouldNotAddIssues?$")
+        .allowEmptyShould(true)
+        .check(CHECKS_PACKAGE);
+  }
+
+  @Test
+  void testCheckTestsShouldThrowAreNamedCorrectly() {
+    methods()
+        .that(CALL_ASSERT_THROW_BY)
+        .and(not(TESTING_IMPLEMENTATION_DETAILS))
+        .should()
+        .haveNameMatching(".*ShouldThrow$")
+        .allowEmptyShould(true)
+        .check(CHECKS_PACKAGE);
+  }
+
+  @Test
+  void testCheckTestsShouldNotThrowAreNamedCorrectly() {
+    methods()
+        .that(CALL_ASSERT_NO_EXCEPTION)
+        .and(not(TESTING_IMPLEMENTATION_DETAILS))
+        .should()
+        .haveNameMatching(".*ShouldNotThrow$")
+        .allowEmptyShould(true)
+        .check(CHECKS_PACKAGE);
+  }
+
+  @Test
+  void testCheckTestsShouldBeNamedCorrectly() {
+    methods()
+        .that()
+        .areAnnotatedWith(Test.class)
+        .and(not(DECLARED_IN_METATESTS))
+        .should()
+        .haveNameMatching(".*Should((Not)?(Throw|Add(Issues?|QuickFix(es)?)))")
+        .orShould()
+        .haveNameMatching(IMPLEMENTATION_DETAIL_PREFIX + ".*")
+        .allowEmptyShould(true)
+        .check(CHECKS_PACKAGE);
+  }
+
+  @Test
+  void testCheckTestsHaveAnAssociatedCheck() {
+    classes()
+        .that()
+        .haveSimpleNameEndingWith("Test")
+        .and()
+        .doNotBelongToAnyOf(CheckListTest.class, CheckMetadataTest.class, CheckTestNameTest.class)
+        .should(HAVE_ASSOCIATED_CHECK)
+        .allowEmptyShould(true)
+        .check(CHECKS_PACKAGE);
+  }
+
+  @Test
+  void testChecksHaveAnAssociatedTest() {
+    classes()
+        .that()
+        .areAssignableTo(DelphiCheck.class)
+        .and()
+        .doNotHaveModifier(JavaModifier.ABSTRACT)
+        .should(HAVE_ASSOCIATED_TEST)
+        .allowEmptyShould(true)
+        .check(CHECKS_PACKAGE);
+  }
+}

--- a/delphi-checks/src/test/java/au/com/integradev/delphi/checks/ClassPerFileCheckTest.java
+++ b/delphi-checks/src/test/java/au/com/integradev/delphi/checks/ClassPerFileCheckTest.java
@@ -80,7 +80,7 @@ class ClassPerFileCheckTest {
   }
 
   @Test
-  void testMultipleViolationsShouldAddOneIssue() {
+  void testMultipleViolationsShouldAddIssue() {
     CheckVerifier.newVerifier()
         .withCheck(new ClassPerFileCheck())
         .onFile(
@@ -99,7 +99,7 @@ class ClassPerFileCheckTest {
   }
 
   @Test
-  void testFalsePositiveMetaClass() {
+  void testClassReferenceShouldNotAddIssue() {
     CheckVerifier.newVerifier()
         .withCheck(new ClassPerFileCheck())
         .onFile(
@@ -113,7 +113,7 @@ class ClassPerFileCheckTest {
   }
 
   @Test
-  void testFalsePositiveClassMethods() {
+  void testClassMethodsShouldNotAddIssue() {
     CheckVerifier.newVerifier()
         .withCheck(new ClassPerFileCheck())
         .onFile(

--- a/delphi-checks/src/test/java/au/com/integradev/delphi/checks/CognitiveComplexityRoutineCheckTest.java
+++ b/delphi-checks/src/test/java/au/com/integradev/delphi/checks/CognitiveComplexityRoutineCheckTest.java
@@ -57,7 +57,7 @@ class CognitiveComplexityRoutineCheckTest {
   }
 
   @Test
-  void testTooComplexSubProcedureShouldOnlyAddIssueForSubProcedure() {
+  void testTooComplexSubProcedureShouldAddIssue() {
     DelphiTestUnitBuilder builder =
         new DelphiTestUnitBuilder()
             .appendImpl("function Foo: Integer;")

--- a/delphi-checks/src/test/java/au/com/integradev/delphi/checks/CommentedOutCodeCheckTest.java
+++ b/delphi-checks/src/test/java/au/com/integradev/delphi/checks/CommentedOutCodeCheckTest.java
@@ -330,7 +330,7 @@ class CommentedOutCodeCheckTest {
   }
 
   @Test
-  void testRegexTimeoutCharSequenceSubsequence() {
+  void testImplementationDetailRegexTimeoutCharSequenceSubsequence() {
     CharSequence charSequence = new RegexTimeoutCharSequence("Hello, World!", 0);
     assertThat(charSequence.subSequence(0, 5)).asString().isEqualTo("Hello");
   }

--- a/delphi-checks/src/test/java/au/com/integradev/delphi/checks/ConstructorNameCheckTest.java
+++ b/delphi-checks/src/test/java/au/com/integradev/delphi/checks/ConstructorNameCheckTest.java
@@ -64,7 +64,7 @@ class ConstructorNameCheckTest {
   }
 
   @Test
-  void testBadPascalCaseAddIssue() {
+  void testBadPascalCaseShouldAddIssue() {
     CheckVerifier.newVerifier()
         .withCheck(new ConstructorNameCheck())
         .onFile(

--- a/delphi-checks/src/test/java/au/com/integradev/delphi/checks/CyclomaticComplexityRoutineCheckTest.java
+++ b/delphi-checks/src/test/java/au/com/integradev/delphi/checks/CyclomaticComplexityRoutineCheckTest.java
@@ -75,7 +75,7 @@ class CyclomaticComplexityRoutineCheckTest {
   }
 
   @Test
-  void testTooComplexNestedRoutineeShouldOnlyAddIssueForNestedRoutine() {
+  void testTooComplexNestedRoutineShouldAddIssue() {
     DelphiTestUnitBuilder builder =
         new DelphiTestUnitBuilder()
             .appendImpl("function Foo: Integer;") // 1

--- a/delphi-checks/src/test/java/au/com/integradev/delphi/checks/EmptyFileCheckTest.java
+++ b/delphi-checks/src/test/java/au/com/integradev/delphi/checks/EmptyFileCheckTest.java
@@ -107,7 +107,7 @@ class EmptyFileCheckTest {
   }
 
   @Test
-  void testIgnorePackage() {
+  void testPackageShouldNotAddIssue() {
     CheckVerifier.newVerifier()
         .withCheck(new EmptyFileCheck())
         .onFile(DelphiTestFile.fromResource(PACKAGE_FILE))

--- a/delphi-checks/src/test/java/au/com/integradev/delphi/checks/EmptyRoutineCheckTest.java
+++ b/delphi-checks/src/test/java/au/com/integradev/delphi/checks/EmptyRoutineCheckTest.java
@@ -160,7 +160,7 @@ class EmptyRoutineCheckTest {
   }
 
   @Test
-  void testFalsePositiveForwardTypeDeclaration() {
+  void testForwardTypeDeclarationShouldNotAddIssue() {
     CheckVerifier.newVerifier()
         .withCheck(new EmptyRoutineCheck())
         .onFile(
@@ -179,7 +179,7 @@ class EmptyRoutineCheckTest {
   }
 
   @Test
-  void testFalsePositiveOverloadedMethod() {
+  void testOverloadedMethodShouldNotAddIssue() {
     CheckVerifier.newVerifier()
         .withCheck(new EmptyRoutineCheck())
         .onFile(

--- a/delphi-checks/src/test/java/au/com/integradev/delphi/checks/FieldNameCheckTest.java
+++ b/delphi-checks/src/test/java/au/com/integradev/delphi/checks/FieldNameCheckTest.java
@@ -57,7 +57,7 @@ class FieldNameCheckTest {
   }
 
   @Test
-  void testPublicAndPublishedFieldsShouldNotAddIssue() {
+  void testPublicAndPublishedFieldsShouldAddIssue() {
     CheckVerifier.newVerifier()
         .withCheck(new FieldNameCheck())
         .onFile(
@@ -76,7 +76,7 @@ class FieldNameCheckTest {
   }
 
   @Test
-  void testPublicAndPublishedFieldsInMultipleClassesShouldNotAddIssue() {
+  void testPublicAndPublishedFieldsInMultipleClassesShouldAddIssue() {
     CheckVerifier.newVerifier()
         .withCheck(new FieldNameCheck())
         .onFile(

--- a/delphi-checks/src/test/java/au/com/integradev/delphi/checks/GroupedParameterDeclarationCheckTest.java
+++ b/delphi-checks/src/test/java/au/com/integradev/delphi/checks/GroupedParameterDeclarationCheckTest.java
@@ -54,7 +54,7 @@ class GroupedParameterDeclarationCheckTest {
   }
 
   @Test
-  void testConstParameterKeywordShouldPropagateInQuickFix() {
+  void testConstParameterKeywordShouldAddQuickFix() {
     CheckVerifier.newVerifier()
         .withCheck(new GroupedParameterDeclarationCheck())
         .onFile(
@@ -71,7 +71,7 @@ class GroupedParameterDeclarationCheckTest {
   }
 
   @Test
-  void testThreeParametersInQuickFix() {
+  void testThreeParametersShouldAddQuickFix() {
     CheckVerifier.newVerifier()
         .withCheck(new GroupedParameterDeclarationCheck())
         .onFile(

--- a/delphi-checks/src/test/java/au/com/integradev/delphi/checks/HelperNameCheckTest.java
+++ b/delphi-checks/src/test/java/au/com/integradev/delphi/checks/HelperNameCheckTest.java
@@ -218,7 +218,7 @@ class HelperNameCheckTest {
   }
 
   @Test
-  void testGetUnknownExtendedTypeSimpleName() {
+  void testImplementationDetailGetUnknownExtendedTypeSimpleName() {
     DelphiAst ast =
         new DelphiTestUnitBuilder()
             .appendDecl("type")

--- a/delphi-checks/src/test/java/au/com/integradev/delphi/checks/ImplicitDefaultEncodingCheckTest.java
+++ b/delphi-checks/src/test/java/au/com/integradev/delphi/checks/ImplicitDefaultEncodingCheckTest.java
@@ -229,7 +229,7 @@ class ImplicitDefaultEncodingCheckTest {
   }
 
   @Test
-  void testForbiddenOverloadsAddIssues() {
+  void testForbiddenOverloadsShouldAddIssues() {
     CheckVerifier.newVerifier()
         .withCheck(new ImplicitDefaultEncodingCheck())
         .withStandardLibraryUnit(getSystem())

--- a/delphi-checks/src/test/java/au/com/integradev/delphi/checks/LowercaseKeywordCheckTest.java
+++ b/delphi-checks/src/test/java/au/com/integradev/delphi/checks/LowercaseKeywordCheckTest.java
@@ -75,7 +75,7 @@ class LowercaseKeywordCheckTest {
   }
 
   @Test
-  void testUppercaseKeywordShouldAddQuickFixOnToken() {
+  void testUppercaseRootTokenKeywordShouldAddIssue() {
     CheckVerifier.newVerifier()
         .withCheck(createCheck())
         .onFile(

--- a/delphi-checks/src/test/java/au/com/integradev/delphi/checks/MissingSemicolonCheckTest.java
+++ b/delphi-checks/src/test/java/au/com/integradev/delphi/checks/MissingSemicolonCheckTest.java
@@ -265,7 +265,7 @@ class MissingSemicolonCheckTest {
   }
 
   @Test
-  void testShouldSkipInlineAsm() {
+  void testInlineAsmShouldNotAddIssue() {
     CheckVerifier.newVerifier()
         .withCheck(new MissingSemicolonCheck())
         .onFile(

--- a/delphi-checks/src/test/java/au/com/integradev/delphi/checks/MixedNamesCheckTest.java
+++ b/delphi-checks/src/test/java/au/com/integradev/delphi/checks/MixedNamesCheckTest.java
@@ -306,7 +306,7 @@ class MixedNamesCheckTest {
   }
 
   @Test
-  void testUnitReferenceMatchingDeclarationAndNotMatchingImportShouldNotAddIssue() {
+  void testUnitReferenceMatchingDeclarationAndNotMatchingImportShouldAddIssue() {
     CheckVerifier.newVerifier()
         .withCheck(new MixedNamesCheck())
         .withUnitScopeName("System")

--- a/delphi-checks/src/test/java/au/com/integradev/delphi/checks/RedundantInheritedCheckTest.java
+++ b/delphi-checks/src/test/java/au/com/integradev/delphi/checks/RedundantInheritedCheckTest.java
@@ -211,7 +211,7 @@ class RedundantInheritedCheckTest {
   }
 
   @Test
-  void testQuickFixesFollowingIncludeDirective() {
+  void testIssuesFollowingIncludeDirectiveShouldAddQuickFixes() {
     CheckVerifier.newVerifier()
         .withCheck(new RedundantInheritedCheck())
         .onFile(

--- a/delphi-checks/src/test/java/au/com/integradev/delphi/checks/RoutineNameCheckTest.java
+++ b/delphi-checks/src/test/java/au/com/integradev/delphi/checks/RoutineNameCheckTest.java
@@ -64,7 +64,7 @@ class RoutineNameCheckTest {
   }
 
   @Test
-  void testPublishedMethodsShouldBeSkipped() {
+  void testPublishedMethodsShouldNotAddIssue() {
     CheckVerifier.newVerifier()
         .withCheck(new RoutineNameCheck())
         .onFile(
@@ -77,7 +77,7 @@ class RoutineNameCheckTest {
   }
 
   @Test
-  void testMethodsImplementingInterfacesWithMatchingNameShouldBeSkipped() {
+  void testInterfaceMethodDeclarationsShouldAddIssue() {
     CheckVerifier.newVerifier()
         .withCheck(new RoutineNameCheck())
         .onFile(
@@ -95,7 +95,7 @@ class RoutineNameCheckTest {
   }
 
   @Test
-  void testMethodOverridesWithMatchingNameShouldBeSkipped() {
+  void testOverriddenMethodsShouldAddIssue() {
     CheckVerifier.newVerifier()
         .withCheck(new RoutineNameCheck())
         .onFile(

--- a/delphi-checks/src/test/java/au/com/integradev/delphi/checks/TabulationCharacterCheckTest.java
+++ b/delphi-checks/src/test/java/au/com/integradev/delphi/checks/TabulationCharacterCheckTest.java
@@ -41,7 +41,7 @@ class TabulationCharacterCheckTest {
   }
 
   @Test
-  void testFileWithMultipleTabsShouldAddOnlyOneIssue() {
+  void testFileWithMultipleTabsShouldAddIssue() {
     CheckVerifier.newVerifier()
         .withCheck(new TabulationCharacterCheck())
         .onFile(

--- a/delphi-checks/src/test/java/au/com/integradev/delphi/checks/TypeAliasCheckTest.java
+++ b/delphi-checks/src/test/java/au/com/integradev/delphi/checks/TypeAliasCheckTest.java
@@ -47,7 +47,7 @@ class TypeAliasCheckTest {
   }
 
   @Test
-  void testFalsePositiveMetaClassIsNotTypeAlias() {
+  void testClassReferenceShouldNotAddIssue() {
     CheckVerifier.newVerifier()
         .withCheck(new TypeAliasCheck())
         .onFile(
@@ -60,7 +60,7 @@ class TypeAliasCheckTest {
   }
 
   @Test
-  void testFalsePositiveEmptyRecordIsNotTypeAlias() {
+  void testEmptyRecordShouldNotAddIssue() {
     CheckVerifier.newVerifier()
         .withCheck(new TypeAliasCheck())
         .onFile(
@@ -72,7 +72,7 @@ class TypeAliasCheckTest {
   }
 
   @Test
-  void testFalsePositiveEmptyClassIsNotTypeAlias() {
+  void testEmptyClassShouldNotAddIssue() {
     CheckVerifier.newVerifier()
         .withCheck(new TypeAliasCheck())
         .onFile(
@@ -84,7 +84,7 @@ class TypeAliasCheckTest {
   }
 
   @Test
-  void testFalsePositiveSetsAreNotTypeAlias() {
+  void testSetsShouldNotAddIssue() {
     CheckVerifier.newVerifier()
         .withCheck(new TypeAliasCheck())
         .onFile(
@@ -95,7 +95,7 @@ class TypeAliasCheckTest {
   }
 
   @Test
-  void testFalsePositiveArraysAreNotTypeAlias() {
+  void testArraysShouldNotAddIssue() {
     CheckVerifier.newVerifier()
         .withCheck(new TypeAliasCheck())
         .onFile(
@@ -106,7 +106,7 @@ class TypeAliasCheckTest {
   }
 
   @Test
-  void testFalsePositiveSubRangesAreNotTypeAlias() {
+  void testSubRangesShouldNotAddIssue() {
     CheckVerifier.newVerifier()
         .withCheck(new TypeAliasCheck())
         .onFile(
@@ -117,7 +117,7 @@ class TypeAliasCheckTest {
   }
 
   @Test
-  void testFalsePositivePointerTypesAreNotTypeAlias() {
+  void testPointerTypesShouldNotAddIssue() {
     CheckVerifier.newVerifier()
         .withCheck(new TypeAliasCheck())
         .onFile(

--- a/delphi-checks/src/test/java/au/com/integradev/delphi/checks/VariableInitializationCheckTest.java
+++ b/delphi-checks/src/test/java/au/com/integradev/delphi/checks/VariableInitializationCheckTest.java
@@ -277,25 +277,6 @@ class VariableInitializationCheckTest {
                 .appendImpl("  FormatSettings: TFormatSettings;")
                 .appendImpl("begin")
                 .appendImpl("  Foo(FormatSettings); // Noncompliant")
-                .appendImpl("end;"))
-        .verifyIssues();
-  }
-
-  @Test
-  void testVariableWithoutInitializationShouldOnlyAddOneIssue() {
-    CheckVerifier.newVerifier()
-        .withCheck(new VariableInitializationCheck())
-        .onFile(
-            new DelphiTestUnitBuilder()
-                .appendDecl("uses")
-                .appendDecl("    System.SysUtils")
-                .appendDecl("  ;")
-                .appendDecl("procedure Foo(FormatSettings: TFormatSettings);")
-                .appendImpl("procedure Test;")
-                .appendImpl("var")
-                .appendImpl("  FormatSettings: TFormatSettings;")
-                .appendImpl("begin")
-                .appendImpl("  Foo(FormatSettings); // Noncompliant")
                 .appendImpl("  Foo(FormatSettings);")
                 .appendImpl("end;"))
         .verifyIssues();
@@ -739,7 +720,7 @@ class VariableInitializationCheckTest {
   }
 
   @Test
-  void testPassedToArrayProcVarOutParameterFalsePositiveShouldFailOnUpgrade() {
+  void testFailOnUpgradeVarPassedToArrayProcVarOutParameterShouldAddIssue() {
     CheckVerifier.newVerifier()
         .withCheck(new VariableInitializationCheck())
         .onFile(
@@ -934,7 +915,7 @@ class VariableInitializationCheckTest {
   }
 
   @Test
-  void testSizeOfShouldNotAddIssueOrAffectInitializationState() {
+  void testUninitializedVariableUseAfterSizeOfShouldAddIssue() {
     CheckVerifier.newVerifier()
         .withCheck(new VariableInitializationCheck())
         .onFile(

--- a/delphi-checks/src/test/java/au/com/integradev/delphi/checks/VariableNameCheckTest.java
+++ b/delphi-checks/src/test/java/au/com/integradev/delphi/checks/VariableNameCheckTest.java
@@ -201,7 +201,7 @@ class VariableNameCheckTest {
   }
 
   @Test
-  void testBadPascalCaseInRoutineImplementingBadPascalCaseInterfaceShouldNotAddIssue() {
+  void testBadPascalCaseInRoutineImplementingBadPascalCaseInterfaceShouldAddIssue() {
     CheckVerifier.newVerifier()
         .withCheck(createCheck())
         .onFile(

--- a/delphi-checks/src/test/java/au/com/integradev/delphi/checks/VisibilityKeywordIndentationCheckTest.java
+++ b/delphi-checks/src/test/java/au/com/integradev/delphi/checks/VisibilityKeywordIndentationCheckTest.java
@@ -34,7 +34,7 @@ class VisibilityKeywordIndentationCheckTest {
         "class helper for TObject",
         "record helper for string"
       })
-  void testTooIndentedVisibilitySpecifierShouldRaiseIssue(String structType) {
+  void testTooIndentedVisibilitySpecifierShouldAddIssue(String structType) {
     CheckVerifier.newVerifier()
         .withCheck(new VisibilityKeywordIndentationCheck())
         .onFile(
@@ -56,7 +56,7 @@ class VisibilityKeywordIndentationCheckTest {
         "class helper for TObject",
         "record helper for string"
       })
-  void testCorrectlyIndentedVisibilitySpecifierShouldNotRaiseIssue(String structType) {
+  void testCorrectlyIndentedVisibilitySpecifierShouldNotAddIssue(String structType) {
     CheckVerifier.newVerifier()
         .withCheck(new VisibilityKeywordIndentationCheck())
         .onFile(
@@ -70,7 +70,7 @@ class VisibilityKeywordIndentationCheckTest {
   }
 
   @Test
-  void testImplicitPublishedVisibilitySectionShouldNotRaiseIssue() {
+  void testImplicitPublishedVisibilitySectionShouldNotAddIssue() {
     CheckVerifier.newVerifier()
         .withCheck(new VisibilityKeywordIndentationCheck())
         .onFile(
@@ -84,7 +84,7 @@ class VisibilityKeywordIndentationCheckTest {
   }
 
   @Test
-  void testUnindentedVisibilitySpecifierShouldRaiseIssue() {
+  void testUnindentedVisibilitySpecifierShouldAddIssue() {
     CheckVerifier.newVerifier()
         .withCheck(new VisibilityKeywordIndentationCheck())
         .onFile(

--- a/delphi-checks/src/test/java/au/com/integradev/delphi/checks/VisibilitySectionOrderCheckTest.java
+++ b/delphi-checks/src/test/java/au/com/integradev/delphi/checks/VisibilitySectionOrderCheckTest.java
@@ -95,7 +95,7 @@ class VisibilitySectionOrderCheckTest {
   }
 
   @Test
-  void testMultipleOutOfOrderSectionsShouldAddMultipleIssues() {
+  void testMultipleOutOfOrderSectionsShouldAddIssues() {
     CheckVerifier.newVerifier()
         .withCheck(new VisibilitySectionOrderCheck())
         .onFile(


### PR DESCRIPTION
It is common for a test name not to represent what it is asserting. An example of this is a test named `...ShouldAddIssue` calling `verifyNoIssues`.

This PR adds some architecture tests targeting checks that assert:
* Test names are accurate to the assertion
* All checks have test units
* All test units have an associated check