### PR TITLE
Improve procedural type modeling around routine directives

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **API:** `AnonymousMethodNode::getAnonymousMethodHeading` method.
+- **API:** `AnonymousMethodNode::getDirectives` method.
+- **API:** `AnonymousMethodNode::hasDirective` method.
+- **API:** `AnonymousMethodHeadingNode` node type.
+- **API:** `DelphiTokenType.ANONYMOUS_METHOD` token type.
+- **API:** `DelphiTokenType.ANONYMOUS_METHOD_HEADING` token type.
+
 ### Fixed
 
 - Parsing errors on `implementation` keywords nested in conditional branches.
+- Parsing errors on anonymous methods with routine directives (like calling conventions).
 
 ## [1.10.0] - 2024-10-01
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **API:** `ProceduralType::directives` method.
+- **API:** `ProceduralTypeNode::getDirectives` method.
+- **API:** `ProceduralTypeNode::hasDirective` method.
+- **API:** `ProceduralTypeHeadingNode::getDirectives` method.
 - **API:** `AnonymousMethodNode::getAnonymousMethodHeading` method.
 - **API:** `AnonymousMethodNode::getDirectives` method.
 - **API:** `AnonymousMethodNode::hasDirective` method.
@@ -20,6 +24,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Parsing errors on `implementation` keywords nested in conditional branches.
 - Parsing errors on anonymous methods with routine directives (like calling conventions).
+- `IndexOutOfBoundsException` errors around procedural types declared with `varargs` in
+  `VariableInitialization`.
 
 ## [1.10.0] - 2024-10-01
 

--- a/delphi-checks/src/test/java/au/com/integradev/delphi/checks/VariableInitializationCheckTest.java
+++ b/delphi-checks/src/test/java/au/com/integradev/delphi/checks/VariableInitializationCheckTest.java
@@ -1237,6 +1237,25 @@ class VariableInitializationCheckTest {
         .verifyNoIssues();
   }
 
+  // See: https://github.com/integrated-application-development/sonar-delphi/issues/297
+  @Test
+  void testIssue297ShouldAddIssue() {
+    CheckVerifier.newVerifier()
+        .withCheck(new VariableInitializationCheck())
+        .onFile(
+            new DelphiTestUnitBuilder()
+                .appendImpl("var")
+                .appendImpl("  SetValues: procedure(Values: Integer); cdecl varargs;")
+                .appendImpl("")
+                .appendImpl("procedure MyProcedure;")
+                .appendImpl("var")
+                .appendImpl("  Value: Integer;")
+                .appendImpl("begin")
+                .appendImpl("  SetValues(Value, Value); // Noncompliant")
+                .appendImpl("end;"))
+        .verifyIssues();
+  }
+
   private static DelphiTestUnitBuilder createSysUtils() {
     return new DelphiTestUnitBuilder()
         .unitName("System.SysUtils")

--- a/delphi-frontend/src/main/antlr3/au/com/integradev/delphi/antlr/Delphi.g
+++ b/delphi-frontend/src/main/antlr3/au/com/integradev/delphi/antlr/Delphi.g
@@ -69,6 +69,8 @@ tokens {
   TkArrayConstructor;
   TkArrayIndices;
   TkArgument;
+  TkAnonymousMethod;
+  TkAnonymousMethodHeading;
 }
 
 @header
@@ -907,8 +909,12 @@ argumentExpression           : expression writeArguments?
                              ;
 writeArguments               : ':'! expression (':'! expression)? // See: https://docwiki.embarcadero.com/Libraries/en/System.Write
                              ;
-anonymousMethod              : PROCEDURE<AnonymousMethodNodeImpl>^ routineParameters? block
-                             | FUNCTION<AnonymousMethodNodeImpl>^ routineParameters? routineReturnType block
+anonymousMethod              : anonymousMethodHeading block -> ^(TkAnonymousMethod<AnonymousMethodNodeImpl> anonymousMethodHeading block)
+                             ;
+anonymousMethodHeading       : PROCEDURE routineParameters? ((';')? interfaceDirective)*
+                             -> ^(TkAnonymousMethodHeading<AnonymousMethodHeadingNodeImpl> PROCEDURE routineParameters? ((';')? interfaceDirective)*)
+                             | FUNCTION routineParameters? routineReturnType ((';')? interfaceDirective)*
+                             -> ^(TkAnonymousMethodHeading<AnonymousMethodHeadingNodeImpl> FUNCTION routineParameters? routineReturnType ((';')? interfaceDirective)*)
                              ;
 expressionOrRange            : expression ('..'<RangeExpressionNodeImpl>^ expression)?
                              ;

--- a/delphi-frontend/src/main/java/au/com/integradev/delphi/antlr/ast/node/AnonymousMethodHeadingNodeImpl.java
+++ b/delphi-frontend/src/main/java/au/com/integradev/delphi/antlr/ast/node/AnonymousMethodHeadingNodeImpl.java
@@ -1,0 +1,84 @@
+/*
+ * Sonar Delphi Plugin
+ * Copyright (C) 2024 Integrated Application Development
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02
+ */
+package au.com.integradev.delphi.antlr.ast.node;
+
+import au.com.integradev.delphi.antlr.ast.visitors.DelphiParserVisitor;
+import com.google.common.collect.ImmutableSet;
+import java.util.Set;
+import org.antlr.runtime.Token;
+import org.sonar.plugins.communitydelphi.api.ast.AnonymousMethodHeadingNode;
+import org.sonar.plugins.communitydelphi.api.ast.DelphiNode;
+import org.sonar.plugins.communitydelphi.api.ast.RoutineParametersNode;
+import org.sonar.plugins.communitydelphi.api.ast.RoutineReturnTypeNode;
+import org.sonar.plugins.communitydelphi.api.symbol.declaration.RoutineDirective;
+import org.sonar.plugins.communitydelphi.api.symbol.declaration.RoutineKind;
+import org.sonar.plugins.communitydelphi.api.token.DelphiToken;
+
+public final class AnonymousMethodHeadingNodeImpl extends DelphiNodeImpl
+    implements AnonymousMethodHeadingNode {
+  private RoutineKind routineKind;
+  private Set<RoutineDirective> directives;
+
+  public AnonymousMethodHeadingNodeImpl(Token token) {
+    super(token);
+  }
+
+  public AnonymousMethodHeadingNodeImpl(int tokenType) {
+    super(tokenType);
+  }
+
+  @Override
+  public <T> T accept(DelphiParserVisitor<T> visitor, T data) {
+    return visitor.visit(this, data);
+  }
+
+  @Override
+  public RoutineParametersNode getRoutineParametersNode() {
+    return getFirstChildOfType(RoutineParametersNode.class);
+  }
+
+  @Override
+  public RoutineReturnTypeNode getReturnTypeNode() {
+    return getFirstChildOfType(RoutineReturnTypeNode.class);
+  }
+
+  @Override
+  public RoutineKind getRoutineKind() {
+    if (routineKind == null) {
+      routineKind = RoutineKind.fromTokenType(getChild(0).getTokenType());
+    }
+    return routineKind;
+  }
+
+  @Override
+  public Set<RoutineDirective> getDirectives() {
+    if (directives == null) {
+      var builder = new ImmutableSet.Builder<RoutineDirective>();
+      for (DelphiNode child : getChildren()) {
+        DelphiToken token = child.getToken();
+        RoutineDirective directive = RoutineDirective.fromToken(token);
+        if (directive != null) {
+          builder.add(directive);
+        }
+      }
+      directives = builder.build();
+    }
+    return directives;
+  }
+}

--- a/delphi-frontend/src/main/java/au/com/integradev/delphi/antlr/ast/node/AnonymousMethodNodeImpl.java
+++ b/delphi-frontend/src/main/java/au/com/integradev/delphi/antlr/ast/node/AnonymousMethodNodeImpl.java
@@ -123,7 +123,8 @@ public final class AnonymousMethodNodeImpl extends ExpressionNodeImpl
     RoutineReturnTypeNode returnTypeNode = getReturnTypeNode();
 
     return ((TypeFactoryImpl) getTypeFactory())
-        .anonymous(
+        .createProcedural(
+            ProceduralKind.ANONYMOUS,
             parameters == null
                 ? Collections.emptyList()
                 : parameters.getParameters().stream()
@@ -131,6 +132,7 @@ public final class AnonymousMethodNodeImpl extends ExpressionNodeImpl
                     .collect(Collectors.toUnmodifiableList()),
             returnTypeNode == null
                 ? TypeFactory.voidType()
-                : returnTypeNode.getTypeNode().getType());
+                : returnTypeNode.getTypeNode().getType(),
+            getDirectives());
   }
 }

--- a/delphi-frontend/src/main/java/au/com/integradev/delphi/antlr/ast/node/AnonymousMethodNodeImpl.java
+++ b/delphi-frontend/src/main/java/au/com/integradev/delphi/antlr/ast/node/AnonymousMethodNodeImpl.java
@@ -22,23 +22,30 @@ import au.com.integradev.delphi.antlr.ast.visitors.DelphiParserVisitor;
 import au.com.integradev.delphi.type.factory.TypeFactoryImpl;
 import au.com.integradev.delphi.type.parameter.FormalParameter;
 import java.util.Collections;
+import java.util.Set;
 import java.util.stream.Collectors;
 import javax.annotation.Nonnull;
 import org.antlr.runtime.Token;
+import org.sonar.plugins.communitydelphi.api.ast.AnonymousMethodHeadingNode;
 import org.sonar.plugins.communitydelphi.api.ast.AnonymousMethodNode;
 import org.sonar.plugins.communitydelphi.api.ast.RoutineParametersNode;
 import org.sonar.plugins.communitydelphi.api.ast.RoutineReturnTypeNode;
+import org.sonar.plugins.communitydelphi.api.symbol.declaration.RoutineDirective;
 import org.sonar.plugins.communitydelphi.api.symbol.declaration.RoutineKind;
 import org.sonar.plugins.communitydelphi.api.type.Type;
+import org.sonar.plugins.communitydelphi.api.type.Type.ProceduralType.ProceduralKind;
 import org.sonar.plugins.communitydelphi.api.type.TypeFactory;
 
 public final class AnonymousMethodNodeImpl extends ExpressionNodeImpl
     implements AnonymousMethodNode {
   private String image;
-  private RoutineKind routineKind;
 
   public AnonymousMethodNodeImpl(Token token) {
     super(token);
+  }
+
+  public AnonymousMethodNodeImpl(int tokenType) {
+    super(tokenType);
   }
 
   @Override
@@ -47,13 +54,18 @@ public final class AnonymousMethodNodeImpl extends ExpressionNodeImpl
   }
 
   @Override
+  public AnonymousMethodHeadingNode getAnonymousMethodHeading() {
+    return (AnonymousMethodHeadingNode) getChild(0);
+  }
+
+  @Override
   public RoutineParametersNode getRoutineParametersNode() {
-    return getFirstChildOfType(RoutineParametersNode.class);
+    return getAnonymousMethodHeading().getRoutineParametersNode();
   }
 
   @Override
   public RoutineReturnTypeNode getReturnTypeNode() {
-    return getFirstChildOfType(RoutineReturnTypeNode.class);
+    return getAnonymousMethodHeading().getReturnTypeNode();
   }
 
   @Override
@@ -63,10 +75,17 @@ public final class AnonymousMethodNodeImpl extends ExpressionNodeImpl
 
   @Override
   public RoutineKind getRoutineKind() {
-    if (routineKind == null) {
-      routineKind = RoutineKind.fromTokenType(getTokenType());
-    }
-    return routineKind;
+    return getAnonymousMethodHeading().getRoutineKind();
+  }
+
+  @Override
+  public Set<RoutineDirective> getDirectives() {
+    return getAnonymousMethodHeading().getDirectives();
+  }
+
+  @Override
+  public boolean hasDirective(RoutineDirective directive) {
+    return getDirectives().contains(directive);
   }
 
   @Override

--- a/delphi-frontend/src/main/java/au/com/integradev/delphi/antlr/ast/node/ProceduralTypeNodeImpl.java
+++ b/delphi-frontend/src/main/java/au/com/integradev/delphi/antlr/ast/node/ProceduralTypeNodeImpl.java
@@ -20,12 +20,14 @@ package au.com.integradev.delphi.antlr.ast.node;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.Set;
 import org.antlr.runtime.Token;
 import org.sonar.plugins.communitydelphi.api.ast.FormalParameterNode.FormalParameterData;
 import org.sonar.plugins.communitydelphi.api.ast.ProceduralTypeNode;
 import org.sonar.plugins.communitydelphi.api.ast.ProcedureTypeHeadingNode;
 import org.sonar.plugins.communitydelphi.api.ast.RoutineParametersNode;
 import org.sonar.plugins.communitydelphi.api.ast.RoutineReturnTypeNode;
+import org.sonar.plugins.communitydelphi.api.symbol.declaration.RoutineDirective;
 import org.sonar.plugins.communitydelphi.api.type.Type;
 import org.sonar.plugins.communitydelphi.api.type.TypeFactory;
 
@@ -52,5 +54,15 @@ public abstract class ProceduralTypeNodeImpl extends TypeNodeImpl implements Pro
   public List<FormalParameterData> getParameters() {
     RoutineParametersNode parametersNode = getHeading().getRoutineParametersNode();
     return parametersNode == null ? Collections.emptyList() : parametersNode.getParameters();
+  }
+
+  @Override
+  public Set<RoutineDirective> getDirectives() {
+    return getHeading().getDirectives();
+  }
+
+  @Override
+  public boolean hasDirective(RoutineDirective directive) {
+    return getDirectives().contains(directive);
   }
 }

--- a/delphi-frontend/src/main/java/au/com/integradev/delphi/antlr/ast/node/ProcedureOfObjectTypeNodeImpl.java
+++ b/delphi-frontend/src/main/java/au/com/integradev/delphi/antlr/ast/node/ProcedureOfObjectTypeNodeImpl.java
@@ -26,6 +26,7 @@ import javax.annotation.Nonnull;
 import org.antlr.runtime.Token;
 import org.sonar.plugins.communitydelphi.api.ast.ProcedureOfObjectTypeNode;
 import org.sonar.plugins.communitydelphi.api.type.Type;
+import org.sonar.plugins.communitydelphi.api.type.Type.ProceduralType.ProceduralKind;
 
 public final class ProcedureOfObjectTypeNodeImpl extends ProceduralTypeNodeImpl
     implements ProcedureOfObjectTypeNode {
@@ -42,10 +43,12 @@ public final class ProcedureOfObjectTypeNodeImpl extends ProceduralTypeNodeImpl
   @Nonnull
   protected Type createType() {
     return ((TypeFactoryImpl) getTypeFactory())
-        .ofObject(
+        .createProcedural(
+            ProceduralKind.PROCEDURE_OF_OBJECT,
             getParameters().stream()
                 .map(FormalParameter::create)
                 .collect(Collectors.toUnmodifiableList()),
-            getReturnType());
+            getReturnType(),
+            getDirectives());
   }
 }

--- a/delphi-frontend/src/main/java/au/com/integradev/delphi/antlr/ast/node/ProcedureReferenceTypeNodeImpl.java
+++ b/delphi-frontend/src/main/java/au/com/integradev/delphi/antlr/ast/node/ProcedureReferenceTypeNodeImpl.java
@@ -26,6 +26,7 @@ import javax.annotation.Nonnull;
 import org.antlr.runtime.Token;
 import org.sonar.plugins.communitydelphi.api.ast.ProcedureReferenceTypeNode;
 import org.sonar.plugins.communitydelphi.api.type.Type;
+import org.sonar.plugins.communitydelphi.api.type.Type.ProceduralType.ProceduralKind;
 
 public final class ProcedureReferenceTypeNodeImpl extends ProceduralTypeNodeImpl
     implements ProcedureReferenceTypeNode {
@@ -42,10 +43,12 @@ public final class ProcedureReferenceTypeNodeImpl extends ProceduralTypeNodeImpl
   @Nonnull
   protected Type createType() {
     return ((TypeFactoryImpl) getTypeFactory())
-        .reference(
+        .createProcedural(
+            ProceduralKind.REFERENCE,
             getParameters().stream()
                 .map(FormalParameter::create)
                 .collect(Collectors.toUnmodifiableList()),
-            getReturnType());
+            getReturnType(),
+            getDirectives());
   }
 }

--- a/delphi-frontend/src/main/java/au/com/integradev/delphi/antlr/ast/node/ProcedureTypeHeadingNodeImpl.java
+++ b/delphi-frontend/src/main/java/au/com/integradev/delphi/antlr/ast/node/ProcedureTypeHeadingNodeImpl.java
@@ -19,15 +19,21 @@
 package au.com.integradev.delphi.antlr.ast.node;
 
 import au.com.integradev.delphi.antlr.ast.visitors.DelphiParserVisitor;
+import com.google.common.collect.ImmutableSet;
+import java.util.Set;
 import javax.annotation.Nullable;
 import org.antlr.runtime.Token;
 import org.sonar.plugins.communitydelphi.api.ast.DelphiNode;
 import org.sonar.plugins.communitydelphi.api.ast.ProcedureTypeHeadingNode;
 import org.sonar.plugins.communitydelphi.api.ast.RoutineParametersNode;
 import org.sonar.plugins.communitydelphi.api.ast.RoutineReturnTypeNode;
+import org.sonar.plugins.communitydelphi.api.symbol.declaration.RoutineDirective;
+import org.sonar.plugins.communitydelphi.api.token.DelphiToken;
 
 public final class ProcedureTypeHeadingNodeImpl extends DelphiNodeImpl
     implements ProcedureTypeHeadingNode {
+  private Set<RoutineDirective> directives;
+
   public ProcedureTypeHeadingNodeImpl(Token token) {
     super(token);
   }
@@ -59,6 +65,22 @@ public final class ProcedureTypeHeadingNodeImpl extends DelphiNodeImpl
   public RoutineReturnTypeNode getRoutineReturnTypeNode() {
     DelphiNode node = getChild(hasRoutineParametersNode() ? 1 : 0);
     return (node instanceof RoutineReturnTypeNode) ? (RoutineReturnTypeNode) node : null;
+  }
+
+  @Override
+  public Set<RoutineDirective> getDirectives() {
+    if (directives == null) {
+      var builder = new ImmutableSet.Builder<RoutineDirective>();
+      for (DelphiNode child : getChildren()) {
+        DelphiToken token = child.getToken();
+        RoutineDirective directive = RoutineDirective.fromToken(token);
+        if (directive != null) {
+          builder.add(directive);
+        }
+      }
+      directives = builder.build();
+    }
+    return directives;
   }
 
   private boolean hasRoutineParametersNode() {

--- a/delphi-frontend/src/main/java/au/com/integradev/delphi/antlr/ast/node/ProcedureTypeNodeImpl.java
+++ b/delphi-frontend/src/main/java/au/com/integradev/delphi/antlr/ast/node/ProcedureTypeNodeImpl.java
@@ -26,6 +26,7 @@ import javax.annotation.Nonnull;
 import org.antlr.runtime.Token;
 import org.sonar.plugins.communitydelphi.api.ast.ProcedureTypeNode;
 import org.sonar.plugins.communitydelphi.api.type.Type;
+import org.sonar.plugins.communitydelphi.api.type.Type.ProceduralType.ProceduralKind;
 
 public final class ProcedureTypeNodeImpl extends ProceduralTypeNodeImpl
     implements ProcedureTypeNode {
@@ -46,10 +47,12 @@ public final class ProcedureTypeNodeImpl extends ProceduralTypeNodeImpl
   @Nonnull
   protected Type createType() {
     return ((TypeFactoryImpl) getTypeFactory())
-        .procedure(
+        .createProcedural(
+            ProceduralKind.PROCEDURE,
             getParameters().stream()
                 .map(FormalParameter::create)
                 .collect(Collectors.toUnmodifiableList()),
-            getReturnType());
+            getReturnType(),
+            getDirectives());
   }
 }

--- a/delphi-frontend/src/main/java/au/com/integradev/delphi/antlr/ast/visitors/DelphiParserVisitor.java
+++ b/delphi-frontend/src/main/java/au/com/integradev/delphi/antlr/ast/visitors/DelphiParserVisitor.java
@@ -23,6 +23,7 @@
 package au.com.integradev.delphi.antlr.ast.visitors;
 
 import org.sonar.plugins.communitydelphi.api.ast.AncestorListNode;
+import org.sonar.plugins.communitydelphi.api.ast.AnonymousMethodHeadingNode;
 import org.sonar.plugins.communitydelphi.api.ast.AnonymousMethodNode;
 import org.sonar.plugins.communitydelphi.api.ast.ArgumentListNode;
 import org.sonar.plugins.communitydelphi.api.ast.ArgumentNode;
@@ -183,6 +184,10 @@ public interface DelphiParserVisitor<T> {
 
   default void visitToken(DelphiToken token, T data) {
     // Do nothing
+  }
+
+  default T visit(AnonymousMethodHeadingNode node, T data) {
+    return visit((DelphiNode) node, data);
   }
 
   default T visit(ArgumentListNode node, T data) {

--- a/delphi-frontend/src/main/java/au/com/integradev/delphi/symbol/declaration/RoutineNameDeclarationImpl.java
+++ b/delphi-frontend/src/main/java/au/com/integradev/delphi/symbol/declaration/RoutineNameDeclarationImpl.java
@@ -52,6 +52,7 @@ import org.sonar.plugins.communitydelphi.api.symbol.declaration.UnitNameDeclarat
 import org.sonar.plugins.communitydelphi.api.type.Parameter;
 import org.sonar.plugins.communitydelphi.api.type.Type;
 import org.sonar.plugins.communitydelphi.api.type.Type.ProceduralType;
+import org.sonar.plugins.communitydelphi.api.type.Type.ProceduralType.ProceduralKind;
 import org.sonar.plugins.communitydelphi.api.type.TypeFactory;
 import org.sonar.plugins.communitydelphi.api.type.TypeSpecializationContext;
 
@@ -112,7 +113,11 @@ public final class RoutineNameDeclarationImpl extends NameDeclarationImpl
         true,
         data.getRoutineKind(),
         ((TypeFactoryImpl) typeFactory)
-            .routine(createParameters(data), data.getReturnType(), data.isVariadic()),
+            .createProcedural(
+                ProceduralKind.ROUTINE,
+                createParameters(data),
+                data.getReturnType(),
+                data.isVariadic() ? Set.of(RoutineDirective.VARARGS) : Collections.emptySet()),
         null,
         VisibilityType.PUBLIC,
         Collections.emptyList(),
@@ -147,7 +152,12 @@ public final class RoutineNameDeclarationImpl extends NameDeclarationImpl
         routine.isClassMethod(),
         isCallable,
         routine.getRoutineKind(),
-        ((TypeFactoryImpl) typeFactory).routine(createParameters(routine), routine.getReturnType()),
+        ((TypeFactoryImpl) typeFactory)
+            .createProcedural(
+                ProceduralKind.ROUTINE,
+                createParameters(routine),
+                routine.getReturnType(),
+                routine.getDirectives()),
         routine.getTypeDeclaration(),
         routine.getVisibility(),
         extractGenericTypeParameters(routine),

--- a/delphi-frontend/src/main/java/au/com/integradev/delphi/type/factory/ProceduralTypeImpl.java
+++ b/delphi-frontend/src/main/java/au/com/integradev/delphi/type/factory/ProceduralTypeImpl.java
@@ -21,7 +21,9 @@ package au.com.integradev.delphi.type.factory;
 import au.com.integradev.delphi.type.generic.GenerifiableTypeImpl;
 import com.google.common.collect.Iterables;
 import java.util.List;
+import java.util.Set;
 import java.util.stream.Collectors;
+import org.sonar.plugins.communitydelphi.api.symbol.declaration.RoutineDirective;
 import org.sonar.plugins.communitydelphi.api.type.Parameter;
 import org.sonar.plugins.communitydelphi.api.type.Type;
 import org.sonar.plugins.communitydelphi.api.type.Type.ProceduralType;
@@ -32,19 +34,19 @@ public final class ProceduralTypeImpl extends GenerifiableTypeImpl implements Pr
   private final ProceduralKind kind;
   private final List<Parameter> parameters;
   private final Type returnType;
-  private final boolean variadic;
+  private final Set<RoutineDirective> directives;
 
   ProceduralTypeImpl(
       int size,
       ProceduralKind kind,
       List<Parameter> parameters,
       Type returnType,
-      boolean variadic) {
+      Set<RoutineDirective> directives) {
     this.size = size;
     this.kind = kind;
     this.parameters = List.copyOf(parameters);
     this.returnType = returnType;
-    this.variadic = variadic;
+    this.directives = directives;
   }
 
   @Override
@@ -93,14 +95,14 @@ public final class ProceduralTypeImpl extends GenerifiableTypeImpl implements Pr
 
   @Override
   public int parametersCount() {
-    return variadic ? 255 : parameters().size();
+    return directives.contains(RoutineDirective.VARARGS) ? 255 : parameters().size();
   }
 
   @Override
   public Parameter getParameter(int index) {
     if (index < parameters().size()) {
       return parameters().get(index);
-    } else if (variadic) {
+    } else if (directives.contains(RoutineDirective.VARARGS)) {
       return Iterables.getLast(parameters());
     }
 
@@ -120,6 +122,11 @@ public final class ProceduralTypeImpl extends GenerifiableTypeImpl implements Pr
   @Override
   public ProceduralKind kind() {
     return kind;
+  }
+
+  @Override
+  public Set<RoutineDirective> directives() {
+    return directives;
   }
 
   @Override
@@ -151,6 +158,6 @@ public final class ProceduralTypeImpl extends GenerifiableTypeImpl implements Pr
             .map(parameter -> parameter.specialize(context))
             .collect(Collectors.toUnmodifiableList()),
         returnType.specialize(context),
-        variadic);
+        directives);
   }
 }

--- a/delphi-frontend/src/main/java/au/com/integradev/delphi/type/factory/TypeFactoryImpl.java
+++ b/delphi-frontend/src/main/java/au/com/integradev/delphi/type/factory/TypeFactoryImpl.java
@@ -43,6 +43,7 @@ import org.sonar.plugins.communitydelphi.api.ast.HelperTypeNode;
 import org.sonar.plugins.communitydelphi.api.ast.Node;
 import org.sonar.plugins.communitydelphi.api.ast.TypeDeclarationNode;
 import org.sonar.plugins.communitydelphi.api.ast.TypeNode;
+import org.sonar.plugins.communitydelphi.api.symbol.declaration.RoutineDirective;
 import org.sonar.plugins.communitydelphi.api.symbol.declaration.TypedDeclaration;
 import org.sonar.plugins.communitydelphi.api.symbol.scope.DelphiScope;
 import org.sonar.plugins.communitydelphi.api.symbol.scope.FileScope;
@@ -378,16 +379,6 @@ public class TypeFactoryImpl implements TypeFactory {
     return null;
   }
 
-  private ProceduralType createProcedural(
-      ProceduralKind kind, List<Parameter> parameters, Type returnType) {
-    return createProcedural(kind, parameters, returnType, false);
-  }
-
-  private ProceduralType createProcedural(
-      ProceduralKind kind, List<Parameter> parameters, Type returnType, boolean variadic) {
-    return new ProceduralTypeImpl(proceduralSize(kind), kind, parameters, returnType, variadic);
-  }
-
   @Override
   public Type getIntrinsic(IntrinsicType intrinsic) {
     return intrinsicTypes.get(intrinsic);
@@ -492,30 +483,6 @@ public class TypeFactoryImpl implements TypeFactory {
     return new ClassReferenceTypeImpl(image, type, pointerSize());
   }
 
-  public ProceduralType procedure(List<Parameter> parameters, Type returnType) {
-    return createProcedural(ProceduralKind.PROCEDURE, parameters, returnType);
-  }
-
-  public ProceduralType ofObject(List<Parameter> parameters, Type returnType) {
-    return createProcedural(ProceduralKind.PROCEDURE_OF_OBJECT, parameters, returnType);
-  }
-
-  public ProceduralType reference(List<Parameter> parameters, Type returnType) {
-    return createProcedural(ProceduralKind.REFERENCE, parameters, returnType);
-  }
-
-  public ProceduralType anonymous(List<Parameter> parameters, Type returnType) {
-    return createProcedural(ProceduralKind.ANONYMOUS, parameters, returnType);
-  }
-
-  public ProceduralType routine(List<Parameter> parameters, Type returnType) {
-    return createProcedural(ProceduralKind.ROUTINE, parameters, returnType);
-  }
-
-  public ProceduralType routine(List<Parameter> parameters, Type returnType, boolean variadic) {
-    return createProcedural(ProceduralKind.ROUTINE, parameters, returnType, variadic);
-  }
-
   @Override
   public AliasType strongAlias(String image, Type aliased) {
     return typeAliasGenerator.generate(image, aliased, true);
@@ -524,6 +491,14 @@ public class TypeFactoryImpl implements TypeFactory {
   @Override
   public AliasType weakAlias(String image, Type aliased) {
     return typeAliasGenerator.generate(image, aliased, false);
+  }
+
+  public ProceduralType createProcedural(
+      ProceduralKind kind,
+      List<Parameter> parameters,
+      Type returnType,
+      Set<RoutineDirective> directives) {
+    return new ProceduralTypeImpl(proceduralSize(kind), kind, parameters, returnType, directives);
   }
 
   public StructType struct(TypeNode node) {

--- a/delphi-frontend/src/main/java/org/sonar/plugins/communitydelphi/api/ast/AnonymousMethodHeadingNode.java
+++ b/delphi-frontend/src/main/java/org/sonar/plugins/communitydelphi/api/ast/AnonymousMethodHeadingNode.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Delphi Plugin
- * Copyright (C) 2023 Integrated Application Development
+ * Copyright (C) 2024 Integrated Application Development
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -21,24 +21,13 @@ package org.sonar.plugins.communitydelphi.api.ast;
 import java.util.Set;
 import org.sonar.plugins.communitydelphi.api.symbol.declaration.RoutineDirective;
 import org.sonar.plugins.communitydelphi.api.symbol.declaration.RoutineKind;
-import org.sonar.plugins.communitydelphi.api.type.Type;
 
-public interface AnonymousMethodNode extends ExpressionNode {
-  AnonymousMethodHeadingNode getAnonymousMethodHeading();
-
+public interface AnonymousMethodHeadingNode extends DelphiNode {
   RoutineParametersNode getRoutineParametersNode();
 
   RoutineReturnTypeNode getReturnTypeNode();
 
-  Type getReturnType();
-
   RoutineKind getRoutineKind();
 
   Set<RoutineDirective> getDirectives();
-
-  boolean hasDirective(RoutineDirective directive);
-
-  boolean isFunction();
-
-  boolean isProcedure();
 }

--- a/delphi-frontend/src/main/java/org/sonar/plugins/communitydelphi/api/ast/ProceduralTypeNode.java
+++ b/delphi-frontend/src/main/java/org/sonar/plugins/communitydelphi/api/ast/ProceduralTypeNode.java
@@ -19,11 +19,17 @@
 package org.sonar.plugins.communitydelphi.api.ast;
 
 import java.util.List;
+import java.util.Set;
 import org.sonar.plugins.communitydelphi.api.ast.FormalParameterNode.FormalParameterData;
+import org.sonar.plugins.communitydelphi.api.symbol.declaration.RoutineDirective;
 import org.sonar.plugins.communitydelphi.api.type.Type;
 
 public interface ProceduralTypeNode extends TypeNode {
   Type getReturnType();
 
   List<FormalParameterData> getParameters();
+
+  Set<RoutineDirective> getDirectives();
+
+  boolean hasDirective(RoutineDirective directive);
 }

--- a/delphi-frontend/src/main/java/org/sonar/plugins/communitydelphi/api/ast/ProcedureTypeHeadingNode.java
+++ b/delphi-frontend/src/main/java/org/sonar/plugins/communitydelphi/api/ast/ProcedureTypeHeadingNode.java
@@ -18,7 +18,9 @@
  */
 package org.sonar.plugins.communitydelphi.api.ast;
 
+import java.util.Set;
 import javax.annotation.Nullable;
+import org.sonar.plugins.communitydelphi.api.symbol.declaration.RoutineDirective;
 
 public interface ProcedureTypeHeadingNode extends DelphiNode {
   @Nullable
@@ -26,4 +28,6 @@ public interface ProcedureTypeHeadingNode extends DelphiNode {
 
   @Nullable
   RoutineReturnTypeNode getRoutineReturnTypeNode();
+
+  Set<RoutineDirective> getDirectives();
 }

--- a/delphi-frontend/src/main/java/org/sonar/plugins/communitydelphi/api/type/Type.java
+++ b/delphi-frontend/src/main/java/org/sonar/plugins/communitydelphi/api/type/Type.java
@@ -21,6 +21,7 @@ package org.sonar.plugins.communitydelphi.api.type;
 import java.math.BigInteger;
 import java.util.List;
 import java.util.Set;
+import org.sonar.plugins.communitydelphi.api.symbol.declaration.RoutineDirective;
 import org.sonar.plugins.communitydelphi.api.symbol.scope.DelphiScope;
 
 public interface Type {
@@ -502,6 +503,13 @@ public interface Type {
      * @return Procedural kind
      */
     ProceduralKind kind();
+
+    /**
+     * The routine directives declared on this procedural type
+     *
+     * @return Routine directives
+     */
+    Set<RoutineDirective> directives();
   }
 
   interface FileType extends Type {

--- a/delphi-frontend/src/test/java/au/com/integradev/delphi/symbol/declaration/RoutineNameDeclarationTest.java
+++ b/delphi-frontend/src/test/java/au/com/integradev/delphi/symbol/declaration/RoutineNameDeclarationTest.java
@@ -39,6 +39,7 @@ import org.sonar.plugins.communitydelphi.api.symbol.scope.DelphiScope;
 import org.sonar.plugins.communitydelphi.api.type.Parameter;
 import org.sonar.plugins.communitydelphi.api.type.Type;
 import org.sonar.plugins.communitydelphi.api.type.Type.ProceduralType;
+import org.sonar.plugins.communitydelphi.api.type.Type.ProceduralType.ProceduralKind;
 import org.sonar.plugins.communitydelphi.api.type.TypeFactory;
 
 class RoutineNameDeclarationTest {
@@ -52,7 +53,12 @@ class RoutineNameDeclarationTest {
   private static final boolean IS_CALLABLE = true;
   private static final RoutineKind KIND = RoutineKind.PROCEDURE;
   private static final ProceduralType ROUTINE_TYPE =
-      ((TypeFactoryImpl) FACTORY).routine(List.of(mock(Parameter.class)), RETURN_TYPE);
+      ((TypeFactoryImpl) FACTORY)
+          .createProcedural(
+              ProceduralKind.ROUTINE,
+              List.of(mock(Parameter.class)),
+              RETURN_TYPE,
+              Collections.emptySet());
   private static final TypeNameDeclaration TYPE_NAME_DECLARATION =
       new TypeNameDeclarationImpl(
           SymbolicNode.imaginary("Baz", DelphiScope.unknownScope()),
@@ -227,7 +233,12 @@ class RoutineNameDeclarationTest {
             IS_CLASS_INVOCABLE,
             IS_CALLABLE,
             KIND,
-            ((TypeFactoryImpl) FACTORY).routine(Collections.emptyList(), TypeFactory.untypedType()),
+            ((TypeFactoryImpl) FACTORY)
+                .createProcedural(
+                    ProceduralKind.ROUTINE,
+                    Collections.emptyList(),
+                    TypeFactory.untypedType(),
+                    Collections.emptySet()),
             TYPE_NAME_DECLARATION,
             VISIBILITY,
             TYPE_PARAMETERS,

--- a/delphi-frontend/src/test/java/au/com/integradev/delphi/symbol/resolve/TypeComparerTest.java
+++ b/delphi-frontend/src/test/java/au/com/integradev/delphi/symbol/resolve/TypeComparerTest.java
@@ -67,6 +67,7 @@ import org.sonar.plugins.communitydelphi.api.type.Type.EnumType;
 import org.sonar.plugins.communitydelphi.api.type.Type.FileType;
 import org.sonar.plugins.communitydelphi.api.type.Type.PointerType;
 import org.sonar.plugins.communitydelphi.api.type.Type.ProceduralType;
+import org.sonar.plugins.communitydelphi.api.type.Type.ProceduralType.ProceduralKind;
 import org.sonar.plugins.communitydelphi.api.type.Type.StructType;
 import org.sonar.plugins.communitydelphi.api.type.Type.SubrangeType;
 import org.sonar.plugins.communitydelphi.api.type.TypeFactory;
@@ -773,20 +774,24 @@ class TypeComparerTest {
 
   private static ProceduralType procedure(List<Type> parameterTypes, Type returnType) {
     return ((TypeFactoryImpl) FACTORY)
-        .procedure(
+        .createProcedural(
+            ProceduralKind.PROCEDURE,
             parameterTypes.stream()
                 .map(TypeMocker::parameter)
                 .collect(Collectors.toUnmodifiableList()),
-            returnType);
+            returnType,
+            Collections.emptySet());
   }
 
   private static ProceduralType anonymous(List<Type> parameterTypes, Type returnType) {
     return ((TypeFactoryImpl) FACTORY)
-        .anonymous(
+        .createProcedural(
+            ProceduralKind.ANONYMOUS,
             parameterTypes.stream()
                 .map(TypeMocker::parameter)
                 .collect(Collectors.toUnmodifiableList()),
-            returnType);
+            returnType,
+            Collections.emptySet());
   }
 
   private static AnsiStringType ansiString(int codePage) {

--- a/delphi-frontend/src/test/java/au/com/integradev/delphi/symbol/resolve/TypeInferrerTest.java
+++ b/delphi-frontend/src/test/java/au/com/integradev/delphi/symbol/resolve/TypeInferrerTest.java
@@ -47,6 +47,7 @@ import org.sonar.plugins.communitydelphi.api.ast.CommonDelphiNode;
 import org.sonar.plugins.communitydelphi.api.ast.ExpressionNode;
 import org.sonar.plugins.communitydelphi.api.type.IntrinsicType;
 import org.sonar.plugins.communitydelphi.api.type.Type;
+import org.sonar.plugins.communitydelphi.api.type.Type.ProceduralType.ProceduralKind;
 import org.sonar.plugins.communitydelphi.api.type.TypeFactory;
 
 class TypeInferrerTest {
@@ -274,7 +275,9 @@ class TypeInferrerTest {
   }
 
   private static ExpressionNode procedural(Type returnType) {
-    return genericExpression(TYPE_FACTORY.routine(Collections.emptyList(), returnType));
+    return genericExpression(
+        TYPE_FACTORY.createProcedural(
+            ProceduralKind.ROUTINE, Collections.emptyList(), returnType, Collections.emptySet()));
   }
 
   private static ExpressionNode genericExpression(IntrinsicType type) {

--- a/delphi-frontend/src/test/java/au/com/integradev/delphi/type/factory/TypeAliasGeneratorTest.java
+++ b/delphi-frontend/src/test/java/au/com/integradev/delphi/type/factory/TypeAliasGeneratorTest.java
@@ -27,6 +27,7 @@ import au.com.integradev.delphi.type.UnresolvedTypeImpl;
 import au.com.integradev.delphi.type.generic.TypeParameterTypeImpl;
 import au.com.integradev.delphi.utils.types.TypeFactoryUtils;
 import au.com.integradev.delphi.utils.types.TypeMocker;
+import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 import java.util.function.Function;
@@ -54,6 +55,7 @@ import org.sonar.plugins.communitydelphi.api.type.Type.HelperType;
 import org.sonar.plugins.communitydelphi.api.type.Type.IntegerType;
 import org.sonar.plugins.communitydelphi.api.type.Type.PointerType;
 import org.sonar.plugins.communitydelphi.api.type.Type.ProceduralType;
+import org.sonar.plugins.communitydelphi.api.type.Type.ProceduralType.ProceduralKind;
 import org.sonar.plugins.communitydelphi.api.type.Type.RealType;
 import org.sonar.plugins.communitydelphi.api.type.Type.ScopedType;
 import org.sonar.plugins.communitydelphi.api.type.Type.StringType;
@@ -86,16 +88,36 @@ class TypeAliasGeneratorTest {
           Arguments.of(FACTORY.untypedPointer(), PointerType.class),
           Arguments.of(FACTORY.pointerTo(ALIASED_NAME, BYTE), PointerType.class),
           Arguments.of(
-              ((TypeFactoryImpl) FACTORY).procedure(List.of(TypeMocker.parameter(BYTE)), BYTE),
+              ((TypeFactoryImpl) FACTORY)
+                  .createProcedural(
+                      ProceduralKind.PROCEDURE,
+                      List.of(TypeMocker.parameter(BYTE)),
+                      BYTE,
+                      Collections.emptySet()),
               ProceduralType.class),
           Arguments.of(
-              ((TypeFactoryImpl) FACTORY).ofObject(List.of(TypeMocker.parameter(BYTE)), BYTE),
+              ((TypeFactoryImpl) FACTORY)
+                  .createProcedural(
+                      ProceduralKind.PROCEDURE_OF_OBJECT,
+                      List.of(TypeMocker.parameter(BYTE)),
+                      BYTE,
+                      Collections.emptySet()),
               ProceduralType.class),
           Arguments.of(
-              ((TypeFactoryImpl) FACTORY).routine(List.of(TypeMocker.parameter(BYTE)), BYTE),
+              ((TypeFactoryImpl) FACTORY)
+                  .createProcedural(
+                      ProceduralKind.ROUTINE,
+                      List.of(TypeMocker.parameter(BYTE)),
+                      BYTE,
+                      Collections.emptySet()),
               ProceduralType.class),
           Arguments.of(
-              ((TypeFactoryImpl) FACTORY).anonymous(List.of(TypeMocker.parameter(BYTE)), BYTE),
+              ((TypeFactoryImpl) FACTORY)
+                  .createProcedural(
+                      ProceduralKind.ANONYMOUS,
+                      List.of(TypeMocker.parameter(BYTE)),
+                      BYTE,
+                      Collections.emptySet()),
               ProceduralType.class),
           Arguments.of(FACTORY.untypedFile(), FileType.class),
           Arguments.of(FACTORY.fileOf(BYTE), FileType.class),

--- a/delphi-frontend/src/test/resources/au/com/integradev/delphi/grammar/AnonymousMethods.pas
+++ b/delphi-frontend/src/test/resources/au/com/integradev/delphi/grammar/AnonymousMethods.pas
@@ -32,4 +32,13 @@ begin
     end)(aValue);
 end;
 
+function IsStringEmptyWithCallingConvention(const aValue : string) : Boolean;
+begin
+  Result := StringMatches(aValue,
+    function(const aValue : string) : Boolean register
+    begin
+      Result := aValue = '';
+    end);
+end;
+
 end.


### PR DESCRIPTION
This PR makes a few improvements:
* fixes parsing errors on anonymous methods with routine directives
* fixes an issue where non-routine procedural types (procvars, anonymous methods, etc.) could never be considered variadic
  * which fixes a downstream `IndexOutOfBoundsException` that surfaced in the `VariableInitialization` rule 
* tidies the AST a bit around anonymous methods by introducing `AnonymousMethodHeadingNode`
* persists routine directives into `ProcedureType`

Fixes #172 and #297.