### PR TITLE
Fix parsing errors on `implementation` keywords in conditional branches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Parsing errors on `implementation` keywords nested in conditional branches.
+
 ## [1.10.0] - 2024-10-01
 
 ### Added

--- a/delphi-frontend/src/main/antlr3/au/com/integradev/delphi/antlr/Delphi.g
+++ b/delphi-frontend/src/main/antlr3/au/com/integradev/delphi/antlr/Delphi.g
@@ -122,6 +122,7 @@ import au.com.integradev.delphi.antlr.ast.node.*;
 
 package au.com.integradev.delphi.antlr;
 
+import org.apache.commons.lang3.StringUtils;
 }
 
 @lexer::members {
@@ -1503,9 +1504,9 @@ COMMENT                 :  '//' ~('\n'|'\r')*                          {$channel
 
                               if ($text.startsWith(start + "\$")) {
                                 $type = TkCompilerDirective;
-                                if ($text.startsWith(start + "\$endif") || $text.startsWith(start + "\$ifend")) {
+                                if (StringUtils.startsWithIgnoreCase($text, start + "\$endif") || StringUtils.startsWithIgnoreCase($text, start + "\$ifend")) {
                                   --directiveNesting;
-                                } else if ($text.startsWith(start + "\$if")) {
+                                } else if (StringUtils.startsWithIgnoreCase($text, start + "\$if")) {
                                   ++directiveNesting;
                                 }
                               }

--- a/delphi-frontend/src/test/java/au/com/integradev/delphi/file/DelphiFileTest.java
+++ b/delphi-frontend/src/test/java/au/com/integradev/delphi/file/DelphiFileTest.java
@@ -18,8 +18,7 @@
  */
 package au.com.integradev.delphi.file;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.*;
 
 import au.com.integradev.delphi.compiler.Platform;
 import au.com.integradev.delphi.core.Delphi;
@@ -36,6 +35,8 @@ import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.util.Collections;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.sonar.api.batch.fs.InputFile;
 import org.sonar.api.batch.fs.internal.TestInputFileBuilder;
 
@@ -105,5 +106,22 @@ class DelphiFileTest {
     DelphiFile delphiFile = DelphiFile.from(file, config);
     String firstLine = delphiFile.getSourceCodeFileLines().get(0);
     assertThat(firstLine).doesNotStartWith("\ufeff");
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {"SkipImplementation.pas", "SkipImplementationWithDirectiveNesting.pas"})
+  void testShouldSkipImplementation(String filename) {
+    File file = DelphiUtils.getResource("/au/com/integradev/delphi/file/" + filename);
+
+    DelphiFileConfig config =
+        DelphiFile.createConfig(
+            StandardCharsets.UTF_8.name(),
+            new DelphiPreprocessorFactory(Platform.WINDOWS),
+            TypeFactoryUtils.defaultFactory(),
+            SearchPath.create(Collections.emptyList()),
+            Collections.emptySet(),
+            true);
+
+    assertThatNoException().isThrownBy(() -> DelphiFile.from(file, config));
   }
 }

--- a/delphi-frontend/src/test/resources/au/com/integradev/delphi/file/SkipImplementation.pas
+++ b/delphi-frontend/src/test/resources/au/com/integradev/delphi/file/SkipImplementation.pas
@@ -1,0 +1,9 @@
+﻿unit SkipImplementation;
+
+interface
+
+implementation
+
+ERROR
+
+end.

--- a/delphi-frontend/src/test/resources/au/com/integradev/delphi/file/SkipImplementationWithDirectiveNesting.pas
+++ b/delphi-frontend/src/test/resources/au/com/integradev/delphi/file/SkipImplementationWithDirectiveNesting.pas
@@ -1,0 +1,14 @@
+﻿unit SkipImplementationWithDirectiveNesting;
+
+interface
+
+{$If False}
+type
+  TFoo = ERROR class
+  emd;
+implementation
+{$eLsE}
+implementation
+{$endif}
+
+end.


### PR DESCRIPTION
In 50726816e318afb456ad0d04fcb2acb22cdf1478, we implemented keyword case-insensitivity directly into the grammar. This gave us a small performance boost, but quietly impaired our ability to track `directiveNesting` while lexing a source file.

We were using the case-sensitive `String#startsWith` to check for a particular compiler directive while lexing the token, which used to work because the input actually was lowercase before. Now, we need to do a case-insensitive comparison because the input is using the original casing.

This `directiveNesting` issue introduced some subtle issues in cases where:
- we're only parsing the interface of a file (skipping the `implementation` section
- `implementation` keywords are nested within conditional directives (`$IF(DEF)`, `$SLSE`)
- the conditional directives are not lowercase

Fixes #299.