### PR TITLE
Reduce duplication around `getDirectives` methods

### DIFF
--- a/delphi-frontend/src/main/java/au/com/integradev/delphi/antlr/ast/node/AnonymousMethodHeadingNodeImpl.java
+++ b/delphi-frontend/src/main/java/au/com/integradev/delphi/antlr/ast/node/AnonymousMethodHeadingNodeImpl.java
@@ -18,17 +18,15 @@
  */
 package au.com.integradev.delphi.antlr.ast.node;
 
+import au.com.integradev.delphi.antlr.ast.node.utils.RoutineDirectiveUtils;
 import au.com.integradev.delphi.antlr.ast.visitors.DelphiParserVisitor;
-import com.google.common.collect.ImmutableSet;
 import java.util.Set;
 import org.antlr.runtime.Token;
 import org.sonar.plugins.communitydelphi.api.ast.AnonymousMethodHeadingNode;
-import org.sonar.plugins.communitydelphi.api.ast.DelphiNode;
 import org.sonar.plugins.communitydelphi.api.ast.RoutineParametersNode;
 import org.sonar.plugins.communitydelphi.api.ast.RoutineReturnTypeNode;
 import org.sonar.plugins.communitydelphi.api.symbol.declaration.RoutineDirective;
 import org.sonar.plugins.communitydelphi.api.symbol.declaration.RoutineKind;
-import org.sonar.plugins.communitydelphi.api.token.DelphiToken;
 
 public final class AnonymousMethodHeadingNodeImpl extends DelphiNodeImpl
     implements AnonymousMethodHeadingNode {
@@ -69,15 +67,7 @@ public final class AnonymousMethodHeadingNodeImpl extends DelphiNodeImpl
   @Override
   public Set<RoutineDirective> getDirectives() {
     if (directives == null) {
-      var builder = new ImmutableSet.Builder<RoutineDirective>();
-      for (DelphiNode child : getChildren()) {
-        DelphiToken token = child.getToken();
-        RoutineDirective directive = RoutineDirective.fromToken(token);
-        if (directive != null) {
-          builder.add(directive);
-        }
-      }
-      directives = builder.build();
+      directives = RoutineDirectiveUtils.getDirectives(this);
     }
     return directives;
   }

--- a/delphi-frontend/src/main/java/au/com/integradev/delphi/antlr/ast/node/RoutineHeadingNodeImpl.java
+++ b/delphi-frontend/src/main/java/au/com/integradev/delphi/antlr/ast/node/RoutineHeadingNodeImpl.java
@@ -18,14 +18,13 @@
  */
 package au.com.integradev.delphi.antlr.ast.node;
 
+import au.com.integradev.delphi.antlr.ast.node.utils.RoutineDirectiveUtils;
 import au.com.integradev.delphi.antlr.ast.visitors.DelphiParserVisitor;
-import com.google.common.collect.ImmutableSet;
 import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 import org.antlr.runtime.Token;
 import org.sonar.plugins.communitydelphi.api.ast.AttributeListNode;
-import org.sonar.plugins.communitydelphi.api.ast.DelphiNode;
 import org.sonar.plugins.communitydelphi.api.ast.FormalParameterNode.FormalParameterData;
 import org.sonar.plugins.communitydelphi.api.ast.RoutineDeclarationNode;
 import org.sonar.plugins.communitydelphi.api.ast.RoutineHeadingNode;
@@ -36,7 +35,6 @@ import org.sonar.plugins.communitydelphi.api.ast.RoutineReturnTypeNode;
 import org.sonar.plugins.communitydelphi.api.ast.TypeDeclarationNode;
 import org.sonar.plugins.communitydelphi.api.symbol.declaration.RoutineDirective;
 import org.sonar.plugins.communitydelphi.api.symbol.declaration.RoutineKind;
-import org.sonar.plugins.communitydelphi.api.token.DelphiToken;
 import org.sonar.plugins.communitydelphi.api.token.DelphiTokenType;
 import org.sonar.plugins.communitydelphi.api.type.Type;
 
@@ -194,15 +192,7 @@ public final class RoutineHeadingNodeImpl extends DelphiNodeImpl implements Rout
   @Override
   public Set<RoutineDirective> getDirectives() {
     if (directives == null) {
-      var builder = new ImmutableSet.Builder<RoutineDirective>();
-      for (DelphiNode child : getChildren()) {
-        DelphiToken token = child.getToken();
-        RoutineDirective directive = RoutineDirective.fromToken(token);
-        if (directive != null) {
-          builder.add(directive);
-        }
-      }
-      directives = builder.build();
+      directives = RoutineDirectiveUtils.getDirectives(this);
     }
     return directives;
   }

--- a/delphi-frontend/src/main/java/au/com/integradev/delphi/antlr/ast/node/utils/RoutineDirectiveUtils.java
+++ b/delphi-frontend/src/main/java/au/com/integradev/delphi/antlr/ast/node/utils/RoutineDirectiveUtils.java
@@ -1,0 +1,43 @@
+/*
+ * Sonar Delphi Plugin
+ * Copyright (C) 2024 Integrated Application Development
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02
+ */
+package au.com.integradev.delphi.antlr.ast.node.utils;
+
+import com.google.common.collect.ImmutableSet;
+import java.util.Set;
+import org.sonar.plugins.communitydelphi.api.ast.DelphiNode;
+import org.sonar.plugins.communitydelphi.api.symbol.declaration.RoutineDirective;
+import org.sonar.plugins.communitydelphi.api.token.DelphiToken;
+
+public final class RoutineDirectiveUtils {
+  private RoutineDirectiveUtils() {
+    // Utility class
+  }
+
+  public static Set<RoutineDirective> getDirectives(DelphiNode node) {
+    var builder = new ImmutableSet.Builder<RoutineDirective>();
+    for (DelphiNode child : node.getChildren()) {
+      DelphiToken token = child.getToken();
+      RoutineDirective directive = RoutineDirective.fromToken(token);
+      if (directive != null) {
+        builder.add(directive);
+      }
+    }
+    return builder.build();
+  }
+}


### PR DESCRIPTION
There's a bit of shared (copy-pasted) code between `AnonymousMethodHeadingNodeImpl` and `RoutineHeadingNodeImpl` around constructing a set of routine directives based on child nodes.

This PR pulls that shared code out into a small util.