### PR TITLE
Add an ignore list to MixedNames

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `RedundantJump` analysis rule, which flags redundant jump statements, e.g., `Continue`, `Exit`.
 - `LoopExecutingAtMostOnce` analysis rule, which flags loop statements that can execute at most once.
+- `excludedNames` rule property to the `MixedNames` rule.
 - **API:** `RepeatStatementNode::getGuardExpression` method.
 - **API:** `RepeatStatementNode::getStatementList` method.
 - **API:** `CaseStatementNode::getSelectorExpression` method.

--- a/delphi-checks/src/test/java/au/com/integradev/delphi/checks/MixedNamesCheckTest.java
+++ b/delphi-checks/src/test/java/au/com/integradev/delphi/checks/MixedNamesCheckTest.java
@@ -23,8 +23,47 @@ import au.com.integradev.delphi.checks.verifier.CheckVerifier;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
+import org.sonar.plugins.communitydelphi.api.check.DelphiCheck;
 
 class MixedNamesCheckTest {
+  private static DelphiCheck createCheck() {
+    MixedNamesCheck check = new MixedNamesCheck();
+    check.excludedNames = "Foo,Bar";
+    return check;
+  }
+
+  @Test
+  void testNamesInExcludedListShouldNotAddIssue() {
+    CheckVerifier.newVerifier()
+        .withCheck(createCheck())
+        .onFile(
+            new DelphiTestUnitBuilder()
+                .appendImpl("procedure Test;")
+                .appendImpl("var")
+                .appendImpl("  Foo: Boolean;")
+                .appendImpl("  Bar: Boolean;")
+                .appendImpl("begin")
+                .appendImpl("  foo := True;")
+                .appendImpl("  BAR := True;")
+                .appendImpl("end;"))
+        .verifyNoIssues();
+  }
+
+  @Test
+  void testDifferentlyCasedNameFromExcludedListShouldNotAddIssue() {
+    CheckVerifier.newVerifier()
+        .withCheck(createCheck())
+        .onFile(
+            new DelphiTestUnitBuilder()
+                .appendImpl("procedure Test;")
+                .appendImpl("var")
+                .appendImpl("  FOO: Boolean;")
+                .appendImpl("begin")
+                .appendImpl("  foo := True;")
+                .appendImpl("end;"))
+        .verifyNoIssues();
+  }
+
   @Test
   void testMatchingVarNamesShouldNotAddIssue() {
     CheckVerifier.newVerifier()


### PR DESCRIPTION
This PR adds a setting on MixedNames rule to ignore certain names.

This PR implements a suggestion I have for MixedNames rule. In my company, we have certain patterns in names, so in some cases it's suggested by the rule to comply with the definition, and ends up not being compliant with our pattern. I think it would be good to have a list for names to be ignored.

For example, sometimes the rules suggest to be WParam, and sometimes WPARAM, due to the definition. If we have a pattern to always be WParam, this addition could help to ignore WParam name, and don't raise any issues.

It's up to you to know if this is a desired feature or not.