### PR TITLE
Fix parsing errors on semicolon-delimited generic type parameters in routine implementation headers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Parsing errors on semicolon-delimited generic type parameters in routine implementation headers.
 - Incorrect return types for `Length`, `High`, and `Low` on open/dynamic arrays depending on the
   compiler version and toolchain.
 

--- a/delphi-frontend/src/main/antlr3/au/com/integradev/delphi/antlr/Delphi.g
+++ b/delphi-frontend/src/main/antlr3/au/com/integradev/delphi/antlr/Delphi.g
@@ -724,7 +724,12 @@ genericConstraint            : typeReference
                              | CONSTRUCTOR
                              ;
 genericArguments             : '<' typeReferenceOrStringOrFile (',' typeReferenceOrStringOrFile)* '>'
-                             -> ^(TkGenericArguments<GenericArgumentsNodeImpl> typeReferenceOrStringOrFile typeReferenceOrStringOrFile*)
+                             -> ^(TkGenericArguments<GenericArgumentsNodeImpl> '<' typeReferenceOrStringOrFile (',' typeReferenceOrStringOrFile)* '>')
+                             ;
+routineNameGenericArguments  : '<' typeReferenceOrStringOrFile (commaOrSemicolon typeReferenceOrStringOrFile)* '>'
+                             -> ^(TkGenericArguments<GenericArgumentsNodeImpl> '<' typeReferenceOrStringOrFile (commaOrSemicolon typeReferenceOrStringOrFile)* '>')
+                             ;
+commaOrSemicolon             : ',' | ';'
                              ;
 
 //----------------------------------------------------------------------------
@@ -810,7 +815,7 @@ routineDeclarationName       : (
                              )
                              -> ^(TkRoutineName<RoutineNameNodeImpl> $decl)
                              ;
-routineImplementationName    : nameReference -> ^(TkRoutineName<RoutineNameNodeImpl> nameReference)
+routineImplementationName    : routineNameReference -> ^(TkRoutineName<RoutineNameNodeImpl> routineNameReference)
                              ;
 routineKey                   : PROCEDURE
                              | CONSTRUCTOR
@@ -1181,6 +1186,12 @@ simpleNameReference          : ident
                              ;
 extendedNameReference        : extendedIdent genericArguments? ('.' extendedNameReference)?
                              -> ^(TkNameReference<NameReferenceNodeImpl> extendedIdent genericArguments? ('.' extendedNameReference)?)
+                             ;
+routineNameReference         : ident routineNameGenericArguments? ('.' extendedRoutineNameReference)?
+                             -> ^(TkNameReference<NameReferenceNodeImpl> ident routineNameGenericArguments? ('.' extendedRoutineNameReference)?)
+                             ;
+extendedRoutineNameReference : extendedIdent routineNameGenericArguments? ('.' extendedRoutineNameReference)?
+                             -> ^(TkNameReference<NameReferenceNodeImpl> extendedIdent routineNameGenericArguments? ('.' extendedRoutineNameReference)?)
                              ;
 extendedIdent                : ident
                              | keywords -> ^({changeTokenType(TkIdentifier)})

--- a/delphi-frontend/src/test/java/au/com/integradev/delphi/antlr/GrammarTest.java
+++ b/delphi-frontend/src/test/java/au/com/integradev/delphi/antlr/GrammarTest.java
@@ -348,4 +348,9 @@ class GrammarTest {
   void testConditionalAsm() {
     assertParsed("ConditionalAsm.pas");
   }
+
+  @Test
+  void testSemicolonSeparatedGenericArguments() {
+    assertParsed("SemicolonSeparatedGenericArguments.pas");
+  }
 }

--- a/delphi-frontend/src/test/resources/au/com/integradev/delphi/grammar/SemicolonSeparatedGenericArguments.pas
+++ b/delphi-frontend/src/test/resources/au/com/integradev/delphi/grammar/SemicolonSeparatedGenericArguments.pas
@@ -1,0 +1,17 @@
+unit SemicolonSeparatedGenericArguments;
+
+interface
+
+implementation
+
+type
+  TFoo = class
+    class procedure Bar<T; C>;
+  end;
+
+class procedure TFoo.Bar<T; C>;
+begin
+  // ...
+end;
+
+end.


### PR DESCRIPTION
Previously, only comma-delimited type parameters were parsing correctly.

Fixes #302.