### PR TITLE
Expose URI of the analyzed file through `DelphiCheckContext::getUri`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **API:** `DelphiCheckContext::getUri` method.
+
 ### Fixed
 
 - Parsing errors on semicolon-delimited generic type parameters in routine implementation headers.

--- a/delphi-checks-testkit/src/main/java/au/com/integradev/delphi/checks/verifier/DelphiCheckContextTester.java
+++ b/delphi-checks-testkit/src/main/java/au/com/integradev/delphi/checks/verifier/DelphiCheckContextTester.java
@@ -22,6 +22,7 @@ import au.com.integradev.delphi.check.MasterCheckRegistrar;
 import au.com.integradev.delphi.file.DelphiFile.DelphiInputFile;
 import au.com.integradev.delphi.preprocessor.CompilerSwitchRegistry;
 import au.com.integradev.delphi.reporting.DelphiIssueBuilderImpl;
+import java.net.URI;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
@@ -56,6 +57,11 @@ class DelphiCheckContextTester implements DelphiCheckContext {
     this.delphiFile = delphiFile;
     this.compilerDirectiveParser = compilerDirectiveParser;
     this.checkRegistrar = checkRegistrar;
+  }
+
+  @Override
+  public URI getUri() {
+    return delphiFile.getInputFile().uri();
   }
 
   @Override

--- a/delphi-frontend/src/main/java/au/com/integradev/delphi/check/DelphiCheckContextImpl.java
+++ b/delphi-frontend/src/main/java/au/com/integradev/delphi/check/DelphiCheckContextImpl.java
@@ -21,6 +21,7 @@ package au.com.integradev.delphi.check;
 import au.com.integradev.delphi.file.DelphiFile.DelphiInputFile;
 import au.com.integradev.delphi.preprocessor.CompilerSwitchRegistry;
 import au.com.integradev.delphi.reporting.DelphiIssueBuilderImpl;
+import java.net.URI;
 import java.util.List;
 import org.sonar.api.batch.sensor.SensorContext;
 import org.sonar.plugins.communitydelphi.api.ast.DelphiAst;
@@ -49,6 +50,11 @@ public class DelphiCheckContextImpl implements DelphiCheckContext {
     this.delphiFile = delphiFile;
     this.compilerDirectiveParser = compilerDirectiveParser;
     this.checkRegistrar = checkRegistrar;
+  }
+
+  @Override
+  public URI getUri() {
+    return delphiFile.getInputFile().uri();
   }
 
   @Override

--- a/delphi-frontend/src/main/java/org/sonar/plugins/communitydelphi/api/check/DelphiCheckContext.java
+++ b/delphi-frontend/src/main/java/org/sonar/plugins/communitydelphi/api/check/DelphiCheckContext.java
@@ -19,8 +19,10 @@
 package org.sonar.plugins.communitydelphi.api.check;
 
 import au.com.integradev.delphi.preprocessor.CompilerSwitchRegistry;
+import java.net.URI;
 import java.util.List;
 import java.util.Objects;
+import org.sonar.api.batch.fs.InputFile;
 import org.sonar.plugins.communitydelphi.api.ast.DelphiAst;
 import org.sonar.plugins.communitydelphi.api.ast.DelphiNode;
 import org.sonar.plugins.communitydelphi.api.directive.CompilerDirectiveParser;
@@ -30,6 +32,15 @@ import org.sonar.plugins.communitydelphi.api.type.TypeFactory;
 
 /** Context injected in check classes and used to report issues. */
 public interface DelphiCheckContext {
+  /**
+   * Identifier of the file. The only guarantee is that it is unique in the project. You should not
+   * assume it is a file:// URI.
+   *
+   * @return identifier of the file
+   * @see InputFile#uri()
+   */
+  URI getUri();
+
   /**
    * Returns the parsed ast of the current file.
    *


### PR DESCRIPTION
This PR adds a new `DelphiCheckContext::getUri` method to expose the URI of the file under analysis.