### PR TITLE
Fix various intrinsic signatures around dynamic and open arrays

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Various intrinsic routines had incorrect signatures around dynamic and open arrays.
+
 ## [1.12.0] - 2024-12-02
 
 ### Added

--- a/delphi-frontend/src/main/java/au/com/integradev/delphi/type/intrinsic/IntrinsicArgumentMatcher.java
+++ b/delphi-frontend/src/main/java/au/com/integradev/delphi/type/intrinsic/IntrinsicArgumentMatcher.java
@@ -27,12 +27,8 @@ import org.sonar.plugins.communitydelphi.api.type.Type;
 public final class IntrinsicArgumentMatcher extends TypeImpl {
   public static final Type LIKE_DYNAMIC_ARRAY =
       new IntrinsicArgumentMatcher(
-          "<dynamic array, array constructor, string, or char>",
-          type ->
-              type.isDynamicArray()
-                  || type.isArrayConstructor()
-                  || type.isString()
-                  || type.isChar());
+          "<dynamic array, array constructor>",
+          type -> type.isDynamicArray() || type.isArrayConstructor());
 
   public static final Type ANY_STRING =
       new IntrinsicArgumentMatcher("<string or char>", type -> type.isString() || type.isChar());

--- a/delphi-frontend/src/main/java/au/com/integradev/delphi/type/intrinsic/IntrinsicReturnType.java
+++ b/delphi-frontend/src/main/java/au/com/integradev/delphi/type/intrinsic/IntrinsicReturnType.java
@@ -26,8 +26,6 @@ import static org.sonar.plugins.communitydelphi.api.type.IntrinsicType.STRING;
 import static org.sonar.plugins.communitydelphi.api.type.IntrinsicType.UNICODESTRING;
 import static org.sonar.plugins.communitydelphi.api.type.IntrinsicType.WIDECHAR;
 
-import au.com.integradev.delphi.compiler.Architecture;
-import au.com.integradev.delphi.compiler.CompilerVersion;
 import au.com.integradev.delphi.type.TypeImpl;
 import au.com.integradev.delphi.type.factory.ArrayOption;
 import au.com.integradev.delphi.type.factory.TypeFactoryImpl;
@@ -42,8 +40,6 @@ import org.sonar.plugins.communitydelphi.api.type.Type;
 import org.sonar.plugins.communitydelphi.api.type.TypeFactory;
 
 public abstract class IntrinsicReturnType extends TypeImpl {
-  private static final CompilerVersion VERSION_ATHENS = CompilerVersion.fromVersionNumber("36.0");
-
   @Override
   public String getImage() {
     return "<" + getClass().getSimpleName() + ">";
@@ -97,25 +93,6 @@ public abstract class IntrinsicReturnType extends TypeImpl {
     return new ArgumentByIndexReturnType(index);
   }
 
-  private static Type getOpenArraySizeType(TypeFactory typeFactory) {
-    if (((TypeFactoryImpl) typeFactory).getToolchain().architecture == Architecture.X86) {
-      return typeFactory.getIntrinsic(IntrinsicType.INTEGER);
-    } else {
-      return typeFactory.getIntrinsic(
-          ((TypeFactoryImpl) typeFactory).getCompilerVersion().compareTo(VERSION_ATHENS) >= 0
-              ? IntrinsicType.NATIVEINT
-              : IntrinsicType.INTEGER);
-    }
-  }
-
-  private static Type getDynamicArraySizeType(TypeFactory typeFactory) {
-    if (((TypeFactoryImpl) typeFactory).getToolchain().architecture == Architecture.X86) {
-      return typeFactory.getIntrinsic(IntrinsicType.INTEGER);
-    } else {
-      return typeFactory.getIntrinsic(IntrinsicType.NATIVEINT);
-    }
-  }
-
   private static final class LengthReturnType extends IntrinsicReturnType {
     private final Type byteType;
     private final Type integerType;
@@ -126,8 +103,8 @@ public abstract class IntrinsicReturnType extends TypeImpl {
     private LengthReturnType(TypeFactory typeFactory) {
       this.byteType = typeFactory.getIntrinsic(IntrinsicType.BYTE);
       this.integerType = typeFactory.getIntrinsic(IntrinsicType.INTEGER);
-      this.openArraySizeType = getOpenArraySizeType(typeFactory);
-      this.dynamicArraySizeType = getDynamicArraySizeType(typeFactory);
+      this.openArraySizeType = ((TypeFactoryImpl) typeFactory).openArraySizeType();
+      this.dynamicArraySizeType = ((TypeFactoryImpl) typeFactory).dynamicArraySizeType();
     }
 
     @Override
@@ -152,8 +129,8 @@ public abstract class IntrinsicReturnType extends TypeImpl {
 
     private HighLowReturnType(TypeFactory typeFactory) {
       this.integerType = typeFactory.getIntrinsic(IntrinsicType.INTEGER);
-      this.openArraySizeType = getOpenArraySizeType(typeFactory);
-      this.dynamicArraySizeType = getDynamicArraySizeType(typeFactory);
+      this.openArraySizeType = ((TypeFactoryImpl) typeFactory).openArraySizeType();
+      this.dynamicArraySizeType = ((TypeFactoryImpl) typeFactory).dynamicArraySizeType();
     }
 
     @Override

--- a/delphi-frontend/src/main/java/au/com/integradev/delphi/type/intrinsic/IntrinsicsInjector.java
+++ b/delphi-frontend/src/main/java/au/com/integradev/delphi/type/intrinsic/IntrinsicsInjector.java
@@ -54,6 +54,7 @@ import au.com.integradev.delphi.symbol.declaration.RoutineNameDeclarationImpl;
 import au.com.integradev.delphi.symbol.declaration.TypeNameDeclarationImpl;
 import au.com.integradev.delphi.symbol.declaration.VariableNameDeclarationImpl;
 import au.com.integradev.delphi.symbol.scope.DelphiScopeImpl;
+import au.com.integradev.delphi.type.factory.TypeFactoryImpl;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -85,6 +86,14 @@ public final class IntrinsicsInjector {
 
   private Type type(IntrinsicType type) {
     return typeFactory.getIntrinsic(type);
+  }
+
+  private Type openArraySizeType() {
+    return ((TypeFactoryImpl) typeFactory).openArraySizeType();
+  }
+
+  private Type dynamicArraySizeType() {
+    return ((TypeFactoryImpl) typeFactory).dynamicArraySizeType();
   }
 
   private void buildRoutines() {
@@ -162,6 +171,11 @@ public final class IntrinsicsInjector {
         .param(LIKE_DYNAMIC_ARRAY)
         .variadic(LIKE_DYNAMIC_ARRAY)
         .returns(IntrinsicReturnType.concat(typeFactory));
+    routine("Concat")
+        .param(ANY_STRING)
+        .param(ANY_STRING)
+        .variadic(ANY_STRING)
+        .returns(IntrinsicReturnType.concat(typeFactory));
     routine("Continue");
     routine("Copy")
         .param(type(PANSICHAR))
@@ -174,9 +188,14 @@ public final class IntrinsicsInjector {
         .param(type(INTEGER))
         .returns(IntrinsicReturnType.copy(typeFactory));
     routine("Copy")
+        .param(ANY_STRING)
+        .param(type(INTEGER))
+        .param(type(INTEGER))
+        .returns(IntrinsicReturnType.copy(typeFactory));
+    routine("Copy")
         .param(LIKE_DYNAMIC_ARRAY)
-        .param(type(INTEGER))
-        .param(type(INTEGER))
+        .param(dynamicArraySizeType())
+        .param(dynamicArraySizeType())
         .required(1)
         .returns(IntrinsicReturnType.copy(typeFactory));
     routine("Dec").varParam(ANY_ORDINAL).param(type(INTEGER)).required(1);
@@ -184,7 +203,11 @@ public final class IntrinsicsInjector {
     routine("Default")
         .param(ANY_CLASS_REFERENCE)
         .returns(IntrinsicReturnType.classReferenceValue());
-    routine("Delete").varParam(LIKE_DYNAMIC_ARRAY).param(type(INTEGER)).param(type(INTEGER));
+    routine("Delete").varParam(ANY_STRING).param(type(INTEGER)).param(type(INTEGER));
+    routine("Delete")
+        .varParam(LIKE_DYNAMIC_ARRAY)
+        .param(dynamicArraySizeType())
+        .param(dynamicArraySizeType());
     routine("Dispose").varParam(ANY_POINTER);
     routine("Eof").varParam(ANY_FILE).required(0).returns(type(BOOLEAN));
     routine("Eoln").varParam(ANY_FILE).required(0).returns(type(BOOLEAN));
@@ -209,7 +232,11 @@ public final class IntrinsicsInjector {
     routine("Inc").varParam(ANY_TYPED_POINTER).param(type(INTEGER)).required(1);
     routine("Include").varParam(ANY_SET).param(ANY_ORDINAL);
     routine("Initialize").varParam(TypeFactory.untypedType()).param(type(NATIVEINT)).required(1);
-    routine("Insert").param(LIKE_DYNAMIC_ARRAY).varParam(LIKE_DYNAMIC_ARRAY).param(type(INTEGER));
+    routine("Insert").param(ANY_STRING).varParam(ANY_STRING).param(type(INTEGER));
+    routine("Insert")
+        .param(LIKE_DYNAMIC_ARRAY)
+        .varParam(LIKE_DYNAMIC_ARRAY)
+        .param(dynamicArraySizeType());
     routine("IsConstValue").param(TypeFactory.untypedType()).returns(type(BOOLEAN));
     routine("IsManagedType").param(ANY_CLASS_REFERENCE).returns(type(BOOLEAN));
     routine("Length").param(type(SHORTSTRING)).returns(IntrinsicReturnType.length(typeFactory));
@@ -251,7 +278,11 @@ public final class IntrinsicsInjector {
     routine("Seek").varParam(ANY_FILE).param(type(INTEGER));
     routine("SeekEof").varParam(ANY_TEXT_FILE).required(0).returns(type(BOOLEAN));
     routine("SeekEoln").varParam(ANY_TEXT_FILE).required(0).returns(type(BOOLEAN));
-    routine("SetLength").varParam(LIKE_DYNAMIC_ARRAY).param(type(INTEGER)).variadic(type(INTEGER));
+    routine("SetLength").varParam(ANY_STRING).param(type(INTEGER));
+    routine("SetLength")
+        .varParam(LIKE_DYNAMIC_ARRAY)
+        .param(dynamicArraySizeType())
+        .variadic(dynamicArraySizeType());
     routine("SetString").varParam(ANY_STRING).param(type(PANSICHAR)).param(type(INTEGER));
     routine("SetString").varParam(ANY_STRING).param(type(PWIDECHAR)).param(type(INTEGER));
     routine("SetTextBuf")
@@ -262,7 +293,7 @@ public final class IntrinsicsInjector {
     routine("SizeOf").param(TypeFactory.untypedType()).returns(type(INTEGER));
     routine("Slice")
         .varParam(ANY_ARRAY)
-        .param(type(INTEGER))
+        .param(openArraySizeType())
         .returns(IntrinsicReturnType.slice(typeFactory));
     routine("Sqr").param(type(EXTENDED)).returns(type(EXTENDED));
     routine("Sqr").param(type(INTEGER)).returns(type(INTEGER));

--- a/delphi-frontend/src/test/java/au/com/integradev/delphi/type/intrinsic/IntrinsicArgumentMatcherTest.java
+++ b/delphi-frontend/src/test/java/au/com/integradev/delphi/type/intrinsic/IntrinsicArgumentMatcherTest.java
@@ -63,14 +63,14 @@ class IntrinsicArgumentMatcherTest {
 
     assertThat(matches(LIKE_DYNAMIC_ARRAY, dynamicArray)).isTrue();
     assertThat(matches(LIKE_DYNAMIC_ARRAY, arrayConstructor)).isTrue();
-    assertThat(matches(LIKE_DYNAMIC_ARRAY, FACTORY.getIntrinsic(IntrinsicType.ANSICHAR))).isTrue();
-    assertThat(matches(LIKE_DYNAMIC_ARRAY, FACTORY.getIntrinsic(IntrinsicType.WIDECHAR))).isTrue();
+    assertThat(matches(LIKE_DYNAMIC_ARRAY, FACTORY.getIntrinsic(IntrinsicType.ANSICHAR))).isFalse();
+    assertThat(matches(LIKE_DYNAMIC_ARRAY, FACTORY.getIntrinsic(IntrinsicType.WIDECHAR))).isFalse();
     assertThat(matches(LIKE_DYNAMIC_ARRAY, FACTORY.getIntrinsic(IntrinsicType.SHORTSTRING)))
-        .isTrue();
+        .isFalse();
     assertThat(matches(LIKE_DYNAMIC_ARRAY, FACTORY.getIntrinsic(IntrinsicType.ANSISTRING)))
-        .isTrue();
+        .isFalse();
     assertThat(matches(LIKE_DYNAMIC_ARRAY, FACTORY.getIntrinsic(IntrinsicType.UNICODESTRING)))
-        .isTrue();
+        .isFalse();
     assertThat(matches(LIKE_DYNAMIC_ARRAY, fixedArray)).isFalse();
     assertThat(matches(LIKE_DYNAMIC_ARRAY, FACTORY.emptySet())).isFalse();
   }


### PR DESCRIPTION
This PR fixes several intrinsic signatures to handle array size types properly.
It's a symmetrical change with #312.

Due to the current asymmetry, it's very trivial to get `PlatformDependentTruncation` false-positives with cases like:
```pas
procedure Test(Foo: TArray<Byte>; Bar: TArray<Byte>);
begin
  // Length returns NativeInt, and SetLength incorrectly expects Integer.
  SetLength(Foo, Length(Bar));
end;
```