### PR TITLE
Fix FPs around binary expressions in `PlatformDependentTruncation`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Various intrinsic routines had incorrect signatures around dynamic and open arrays.
+- False positives around platform-dependent binary expressions in `PlatformDependentTruncation`.
 
 ## [1.12.0] - 2024-12-02
 

--- a/delphi-checks/src/test/java/au/com/integradev/delphi/checks/PlatformDependentTruncationCheckTest.java
+++ b/delphi-checks/src/test/java/au/com/integradev/delphi/checks/PlatformDependentTruncationCheckTest.java
@@ -21,6 +21,7 @@ package au.com.integradev.delphi.checks;
 import au.com.integradev.delphi.builders.DelphiTestUnitBuilder;
 import au.com.integradev.delphi.checks.verifier.CheckVerifier;
 import au.com.integradev.delphi.compiler.CompilerVersion;
+import au.com.integradev.delphi.compiler.Toolchain;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
@@ -204,6 +205,80 @@ class PlatformDependentTruncationCheckTest {
                 .appendImpl("  Nat: NativeInt;")
                 .appendImpl("begin")
                 .appendImpl("  Bar(Nat);")
+                .appendImpl("end;"))
+        .verifyNoIssues();
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {VERSION_ALEXANDRIA, VERSION_ATHENS})
+  void testNativeIntAssignmentInBinaryExpressionShouldNotAddIssue(String versionSymbol) {
+    CheckVerifier.newVerifier()
+        .withCheck(new PlatformDependentTruncationCheck())
+        .withCompilerVersion(CompilerVersion.fromVersionSymbol(versionSymbol))
+        .withToolchain(Toolchain.DCC64)
+        .onFile(
+            new DelphiTestUnitBuilder()
+                .appendImpl("procedure Foo;")
+                .appendImpl("var")
+                .appendImpl("  Nat: NativeInt;")
+                .appendImpl("begin")
+                .appendImpl("  Nat := Nat + 1;")
+                .appendImpl("end;"))
+        .verifyNoIssues();
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {VERSION_ALEXANDRIA, VERSION_ATHENS})
+  void testNativeIntArgumentInBinaryExpressionShouldNotAddIssue(String versionSymbol) {
+    CheckVerifier.newVerifier()
+        .withCheck(new PlatformDependentTruncationCheck())
+        .withCompilerVersion(CompilerVersion.fromVersionSymbol(versionSymbol))
+        .withToolchain(Toolchain.DCC64)
+        .onFile(
+            new DelphiTestUnitBuilder()
+                .appendDecl("procedure Bar(Nat: NativeInt);")
+                .appendImpl("procedure Foo;")
+                .appendImpl("var")
+                .appendImpl("  Nat: NativeInt;")
+                .appendImpl("begin")
+                .appendImpl("  Bar(Nat + 1);")
+                .appendImpl("end;"))
+        .verifyNoIssues();
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {VERSION_ALEXANDRIA, VERSION_ATHENS})
+  void testNativeIntAssignmentInNestedBinaryExpressionShouldNotAddIssue(String versionSymbol) {
+    CheckVerifier.newVerifier()
+        .withCheck(new PlatformDependentTruncationCheck())
+        .withCompilerVersion(CompilerVersion.fromVersionSymbol(versionSymbol))
+        .withToolchain(Toolchain.DCC64)
+        .onFile(
+            new DelphiTestUnitBuilder()
+                .appendImpl("procedure Foo;")
+                .appendImpl("var")
+                .appendImpl("  Nat: NativeInt;")
+                .appendImpl("begin")
+                .appendImpl("  Nat := (Nat + 1) + 1;")
+                .appendImpl("end;"))
+        .verifyNoIssues();
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {VERSION_ALEXANDRIA, VERSION_ATHENS})
+  void testPlatformDependentCastInBinaryExpressionShouldNotAddIssue(String versionSymbol) {
+    CheckVerifier.newVerifier()
+        .withCheck(new PlatformDependentTruncationCheck())
+        .withCompilerVersion(CompilerVersion.fromVersionSymbol(versionSymbol))
+        .withToolchain(Toolchain.DCC64)
+        .onFile(
+            new DelphiTestUnitBuilder()
+                .appendImpl("procedure Foo;")
+                .appendImpl("var")
+                .appendImpl("  Int: Integer;")
+                .appendImpl("  Nat: NativeInt;")
+                .appendImpl("begin")
+                .appendImpl("  Int := Integer(Nat) + 1;")
                 .appendImpl("end;"))
         .verifyNoIssues();
   }


### PR DESCRIPTION
# Problem

Under 64-bit toolchains, `PlatformDependentTruncation` currently produces false positives around binary expressions with platform-dependent operands.

# Example

```pas
procedure Test(Nat: NativeInt);
begin
  Nat := Nat + 1;
end;
```

* On a 64-bit toolchain, the expression `Nat + 1` has result type `Int64` because the `Int64` overload of the `Add` operator intrinsic is selected.
* On a 64-bit toolchain, the assignment expression is `<NativeInt> = <Int64>`, and so the rule says "hey, `Int64` doesn't fit into `NativeInt` on 32-bit, that will truncate!"
* What the rule doesn't understand is that, on a 32-bit toolchain, a different overload of the `Add` operator intrinsic will be selected and the result type will be `Integer` - giving us an effective expression of `<32-bit NativeInt> = <Integer>` on that toolchain.

# Solution

Recursively check the operands of binary expression for platform-dependent operands - the whole expression is considered platform-dependent if any of the operands are.

## Is this the right solution?

**Kind of.** It's certainly the right solution for solving this narrowly-scoped problem with binary expressions.

In the grand scheme it's more of a half-measure that covers common cases like `NativeInt + 1` "decaying" to `Integer`/`Int64` and causing really stupid-looking false positives.

There are still holes in this rule's reasoning that we should try to tackle at some stage, but it's non-trivial and would require some solid heuristics - or support for emulating name resolution in a granular way on different toolchains from within rule implementations.

### What kind of holes?

```pas
procedure GetPlatformIndependentType(Int: Integer): Integer; overload;
begin
  Result := Int;
end;

procedure GetPlatformIndependentType(I64: Int64): Integer; overload;
begin
  Result := I64;
end;

procedure Test(Nat: NativeInt);
begin
  Nat := GetPlatformIndependentType(Nat); // This will cause false positives on 64-bit toolchains.
end;
```
