### PR TITLE
Include Delphi version in bug report required fields

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -28,6 +28,14 @@ body:
       required: true
   - type: input
     attributes:
+      label: Delphi version
+      description: >
+        Specify the version of Delphi you are using.
+      placeholder: "12.2"
+    validations:
+      required: true
+  - type: input
+    attributes:
       label: SonarQube version
       description: >
         If applicable, specify the SonarQube version you are using.


### PR DESCRIPTION
This PR adds a new required field "Delphi version" to the bug report issue template. This will help us triage issues that are due to various issue-specific syntaxes or behaviours.