### PR TITLE
Fix incorrect type resolution around array property accesses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Various intrinsic routines had incorrect signatures around dynamic and open arrays.
 - False positives around platform-dependent binary expressions in `PlatformDependentTruncation`.
+- Incorrect type resolution around array property accesses.
 
 ## [1.12.0] - 2024-12-02
 

--- a/delphi-frontend/src/test/java/au/com/integradev/delphi/executor/DelphiSymbolTableExecutorTest.java
+++ b/delphi-frontend/src/test/java/au/com/integradev/delphi/executor/DelphiSymbolTableExecutorTest.java
@@ -871,6 +871,20 @@ class DelphiSymbolTableExecutorTest {
   }
 
   @Test
+  void testArrayProperties() {
+    execute("properties/ArrayProperties.pas");
+    verifyUsages(9, 13, reference(29, 23));
+    verifyUsages(16, 10, reference(28, 2));
+  }
+
+  @Test
+  void testClassArrayProperties() {
+    execute("properties/ClassArrayProperties.pas");
+    verifyUsages(9, 13, reference(29, 24));
+    verifyUsages(16, 10, reference(28, 2));
+  }
+
+  @Test
   void testDefaultArrayProperties() {
     execute("properties/DefaultArrayProperties.pas");
     verifyUsages(12, 14, reference(44, 15), reference(48, 19));

--- a/delphi-frontend/src/test/resources/au/com/integradev/delphi/symbol/properties/ArrayProperties.pas
+++ b/delphi-frontend/src/test/resources/au/com/integradev/delphi/symbol/properties/ArrayProperties.pas
@@ -1,0 +1,32 @@
+unit ArrayProperties;
+
+interface
+
+implementation
+
+type
+  TStringHelper = record helper for string
+    function IsEmpty: Boolean;
+  end;
+
+  TFoo = class
+    property Baz[I: Integer]: string;
+  end;
+
+procedure Consume(S: string);
+begin
+  // do nothing
+end;
+
+procedure Consume(C: Char);
+begin
+  // do nothing
+end;
+
+function Test(Foo: TFoo): Boolean;
+begin
+  Consume(Foo.Baz[0]);
+  Result := Foo.Baz[0].IsEmpty;
+end;
+
+end.

--- a/delphi-frontend/src/test/resources/au/com/integradev/delphi/symbol/properties/ClassArrayProperties.pas
+++ b/delphi-frontend/src/test/resources/au/com/integradev/delphi/symbol/properties/ClassArrayProperties.pas
@@ -1,0 +1,32 @@
+unit ClassArrayProperties;
+
+interface
+
+implementation
+
+type
+  TStringHelper = record helper for string
+    function IsEmpty: Boolean;
+  end;
+
+  TFoo = class
+    class property Baz[I: Integer]: string;
+  end;
+
+procedure Consume(S: string);
+begin
+  // do nothing
+end;
+
+procedure Consume(C: Char);
+begin
+  // do nothing
+end;
+
+function Test(Foo: TFoo): Boolean;
+begin
+  Consume(TFoo.Baz[0]);
+  Result := TFoo.Baz[0].IsEmpty;
+end;
+
+end.


### PR DESCRIPTION
#313 introduced a regression in type resolution for plain array properties.

We started erroneously calling `addResolvedDeclaration()` before resolving array properties, where before we would exit immediately and return to argument disambiguation on the array accessor.

The effect was a subtle breakage of the type resolution around array properties. Take, for example, the expression `Foo.Bar[0]`, where `Bar` is an array property returning `string`. The old behavior would yield type `string`, while the new behavior would yield type `Char` due to the premature `addResolvedDeclaration()` call updating the `currentType` to `string` before the array accessor was processed.