### PR TITLE
Implement Dependency Submission workflow

### DIFF
--- a/.github/workflows/scan-dependencies.yml
+++ b/.github/workflows/scan-dependencies.yml
@@ -1,0 +1,27 @@
+name: Scan Dependencies
+
+on:
+  push:
+    paths:
+      - '**/pom.xml'
+    branches:
+      - 'master'
+
+permissions:
+  contents: write
+
+jobs:
+  install:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup Java
+        uses: actions/setup-java@v4
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+          cache: maven
+      - name: Maven Install
+        run: mvn clean install --batch-mode --no-transfer-progress -DskipTests=true
+      - name: Submit Dependency Snapshot
+        uses: advanced-security/maven-dependency-submission-action@v4


### PR DESCRIPTION
@spiltcoffee, a replacement for the automatic dependency submission.

The automatic dependency submission always fails on release commits because the new versions for `delphi-tokens-generator-maven-plugin` and `license-maven-plugin` are unavailable until they've been published.

This new workflow installs everything locally before running the dependency submission.