### PR TITLE
Fix case-sensitive treatment of file names in coverage reports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Incorrect case-sensitive treatment of file names in coverage reports.
+
 ## [1.12.1] - 2024-12-06
 
 ### Fixed

--- a/delphi-frontend/src/main/java/au/com/integradev/delphi/msbuild/DelphiProjectHelper.java
+++ b/delphi-frontend/src/main/java/au/com/integradev/delphi/msbuild/DelphiProjectHelper.java
@@ -365,10 +365,6 @@ public class DelphiProjectHelper {
     return fs.inputFile(fs.predicates().hasURI(Paths.get(path).toUri()));
   }
 
-  public InputFile getFileFromBasename(String basename) {
-    return fs.inputFile(fs.predicates().hasFilename(basename));
-  }
-
   public String encoding() {
     return fs != null ? fs.encoding().name() : Charset.defaultCharset().name();
   }

--- a/delphi-frontend/src/test/java/au/com/integradev/delphi/coverage/delphicodecoveragetool/DelphiCoverageToolParserTest.java
+++ b/delphi-frontend/src/test/java/au/com/integradev/delphi/coverage/delphicodecoveragetool/DelphiCoverageToolParserTest.java
@@ -56,6 +56,8 @@ class DelphiCoverageToolParserTest {
   private static final String INVALID_STRUCTURE = BASE_REPORT_PATH + "InvalidStructure.xml";
   private static final String NORMAL_COVERAGE = BASE_REPORT_PATH + "NormalCoverage.xml";
   private static final String NORMAL_COVERAGE_PART_2 = BASE_REPORT_PATH + "NormalCoverage2.xml";
+  private static final String MISMATCHED_CASING_COVERAGE =
+      BASE_REPORT_PATH + "MismatchedCasingCoverage.xml";
 
   private static final String GLOBALS_FILENAME = "Globals.pas";
   private static final String GLOBALS_FILE_KEY = ":" + GLOBALS_FILENAME;
@@ -92,10 +94,11 @@ class DelphiCoverageToolParserTest {
     delphiProjectHelper =
         new DelphiProjectHelper(
             context.config(), context.fileSystem(), environmentVariableProvider);
-    parser = new DelphiCodeCoverageParser(delphiProjectHelper);
 
     addFile(ROOT_NAME + "/" + GLOBALS_FILENAME);
     addFile(ROOT_NAME + "/" + MAIN_WINDOW_FILENAME);
+
+    parser = new DelphiCodeCoverageParser(delphiProjectHelper);
   }
 
   @Test
@@ -122,6 +125,22 @@ class DelphiCoverageToolParserTest {
     assertThat(context.lineHits(GLOBALS_FILE_KEY, 16)).isEqualTo((Integer) 1);
     assertThat(context.lineHits(GLOBALS_FILE_KEY, 17)).isEqualTo((Integer) 1);
     assertThat(context.lineHits(GLOBALS_FILE_KEY, 23)).isEqualTo((Integer) 1);
+  }
+
+  @Test
+  void testMismatchedCasingAllowed() {
+    parser.parse(context, DelphiUtils.getResource(MISMATCHED_CASING_COVERAGE));
+
+    assertThat(context.lineHits(GLOBALS_FILE_KEY, 16)).isEqualTo(1);
+    assertThat(context.lineHits(GLOBALS_FILE_KEY, 17)).isEqualTo(1);
+    assertThat(context.lineHits(GLOBALS_FILE_KEY, 23)).isZero();
+
+    assertThat(context.lineHits(MAIN_WINDOW_FILE_KEY, 31)).isEqualTo(1);
+    assertThat(context.lineHits(MAIN_WINDOW_FILE_KEY, 36)).isEqualTo(1);
+    assertThat(context.lineHits(MAIN_WINDOW_FILE_KEY, 37)).isEqualTo(1);
+    assertThat(context.lineHits(MAIN_WINDOW_FILE_KEY, 38)).isEqualTo(1);
+    assertThat(context.lineHits(MAIN_WINDOW_FILE_KEY, 39)).isEqualTo(1);
+    assertThat(context.lineHits(MAIN_WINDOW_FILE_KEY, 40)).isEqualTo(1);
   }
 
   void testReportFileIsIgnored(File file) {

--- a/delphi-frontend/src/test/resources/au/com/integradev/delphi/projects/SimpleProject/delphicodecoveragereports/MismatchedCasingCoverage.xml
+++ b/delphi-frontend/src/test/resources/au/com/integradev/delphi/projects/SimpleProject/delphicodecoveragereports/MismatchedCasingCoverage.xml
@@ -1,0 +1,71 @@
+<?xml version="1.0" encoding="Windows-1252" standalone="no"?>
+<report>
+  <stats>
+    <packages value="1"/>
+    <classes value="2"/>
+    <methods value="3"/>
+    <srcfiles value="4"/>
+    <srclines value="5"/>
+    <totallines value="6"/>
+    <coveredlines value="7"/>
+    <coveredpercent value="8"/>
+  </stats>
+  <data>
+    <all name="all classes">
+      <coverage type="class, %" value="41%   (41/101)"/>
+      <coverage type="method, %" value="18%   (112/636)"/>
+      <coverage type="block, %" value="12%   (815/6924)"/>
+      <coverage type="line, %" value="12%   (815/6924)"/>
+      <package name="[default]">
+        <coverage type="class, %" value="100%   (5/5)"/>
+        <coverage type="method, %" value="74%   (14/19)"/>
+        <coverage type="block, %" value="66%   (93/140)"/>
+        <coverage type="line, %" value="66%   (93/140)"/>
+        <srcfile name="MainWindow.pas">
+          <coverage type="class, %" value="100%   (5/5)"/>
+          <coverage type="method, %" value="74%   (14/19)"/>
+          <coverage type="block, %" value="66%   (93/140)"/>
+          <coverage type="line, %" value="66%   (93/140)"/>
+          <class name="TMainWindow">
+            <coverage type="class, %" value="100%   (1/1)"/>
+            <coverage type="method, %" value="100%   (1/1)"/>
+            <coverage type="block, %" value="56%   (5/9)"/>
+            <coverage type="line, %" value="56%   (5/9)"/>
+            <method name="foo2">
+              <coverage type="method, %" value="100%   (1/1)"/>
+              <coverage type="block, %" value="56%   (5/9)"/>
+              <coverage type="line, %" value="56%   (5/9)"/>
+              <line number="36" covered="True"/>
+              <line number="37" covered="False"/>
+              <line number="38" covered="True"/>
+              <line number="39" covered="False"/>
+            </method>
+          </class>         
+        </srcfile>
+        <srcfile name="Globals.pas">
+          <coverage type="class, %" value="100%   (5/5)"/>
+          <coverage type="method, %" value="74%   (14/19)"/>
+          <coverage type="block, %" value="66%   (93/140)"/>
+          <coverage type="line, %" value="66%   (93/140)"/>
+          <class name="TGlobals">
+            <coverage type="class, %" value="100%   (1/1)"/>
+            <coverage type="method, %" value="100%   (1/1)"/>
+            <coverage type="block, %" value="56%   (5/9)"/>
+            <coverage type="line, %" value="56%   (5/9)"/>
+            <method name="globalProcedure">
+              <coverage type="method, %" value="100%   (2/2)"/>
+              <coverage type="block, %" value="100%   (1/1)"/>
+              <coverage type="line, %" value="100%   (2/2)"/>
+			  <line number="19" covered="True"/>
+              <line number="20" covered="True"/>
+            </method>
+          </class>         
+        </srcfile>
+      </package>
+    </all>
+    <linehits>
+      <file name="GlObAlS.pas">16=1;17=1;23=0</file>
+      <file name="maINwInDoW.pas">31=1;36=1;37=1;38=1;39=1;40=1</file>
+    </linehits>
+  </data>
+</report>


### PR DESCRIPTION
File names in coverage reports are now treated as case-insensitive on windows.

Fixes #325.