### PR TITLE
Reprioritize the analysis search path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Reprioritize the analysis search path in the following order (highest to lowest):
+  - Analysis source files (`sonar.sources`)
+  - Referenced project files (`DCCReference`)
+  - Search path (`DCC_UnitSearchPath`)
+  - Debugger source path (`Debugger_DebugSourcePath`)
+  - Library path (`DelphiLibraryPath`/`DelphiTranslatedLibraryPath`)
+  - Standard library
+
+
 ## [1.12.2] - 2025-01-06
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,14 +9,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Include the global browsing path in unit import resolution.
 - Reprioritize the analysis search path in the following order (highest to lowest):
   - Analysis source files (`sonar.sources`)
   - Referenced project files (`DCCReference`)
   - Search path (`DCC_UnitSearchPath`)
   - Debugger source path (`Debugger_DebugSourcePath`)
   - Library path (`DelphiLibraryPath`/`DelphiTranslatedLibraryPath`)
+  - Browsing path (`DelphiBrowsingPath`)
   - Standard library
-
 
 ## [1.12.2] - 2025-01-06
 

--- a/delphi-frontend/src/main/java/au/com/integradev/delphi/msbuild/DelphiProject.java
+++ b/delphi-frontend/src/main/java/au/com/integradev/delphi/msbuild/DelphiProject.java
@@ -38,5 +38,9 @@ public interface DelphiProject {
 
   List<Path> getDebugSourceDirectories();
 
+  List<Path> getLibraryPathDirectories();
+
+  List<Path> getBrowsingPathDirectories();
+
   Map<String, String> getUnitAliases();
 }

--- a/delphi-frontend/src/main/java/au/com/integradev/delphi/msbuild/DelphiProjectHelper.java
+++ b/delphi-frontend/src/main/java/au/com/integradev/delphi/msbuild/DelphiProjectHelper.java
@@ -69,6 +69,8 @@ public class DelphiProjectHelper {
   private final CompilerVersion compilerVersion;
   private final List<Path> searchDirectories;
   private final List<Path> debugSourceDirectories;
+  private final List<Path> libraryPathDirectories;
+  private final List<Path> browsingPathDirectories;
   private final List<Path> referencedFiles;
   private final Set<String> conditionalDefines;
   private final Set<String> unitScopeNames;
@@ -93,6 +95,8 @@ public class DelphiProjectHelper {
     this.compilerVersion = getCompilerVersionFromSettings();
     this.searchDirectories = getSearchDirectoriesFromSettings();
     this.debugSourceDirectories = new ArrayList<>();
+    this.libraryPathDirectories = new ArrayList<>();
+    this.browsingPathDirectories = new ArrayList<>();
     this.referencedFiles = new ArrayList<>();
     this.conditionalDefines = getPredefinedConditionalDefines();
     this.unitScopeNames = getSetFromSettings(DelphiProperties.UNIT_SCOPE_NAMES_KEY);
@@ -201,6 +205,8 @@ public class DelphiProjectHelper {
     for (DelphiProject project : projects) {
       searchDirectories.addAll(project.getSearchDirectories());
       debugSourceDirectories.addAll(project.getDebugSourceDirectories());
+      libraryPathDirectories.addAll(project.getLibraryPathDirectories());
+      browsingPathDirectories.addAll(project.getBrowsingPathDirectories());
       conditionalDefines.addAll(project.getConditionalDefines());
       referencedFiles.addAll(project.getSourceFiles());
       unitScopeNames.addAll(project.getUnitScopeNames());
@@ -310,11 +316,31 @@ public class DelphiProjectHelper {
   /**
    * Gets the debug source directories specified in project files
    *
-   * @return List of debug source directorie
+   * @return List of debug source directories
    */
   public List<Path> getDebugSourceDirectories() {
     indexProjects();
     return debugSourceDirectories;
+  }
+
+  /**
+   * Gets the library path directories specified in project files
+   *
+   * @return List of library path directories
+   */
+  public List<Path> getLibraryPathDirectories() {
+    indexProjects();
+    return libraryPathDirectories;
+  }
+
+  /**
+   * Gets the browsing path directories specified in project files
+   *
+   * @return List of browsing path directories
+   */
+  public List<Path> getBrowsingPathDirectories() {
+    indexProjects();
+    return browsingPathDirectories;
   }
 
   /**

--- a/delphi-frontend/src/main/java/au/com/integradev/delphi/symbol/SymbolTableBuilder.java
+++ b/delphi-frontend/src/main/java/au/com/integradev/delphi/symbol/SymbolTableBuilder.java
@@ -185,7 +185,7 @@ public class SymbolTableBuilder {
   }
 
   private void createUnitData(Path unitPath, boolean isSourceFile) {
-    if (unitPaths.add(unitPath) || isSourceFile) {
+    if (unitPaths.add(unitPath)) {
       String unitName = FilenameUtils.getBaseName(unitPath.toString());
       UnitData unitData = new UnitData(unitPath, isSourceFile);
 
@@ -459,10 +459,11 @@ public class SymbolTableBuilder {
       throw new SymbolTableConstructionException("typeFactory was not supplied.");
     }
 
-    processStandardLibrarySearchPaths();
-    searchPath.getRootDirectories().forEach(this::processSearchPath);
-    referencedFiles.forEach(file -> this.createUnitData(file, false));
     sourceFiles.forEach(file -> this.createUnitData(file, true));
+    referencedFiles.forEach(file -> this.createUnitData(file, false));
+    searchPath.getRootDirectories().forEach(this::processSearchPath);
+
+    processStandardLibrarySearchPaths();
 
     ProgressReport progressReport =
         new ProgressReport(

--- a/delphi-frontend/src/test/java/au/com/integradev/delphi/msbuild/DelphiProjectParserTest.java
+++ b/delphi-frontend/src/test/java/au/com/integradev/delphi/msbuild/DelphiProjectParserTest.java
@@ -57,6 +57,9 @@ class DelphiProjectParserTest {
   private static final String LIBRARY_PATH_PROJECT =
       "/au/com/integradev/delphi/msbuild/LibraryPath.dproj";
 
+  private static final String BROWSING_PATH_PROJECT =
+      "/au/com/integradev/delphi/msbuild/BrowsingPath.dproj";
+
   private EnvironmentVariableProvider environmentVariableProvider;
   private Path environmentProj;
 
@@ -158,14 +161,20 @@ class DelphiProjectParserTest {
   }
 
   @Test
-  void testLibraryPathShouldBeAppendedToSearchDirectories() {
+  void testLibraryPathProject() {
     DelphiProject project = parse(LIBRARY_PATH_PROJECT);
 
-    assertThat(project.getSearchDirectories())
+    assertThat(project.getLibraryPathDirectories())
         .containsExactly(
-            DelphiUtils.getResource("/au/com/integradev/delphi/msbuild").toPath(),
             DelphiUtils.getResource("/au/com/integradev/delphi").toPath(),
-            DelphiUtils.getResource("/au/com/integradev").toPath(),
-            DelphiUtils.getResource("/au/com").toPath());
+            DelphiUtils.getResource("/au/com/integradev").toPath());
+  }
+
+  @Test
+  void testBrowsingPathProject() {
+    DelphiProject project = parse(BROWSING_PATH_PROJECT);
+
+    assertThat(project.getBrowsingPathDirectories())
+        .containsExactly(DelphiUtils.getResource("/au/com/integradev/delphi").toPath());
   }
 }

--- a/delphi-frontend/src/test/resources/au/com/integradev/delphi/msbuild/BrowsingPath.dproj
+++ b/delphi-frontend/src/test/resources/au/com/integradev/delphi/msbuild/BrowsingPath.dproj
@@ -1,6 +1,5 @@
 ﻿<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
     <PropertyGroup>
-        <DelphiLibraryPath>../</DelphiLibraryPath>
-        <DelphiTranslatedLibraryPath>../../</DelphiTranslatedLibraryPath>
+        <DelphiBrowsingPath>../</DelphiBrowsingPath>
     </PropertyGroup>
 </Project>


### PR DESCRIPTION
This PR includes the browsing path in the search path, makes changes to the order of paths during `SearchPath` creation, and changes up the order of the unit data processing in the `SymbolTableBuilder`.

The new search path priority is (highest to lowest):
  - `sonar.sources`
  - `DCCReference`
  - `DCC_UnitSearchPath`
  - `Debugger_DebugSourcePath`
  - `DelphiLibraryPath`
  - `DelphiTranslatedLibraryPath`
  - `DelphiBrowsingPath`
  - Standard library

This change enables behaviors like:
- shadowing standard library units with a unit on `DCC_UnitSearchPath`
- shadowing `DCC_UnitSearchPath` units with a `DCCReference` unit

These cases are somewhat unusual, but they are possible in Delphi.