### PR TITLE
Handle empty anonymous methods in `EmptyRoutine` instead of `EmptyBlock`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Library path (`DelphiLibraryPath`/`DelphiTranslatedLibraryPath`)
   - Browsing path (`DelphiBrowsingPath`)
   - Standard library
+- Empty anonymous methods are now flagged in `EmptyRoutine`.
+- **API:** `AnonymousMethodNode::getStatementBlock` method.
+- **API:** `AnonymousMethodNode::isEmpty` method.
 
 ## [1.12.2] - 2025-01-06
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Library path (`DelphiLibraryPath`/`DelphiTranslatedLibraryPath`)
   - Browsing path (`DelphiBrowsingPath`)
   - Standard library
+- Empty anonymous methods are now ignored in `EmptyBlock`.
 - Empty anonymous methods are now flagged in `EmptyRoutine`.
 - **API:** `AnonymousMethodNode::getStatementBlock` method.
 - **API:** `AnonymousMethodNode::isEmpty` method.

--- a/delphi-checks/src/main/java/au/com/integradev/delphi/checks/EmptyBlockCheck.java
+++ b/delphi-checks/src/main/java/au/com/integradev/delphi/checks/EmptyBlockCheck.java
@@ -19,6 +19,7 @@
 package au.com.integradev.delphi.checks;
 
 import org.sonar.check.Rule;
+import org.sonar.plugins.communitydelphi.api.ast.AnonymousMethodNode;
 import org.sonar.plugins.communitydelphi.api.ast.CaseItemStatementNode;
 import org.sonar.plugins.communitydelphi.api.ast.CaseStatementNode;
 import org.sonar.plugins.communitydelphi.api.ast.CompoundStatementNode;
@@ -49,7 +50,7 @@ public class EmptyBlockCheck extends DelphiCheck {
   private static boolean shouldAddViolation(CompoundStatementNode block) {
     DelphiNode parent = block.getParent();
 
-    if (parent instanceof RoutineBodyNode) {
+    if (parent instanceof RoutineBodyNode || parent instanceof AnonymousMethodNode) {
       // Handled by EmptyRoutineRule
       return false;
     }

--- a/delphi-checks/src/main/resources/org/sonar/l10n/delphi/rules/community-delphi/EmptyRoutine.html
+++ b/delphi-checks/src/main/resources/org/sonar/l10n/delphi/rules/community-delphi/EmptyRoutine.html
@@ -9,6 +9,7 @@
   <li>Virtual methods (e.g. to provide a no-op default behaviour for child classes)</li>
   <li>Override methods (e.g. to not run behaviour implemented in ancestor classes)</li>
   <li>Methods that implement an interface</li>
+  <li>Anonymous methods</li>
 </ul>
 <h2>How to fix it</h2>
 <p>If the empty routine is an omission, remove it.</p>

--- a/delphi-checks/src/test/java/au/com/integradev/delphi/checks/EmptyBlockCheckTest.java
+++ b/delphi-checks/src/test/java/au/com/integradev/delphi/checks/EmptyBlockCheckTest.java
@@ -157,4 +157,24 @@ class EmptyBlockCheckTest {
                 .appendImpl("end;"))
         .verifyNoIssues();
   }
+
+  @Test
+  void testEmptyAnonymousMethodShouldNotAddIssue() {
+    CheckVerifier.newVerifier()
+        .withCheck(new EmptyBlockCheck())
+        .onFile(
+            new DelphiTestUnitBuilder()
+                .appendDecl("type")
+                .appendDecl("  TProc = reference to procedure;")
+                .appendImpl("procedure Foo;")
+                .appendImpl("var")
+                .appendImpl("  Bar: TProc;")
+                .appendImpl("begin")
+                .appendImpl("  Bar :=")
+                .appendImpl("    procedure")
+                .appendImpl("    begin")
+                .appendImpl("    end;")
+                .appendImpl("end;"))
+        .verifyNoIssues();
+  }
 }

--- a/delphi-checks/src/test/java/au/com/integradev/delphi/checks/EmptyRoutineCheckTest.java
+++ b/delphi-checks/src/test/java/au/com/integradev/delphi/checks/EmptyRoutineCheckTest.java
@@ -201,6 +201,47 @@ class EmptyRoutineCheckTest {
   }
 
   @Test
+  void testEmptyAnonymousMethodWithoutCommentShouldAddIssue() {
+    CheckVerifier.newVerifier()
+        .withCheck(new EmptyRoutineCheck())
+        .onFile(
+            new DelphiTestUnitBuilder()
+                .appendDecl("type")
+                .appendDecl("  TProc = reference to procedure;")
+                .appendImpl("procedure Foo;")
+                .appendImpl("var")
+                .appendImpl("  Bar: TProc;")
+                .appendImpl("begin")
+                .appendImpl("  Bar :=")
+                .appendImpl("    procedure // Noncompliant")
+                .appendImpl("    begin")
+                .appendImpl("    end;")
+                .appendImpl("end;"))
+        .verifyIssues();
+  }
+
+  @Test
+  void testEmptyAnonymousMethodWithCommentShouldNotAddIssue() {
+    CheckVerifier.newVerifier()
+        .withCheck(new EmptyRoutineCheck())
+        .onFile(
+            new DelphiTestUnitBuilder()
+                .appendDecl("type")
+                .appendDecl("  TProc = reference to procedure;")
+                .appendImpl("procedure Foo;")
+                .appendImpl("var")
+                .appendImpl("  Bar: TProc;")
+                .appendImpl("begin")
+                .appendImpl("  Bar :=")
+                .appendImpl("    procedure")
+                .appendImpl("    begin")
+                .appendImpl("      // do nothing")
+                .appendImpl("    end;")
+                .appendImpl("end;"))
+        .verifyNoIssues();
+  }
+
+  @Test
   void testForwardDeclarationShouldNotAddIssue() {
     CheckVerifier.newVerifier()
         .withCheck(new EmptyRoutineCheck())

--- a/delphi-frontend/src/main/java/au/com/integradev/delphi/antlr/ast/node/AnonymousMethodNodeImpl.java
+++ b/delphi-frontend/src/main/java/au/com/integradev/delphi/antlr/ast/node/AnonymousMethodNodeImpl.java
@@ -28,6 +28,7 @@ import javax.annotation.Nonnull;
 import org.antlr.runtime.Token;
 import org.sonar.plugins.communitydelphi.api.ast.AnonymousMethodHeadingNode;
 import org.sonar.plugins.communitydelphi.api.ast.AnonymousMethodNode;
+import org.sonar.plugins.communitydelphi.api.ast.CompoundStatementNode;
 import org.sonar.plugins.communitydelphi.api.ast.RoutineParametersNode;
 import org.sonar.plugins.communitydelphi.api.ast.RoutineReturnTypeNode;
 import org.sonar.plugins.communitydelphi.api.symbol.declaration.RoutineDirective;
@@ -96,6 +97,16 @@ public final class AnonymousMethodNodeImpl extends ExpressionNodeImpl
   @Override
   public boolean isProcedure() {
     return getRoutineKind() == RoutineKind.PROCEDURE;
+  }
+
+  @Override
+  public CompoundStatementNode getStatementBlock() {
+    return (CompoundStatementNode) getChild(1);
+  }
+
+  @Override
+  public boolean isEmpty() {
+    return getStatementBlock().isEmpty();
   }
 
   @Override

--- a/delphi-frontend/src/main/java/org/sonar/plugins/communitydelphi/api/ast/AnonymousMethodNode.java
+++ b/delphi-frontend/src/main/java/org/sonar/plugins/communitydelphi/api/ast/AnonymousMethodNode.java
@@ -41,4 +41,8 @@ public interface AnonymousMethodNode extends ExpressionNode {
   boolean isFunction();
 
   boolean isProcedure();
+
+  CompoundStatementNode getStatementBlock();
+
+  boolean isEmpty();
 }


### PR DESCRIPTION
This PR excludes anonymous methods from `EmptyBlock` and flags them in `EmptyRoutine` instead.

Fixes #315.