### PR TITLE
Tidy the `AnonymousMethodNode` API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **API:** `AnonymousMethodNode::getDeclarationSection` method.
 - **API:** `AnonymousMethodNode::getStatementBlock` method.
 - **API:** `AnonymousMethodNode::isEmpty` method.
 

--- a/delphi-frontend/src/main/java/au/com/integradev/delphi/antlr/ast/node/AnonymousMethodNodeImpl.java
+++ b/delphi-frontend/src/main/java/au/com/integradev/delphi/antlr/ast/node/AnonymousMethodNodeImpl.java
@@ -25,10 +25,12 @@ import java.util.Collections;
 import java.util.Set;
 import java.util.stream.Collectors;
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import org.antlr.runtime.Token;
 import org.sonar.plugins.communitydelphi.api.ast.AnonymousMethodHeadingNode;
 import org.sonar.plugins.communitydelphi.api.ast.AnonymousMethodNode;
 import org.sonar.plugins.communitydelphi.api.ast.CompoundStatementNode;
+import org.sonar.plugins.communitydelphi.api.ast.LocalDeclarationSectionNode;
 import org.sonar.plugins.communitydelphi.api.ast.RoutineParametersNode;
 import org.sonar.plugins.communitydelphi.api.ast.RoutineReturnTypeNode;
 import org.sonar.plugins.communitydelphi.api.symbol.declaration.RoutineDirective;
@@ -97,6 +99,12 @@ public final class AnonymousMethodNodeImpl extends ExpressionNodeImpl
   @Override
   public boolean isProcedure() {
     return getRoutineKind() == RoutineKind.PROCEDURE;
+  }
+
+  @Override
+  @Nullable
+  public LocalDeclarationSectionNode getDeclarationSection() {
+    return getFirstChildOfType(LocalDeclarationSectionNode.class);
   }
 
   @Override

--- a/delphi-frontend/src/main/java/au/com/integradev/delphi/antlr/ast/node/AnonymousMethodNodeImpl.java
+++ b/delphi-frontend/src/main/java/au/com/integradev/delphi/antlr/ast/node/AnonymousMethodNodeImpl.java
@@ -101,7 +101,7 @@ public final class AnonymousMethodNodeImpl extends ExpressionNodeImpl
 
   @Override
   public CompoundStatementNode getStatementBlock() {
-    return (CompoundStatementNode) getChild(1);
+    return getFirstChildOfType(CompoundStatementNode.class);
   }
 
   @Override

--- a/delphi-frontend/src/main/java/org/sonar/plugins/communitydelphi/api/ast/AnonymousMethodNode.java
+++ b/delphi-frontend/src/main/java/org/sonar/plugins/communitydelphi/api/ast/AnonymousMethodNode.java
@@ -19,6 +19,7 @@
 package org.sonar.plugins.communitydelphi.api.ast;
 
 import java.util.Set;
+import javax.annotation.Nullable;
 import org.sonar.plugins.communitydelphi.api.symbol.declaration.RoutineDirective;
 import org.sonar.plugins.communitydelphi.api.symbol.declaration.RoutineKind;
 import org.sonar.plugins.communitydelphi.api.type.Type;
@@ -41,6 +42,9 @@ public interface AnonymousMethodNode extends ExpressionNode {
   boolean isFunction();
 
   boolean isProcedure();
+
+  @Nullable
+  LocalDeclarationSectionNode getDeclarationSection();
 
   CompoundStatementNode getStatementBlock();
 


### PR DESCRIPTION
This PR fixes a bug in the `getStatementBlock` implementation, and adds a `getDeclarationSection` method.