### PR TITLE
Deprioritize `sonar.sources` in the analysis search path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,13 +17,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Include the global browsing path in unit import resolution.
 - Reprioritize the analysis search path in the following order (highest to lowest):
-  - Analysis source files (`sonar.sources`)
   - Referenced project files (`DCCReference`)
   - Search path (`DCC_UnitSearchPath`)
   - Debugger source path (`Debugger_DebugSourcePath`)
   - Library path (`DelphiLibraryPath`/`DelphiTranslatedLibraryPath`)
   - Browsing path (`DelphiBrowsingPath`)
   - Standard library
+  - Analysis source files (`sonar.sources`)
 - Empty anonymous methods are now ignored in `EmptyBlock`.
 - Empty anonymous methods are now flagged in `EmptyRoutine`.
 

--- a/delphi-frontend/src/main/java/au/com/integradev/delphi/symbol/SymbolTableBuilder.java
+++ b/delphi-frontend/src/main/java/au/com/integradev/delphi/symbol/SymbolTableBuilder.java
@@ -185,7 +185,7 @@ public class SymbolTableBuilder {
   }
 
   private void createUnitData(Path unitPath, boolean isSourceFile) {
-    if (unitPaths.add(unitPath)) {
+    if (unitPaths.add(unitPath) || isSourceFile) {
       String unitName = FilenameUtils.getBaseName(unitPath.toString());
       UnitData unitData = new UnitData(unitPath, isSourceFile);
 
@@ -459,11 +459,10 @@ public class SymbolTableBuilder {
       throw new SymbolTableConstructionException("typeFactory was not supplied.");
     }
 
-    sourceFiles.forEach(file -> this.createUnitData(file, true));
     referencedFiles.forEach(file -> this.createUnitData(file, false));
     searchPath.getRootDirectories().forEach(this::processSearchPath);
-
     processStandardLibrarySearchPaths();
+    sourceFiles.forEach(file -> this.createUnitData(file, true));
 
     ProgressReport progressReport =
         new ProgressReport(

--- a/delphi-frontend/src/test/java/au/com/integradev/delphi/symbol/SymbolTableBuilderTest.java
+++ b/delphi-frontend/src/test/java/au/com/integradev/delphi/symbol/SymbolTableBuilderTest.java
@@ -160,43 +160,6 @@ class SymbolTableBuilderTest {
   }
 
   @Test
-  void testSonarSourcesArePrioritizedOverReferencedFiles(
-      @TempDir Path standardLibraryPath,
-      @TempDir Path referencedFilesPath,
-      @TempDir Path sourceFilesPath)
-      throws IOException {
-    createStandardLibrary(standardLibraryPath);
-    createStandardLibrary(referencedFilesPath);
-    createStandardLibrary(sourceFilesPath);
-
-    List<Path> referencedFiles;
-    try (Stream<Path> referencedFilesStream = Files.list(referencedFilesPath)) {
-      referencedFiles = referencedFilesStream.collect(Collectors.toUnmodifiableList());
-    }
-
-    List<Path> sourceFiles;
-    try (Stream<Path> sourceFilesStream = Files.list(sourceFilesPath)) {
-      sourceFiles = sourceFilesStream.collect(Collectors.toUnmodifiableList());
-    }
-
-    SymbolTable symbolTable =
-        SymbolTable.builder()
-            .preprocessorFactory(new DelphiPreprocessorFactory(Platform.WINDOWS))
-            .typeFactory(TypeFactoryUtils.defaultFactory())
-            .standardLibraryPath(standardLibraryPath)
-            .referencedFiles(referencedFiles)
-            .sourceFiles(sourceFiles)
-            .build();
-
-    assertThat(symbolTable.getUnitByPath(standardLibraryPath.resolve("SysInit.pas").toString()))
-        .isNull();
-    assertThat(symbolTable.getUnitByPath(referencedFilesPath.resolve("SysInit.pas").toString()))
-        .isNull();
-    assertThat(symbolTable.getUnitByPath(sourceFilesPath.resolve("SysInit.pas").toString()))
-        .isNotNull();
-  }
-
-  @Test
   void testReferencedFilesArePrioritizedOverSearchPath(
       @TempDir Path standardLibraryPath,
       @TempDir Path searchPathRoot,


### PR DESCRIPTION
The previous approach (where `sonar.sources` took first priority in the analysis search path) caused some surprising/undesirable behavior in projects where there are multiple units with the same name.

It becomes very hard in that scenario for a user to configure the scan in a way where the correct unit will win during import resolution, even if the search path was correct in the dproj file.