### PR TITLE
Fix parsing ambiguity around adjacent `>` and `=` tokens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Parsing errors where adjacent `>` and `=` tokens were wrongly interpreted as the `>=` operator.
+
 ## [1.13.0] - 2025-02-05
 
 ### Added

--- a/delphi-frontend/src/test/java/au/com/integradev/delphi/antlr/GrammarTest.java
+++ b/delphi-frontend/src/test/java/au/com/integradev/delphi/antlr/GrammarTest.java
@@ -353,4 +353,9 @@ class GrammarTest {
   void testSemicolonSeparatedGenericArguments() {
     assertParsed("SemicolonSeparatedGenericArguments.pas");
   }
+
+  @Test
+  void testGreaterThanEqualAmbiguity() {
+    assertParsed("GreaterThanEqualAmbiguity.pas");
+  }
 }

--- a/delphi-frontend/src/test/resources/au/com/integradev/delphi/grammar/GreaterThanEqualAmbiguity.pas
+++ b/delphi-frontend/src/test/resources/au/com/integradev/delphi/grammar/GreaterThanEqualAmbiguity.pas
@@ -1,0 +1,30 @@
+unit GreaterThanEqualAmbiguity;
+
+interface
+
+type
+  TFoo = class(TObject)
+    procedure Bar(Baz: IBaz<string>=nil);
+  end;
+
+implementation
+
+procedure TFoo.Bar(Baz: IBaz<string>=nil);
+begin
+  // do nothing
+end;
+
+function Flarp: TArray<Byte>;
+const
+  Bytes: TArray<Byte>=[1, 2, 3];
+begin
+  Result := Bytes;
+end;
+
+function FlimFlam: TArray<Byte>;
+begin
+  const Bytes: TArray<Byte>=[1, 2, 3];
+  Result := Bytes;
+end;
+
+end.


### PR DESCRIPTION
This PR fixes a grammar ambiguity around adjacent `>` and `=` tokens. (Fixes #318)

We now create `>=` tokens during parsing by combining the `>`/`=` tokens, instead of combining them at the lexing stage.
(For consistently, we're doing this for "less than equal" tokens as well)

This allows us to only create `>=` tokens when we're parsing a binary expression.

As a result, we can now successfully parse code that looks like this:
```pas
const Foo: TArray<Byte>=[1, 2, 3];
```
Previously this would create a `>=` token in the middle and make everything fall over.