### PR TITLE
Improve coverage in `DestructorWithoutInheritedCheck`

### DIFF
--- a/delphi-checks/src/test/java/au/com/integradev/delphi/checks/DestructorWithoutInheritedCheckTest.java
+++ b/delphi-checks/src/test/java/au/com/integradev/delphi/checks/DestructorWithoutInheritedCheckTest.java
@@ -77,4 +77,97 @@ class DestructorWithoutInheritedCheckTest {
                 .appendImpl("end;"))
         .verifyNoIssues();
   }
+
+  @Test
+  void testDestructorLikeWithInheritedShouldNotAddIssue() {
+    var check = new DestructorWithoutInheritedCheck();
+    check.destructorLikes = "Foo,Bar";
+
+    CheckVerifier.newVerifier()
+        .withCheck(check)
+        .onFile(
+            new DelphiTestUnitBuilder()
+                .appendDecl("type")
+                .appendDecl("  TTestDestructorLike = class(TObject)")
+                .appendDecl("  public")
+                .appendDecl("    procedure Foo; override;")
+                .appendDecl("    procedure Bar; override;")
+                .appendDecl("  end;")
+                .appendImpl("procedure TTestDestructorLike.Foo;")
+                .appendImpl("begin")
+                .appendImpl("  inherited;")
+                .appendImpl("  WriteLn('do something');")
+                .appendImpl("end;")
+                .appendImpl("procedure TTestDestructorLike.Bar;")
+                .appendImpl("begin")
+                .appendImpl("  inherited;")
+                .appendImpl("  WriteLn('do something');")
+                .appendImpl("end;"))
+        .verifyNoIssues();
+  }
+
+  @Test
+  void testDestructorLikeWithoutInheritedShouldAddIssue() {
+    var check = new DestructorWithoutInheritedCheck();
+    check.destructorLikes = "Foo,Bar";
+
+    CheckVerifier.newVerifier()
+        .withCheck(check)
+        .onFile(
+            new DelphiTestUnitBuilder()
+                .appendDecl("type")
+                .appendDecl("  TTestDestructorLike = class(TObject)")
+                .appendDecl("  public")
+                .appendDecl("    procedure Foo; override;")
+                .appendDecl("    procedure Bar; override;")
+                .appendDecl("  end;")
+                .appendImpl("procedure TTestDestructorLike.Foo; // Noncompliant")
+                .appendImpl("begin")
+                .appendImpl("  WriteLn('do something');")
+                .appendImpl("end;")
+                .appendImpl("procedure TTestDestructorLike.Bar; // Noncompliant")
+                .appendImpl("begin")
+                .appendImpl("  WriteLn('do something');")
+                .appendImpl("end;"))
+        .verifyIssues();
+  }
+
+  @Test
+  void testDestructorLikeWithoutInheritedOrOverrideShouldNotAddIssue() {
+    var check = new DestructorWithoutInheritedCheck();
+    check.destructorLikes = "Foo";
+
+    CheckVerifier.newVerifier()
+        .withCheck(check)
+        .onFile(
+            new DelphiTestUnitBuilder()
+                .appendDecl("type")
+                .appendDecl("  TTestDestructorLike = class(TObject)")
+                .appendDecl("  public")
+                .appendDecl("    procedure Foo;")
+                .appendDecl("  end;")
+                .appendImpl("procedure TTestDestructorLike.Foo;")
+                .appendImpl("begin")
+                .appendImpl("  WriteLn('do something');")
+                .appendImpl("end;"))
+        .verifyNoIssues();
+  }
+
+  @Test
+  void testRandomMethodWithoutInheritedShouldNotAddIssue() {
+    CheckVerifier.newVerifier()
+        .withCheck(new DestructorWithoutInheritedCheck())
+        .onFile(
+            new DelphiTestUnitBuilder()
+                .appendDecl("type")
+                .appendDecl("  TFoo = class(TObject)")
+                .appendDecl("  public")
+                .appendDecl("    procedure Bar; override;")
+                .appendDecl("  end;")
+                .appendImpl("procedure TTestDestructorLike.Bar;")
+                .appendImpl("begin")
+                .appendImpl("  WriteLn('do something');")
+                .appendImpl("end;"))
+        .verifyNoIssues();
+  }
 }


### PR DESCRIPTION
This PR improves coverage in `DestructorWithoutInheritedCheck`, which previously had only 50% coverage.