### PR TITLE
Fix IndexLastListElement issues on assignments and var/out

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Parsing errors where adjacent `>` and `=` tokens were wrongly interpreted as the `>=` operator.
+- False-positives within assignment statements in `IndexLastListElement`.
 
 ## [1.13.0] - 2025-02-05
 

--- a/delphi-checks/src/main/java/au/com/integradev/delphi/checks/IndexLastListElementCheck.java
+++ b/delphi-checks/src/main/java/au/com/integradev/delphi/checks/IndexLastListElementCheck.java
@@ -22,6 +22,7 @@ import java.util.List;
 import java.util.Optional;
 import org.sonar.check.Rule;
 import org.sonar.plugins.communitydelphi.api.ast.ArrayAccessorNode;
+import org.sonar.plugins.communitydelphi.api.ast.AssignmentStatementNode;
 import org.sonar.plugins.communitydelphi.api.ast.BinaryExpressionNode;
 import org.sonar.plugins.communitydelphi.api.ast.CommonDelphiNode;
 import org.sonar.plugins.communitydelphi.api.ast.DelphiNode;
@@ -45,6 +46,13 @@ public class IndexLastListElementCheck extends DelphiCheck {
     doVisit(arrayTypeNode, context);
 
     return super.visit(arrayTypeNode, context);
+  }
+
+  @Override
+  public DelphiCheckContext visit(
+      AssignmentStatementNode assignmentStatementNode, DelphiCheckContext context) {
+    // Ignore LHS of assignment statements - TList.Last is a function, so can't be put here
+    return super.visit(assignmentStatementNode.getValue(), context);
   }
 
   private void doVisit(ArrayAccessorNode arrayTypeNode, DelphiCheckContext context) {

--- a/delphi-checks/src/test/java/au/com/integradev/delphi/checks/IndexLastListElementCheckTest.java
+++ b/delphi-checks/src/test/java/au/com/integradev/delphi/checks/IndexLastListElementCheckTest.java
@@ -198,4 +198,22 @@ class IndexLastListElementCheckTest {
                 .appendImpl("end;"))
         .verifyIssues();
   }
+
+  @Test
+  void testAssignmentShouldNotAddIssue() {
+    CheckVerifier.newVerifier()
+        .withCheck(new IndexLastListElementCheck())
+        .withStandardLibraryUnit(systemGenericsCollections())
+        .onFile(
+            new DelphiTestUnitBuilder()
+                .appendImpl("uses")
+                .appendImpl("  System.Generics.Collections;")
+                .appendImpl("procedure Test;")
+                .appendImpl("var")
+                .appendImpl("  List: TList<Integer>;")
+                .appendImpl("begin")
+                .appendImpl("  List[List.Count - 1] := 5;")
+                .appendImpl("end;"))
+        .verifyNoIssues();
+  }
 }


### PR DESCRIPTION
This PR updates IndexLastListElement to ignore the left-hand side of expression statements. This is a current false-positive, since `TList.Last` is a function and is not eligible to be assigned to. 