### PR TITLE
Fix file pointer errors around `>=` and `<=` tokens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- File pointer errors around `>=` and `<=` tokens.
+
 ## [1.14.0] - 2025-03-03
 
 ### Added

--- a/delphi-frontend/src/main/antlr3/au/com/integradev/delphi/antlr/Delphi.g
+++ b/delphi-frontend/src/main/antlr3/au/com/integradev/delphi/antlr/Delphi.g
@@ -335,6 +335,8 @@ import org.apache.commons.lang3.StringUtils;
     CommonToken lastToken = (CommonToken) input.LT(-1);
     lastToken.setType(type);
     lastToken.setStartIndex(firstToken.getStartIndex());
+    lastToken.setLine(firstToken.getLine());
+    lastToken.setCharPositionInLine(firstToken.getCharPositionInLine());
     return lastToken;
   }
 


### PR DESCRIPTION
This PR fixes instances of  `IllegalArgumentException` being raised by the CPD executor on lines that end with `>=` or `<=`,, caused by file pointer errors.

`>=` and `<=` token positions were incorrect after token combination had occurred.
The solution is to adjust the token `line` and `charPositionInLine` as part of the combination step, where we previously only adjusted the token start/stop indices.