### PR TITLE
Fix "tokens out of order" CPD errors around `>=` and `<=` tokens

### DIFF
--- a/delphi-frontend/src/main/antlr3/au/com/integradev/delphi/antlr/Delphi.g
+++ b/delphi-frontend/src/main/antlr3/au/com/integradev/delphi/antlr/Delphi.g
@@ -333,11 +333,12 @@ import org.apache.commons.lang3.StringUtils;
   private Token combineLastNTokens(int type, int count) {
     CommonToken firstToken = (CommonToken) input.LT(-count);
     CommonToken lastToken = (CommonToken) input.LT(-1);
-    lastToken.setType(type);
-    lastToken.setStartIndex(firstToken.getStartIndex());
-    lastToken.setLine(firstToken.getLine());
-    lastToken.setCharPositionInLine(firstToken.getCharPositionInLine());
-    return lastToken;
+    CommonToken result = new CommonToken(lastToken);
+    result.setType(type);
+    result.setStartIndex(firstToken.getStartIndex());
+    result.setLine(firstToken.getLine());
+    result.setCharPositionInLine(firstToken.getCharPositionInLine());
+    return result;
   }
 
   private BinaryExpressionNodeImpl createBinaryExpression(Object operator) {

--- a/its/src/projects/cpd-simple/src/CpdTest.pas
+++ b/its/src/projects/cpd-simple/src/CpdTest.pas
@@ -15,7 +15,7 @@ type
   public
   {testDefinitionsIncludes}
   end;
-  
+
 type
   TfDemoSecond = class (TForm)
     bShowTracker: TButton;
@@ -25,7 +25,7 @@ type
   public
 
   end;
-  
+
 var
   fDemo: TfDemo;
 
@@ -37,7 +37,7 @@ begin
   multiline
   comment
   *)
-  
+
   for i:=0 to 100 do
   begin
     a := b;
@@ -46,7 +46,7 @@ begin
     end;
     c := d;
     a := b;
-    if a < b then begin
+    if a >= b then begin
       c := b;
     end;
   end;
@@ -59,11 +59,11 @@ begin
     end;
     c := d;
     a := b;
-    if a < b then begin
+    if a >= b then begin
       c := b;
     end;
   end;
-  
+
 end;
 
 end.


### PR DESCRIPTION
Token combination now creates a new token instead of mutating the last token in the group of combined tokens.

This was causing problems because the combined token would be reflected back to the original list of "raw tokens" returned by `DelphiFile::getTokens`, resulting in overlapping tokens being reported to the sonar API.

The mutability of the raw tokens is a point of brittleness that we could address, but it would have significant performance implications because it would involve constructing a copy of every token in every file.