### PR TITLE
Improve `RedundantJump` and fix bugs with control flow graph

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Exceptions from empty structures (e.g., `if`) in `LoopExecutingAtMostOnce` and `RedundantJump`.
+
 ## [1.14.1] - 2025-03-05
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Exceptions from empty structures (e.g., `if`) in `LoopExecutingAtMostOnce` and `RedundantJump`.
 - False positives from case statements in `LoopExecutingAtMostOnce`.
+- False positives from nested finally-except blocks in `RedundantJump`.
 
 ## [1.14.1] - 2025-03-05
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Exceptions from empty structures (e.g., `if`) in `LoopExecutingAtMostOnce` and `RedundantJump`.
+- False positives from case statements in `LoopExecutingAtMostOnce`.
 
 ## [1.14.1] - 2025-03-05
 

--- a/delphi-checks/src/main/java/au/com/integradev/delphi/checks/RedundantJumpCheck.java
+++ b/delphi-checks/src/main/java/au/com/integradev/delphi/checks/RedundantJumpCheck.java
@@ -18,18 +18,20 @@
  */
 package au.com.integradev.delphi.checks;
 
-import au.com.integradev.delphi.antlr.ast.node.RoutineImplementationNodeImpl;
-import au.com.integradev.delphi.cfg.ControlFlowGraphFactory;
 import au.com.integradev.delphi.cfg.api.Block;
 import au.com.integradev.delphi.cfg.api.ControlFlowGraph;
 import au.com.integradev.delphi.cfg.api.Finally;
+import au.com.integradev.delphi.cfg.api.Terminated;
 import au.com.integradev.delphi.cfg.api.UnconditionalJump;
+import au.com.integradev.delphi.utils.ControlFlowGraphUtils;
+import java.util.ArrayDeque;
+import java.util.Deque;
 import org.sonar.check.Rule;
-import org.sonar.plugins.communitydelphi.api.ast.AnonymousMethodNode;
 import org.sonar.plugins.communitydelphi.api.ast.ArgumentListNode;
 import org.sonar.plugins.communitydelphi.api.ast.DelphiNode;
+import org.sonar.plugins.communitydelphi.api.ast.FinallyBlockNode;
 import org.sonar.plugins.communitydelphi.api.ast.NameReferenceNode;
-import org.sonar.plugins.communitydelphi.api.ast.RoutineImplementationNode;
+import org.sonar.plugins.communitydelphi.api.ast.TryStatementNode;
 import org.sonar.plugins.communitydelphi.api.check.DelphiCheck;
 import org.sonar.plugins.communitydelphi.api.check.DelphiCheckContext;
 import org.sonar.plugins.communitydelphi.api.symbol.declaration.NameDeclaration;
@@ -39,103 +41,115 @@ import org.sonar.plugins.communitydelphi.api.symbol.declaration.RoutineNameDecla
 public class RedundantJumpCheck extends DelphiCheck {
   private static final String MESSAGE = "Remove this redundant jump.";
 
-  @Override
-  public DelphiCheckContext visit(RoutineImplementationNode routine, DelphiCheckContext context) {
-    ControlFlowGraph cfg = ((RoutineImplementationNodeImpl) routine).getControlFlowGraph();
-    if (cfg != null) {
-      cfg.getBlocks().forEach(block -> checkBlock(block, context));
-    }
-
-    return super.visit(routine, context);
-  }
+  private final Deque<TryStatementNode> tryFinallyStatements = new ArrayDeque<>();
 
   @Override
-  public DelphiCheckContext visit(AnonymousMethodNode routine, DelphiCheckContext context) {
-    ControlFlowGraph cfg = ControlFlowGraphFactory.create(routine.getStatementBlock());
-    cfg.getBlocks().forEach(block -> checkBlock(block, context));
-
-    return super.visit(routine, context);
+  public DelphiCheckContext visit(TryStatementNode node, DelphiCheckContext data) {
+    boolean finallyBlock = node.hasFinallyBlock();
+    if (!finallyBlock) {
+      return super.visit(node, data);
+    }
+    this.tryFinallyStatements.push(node);
+    super.visit(node.getStatementList(), data);
+    this.tryFinallyStatements.pop();
+    return super.visit(node.getFinallyBlock(), data);
   }
 
-  private void checkBlock(Block block, DelphiCheckContext context) {
-    if (!(block instanceof UnconditionalJump)) {
-      return;
+  @Override
+  public DelphiCheckContext visit(NameReferenceNode node, DelphiCheckContext data) {
+    RoutineNameDeclaration routineNameDeclaration = getRoutineNameDeclaration(node);
+    if (routineNameDeclaration != null
+        && (isContinue(routineNameDeclaration)
+            || isExitWithoutArgs(routineNameDeclaration, node))) {
+      checkJumpNode(node, data);
+      return data;
     }
-
-    UnconditionalJump jump = (UnconditionalJump) block;
-    DelphiNode terminator = jump.getTerminator();
-
-    RoutineNameDeclaration routineNameDeclaration = getRoutineNameDeclaration(terminator);
-    if (routineNameDeclaration == null) {
-      return;
-    }
-
-    if (!isContinueOrExit(routineNameDeclaration)
-        || isExitWithExpression(routineNameDeclaration, terminator)) {
-      return;
-    }
-
-    Block successor = jump.getSuccessor();
-    if (!successor.equals(jump.getSuccessorIfRemoved())) {
-      return;
-    }
-
-    Block finallyBlock = getFinallyBlock(block);
-    if (finallyBlock != null) {
-      if (onlyFinallyBlocksBeforeEnd(finallyBlock)) {
-        reportIssue(context, terminator, MESSAGE);
-      }
-      return;
-    }
-
-    reportIssue(context, terminator, MESSAGE);
+    return super.visit(node, data);
   }
 
-  private static Block getFinallyBlock(Block block) {
-    return block.getSuccessors().stream()
-        .filter(Finally.class::isInstance)
-        .findFirst()
-        .orElse(null);
-  }
-
-  private static boolean onlyFinallyBlocksBeforeEnd(Block finallyBlock) {
-    while (finallyBlock.getSuccessors().size() == 1) {
-      Block finallySuccessor = finallyBlock.getSuccessors().iterator().next();
-      if (!(finallySuccessor instanceof Finally)) {
-        break;
-      }
-      finallyBlock = finallySuccessor;
-    }
-    return finallyBlock.getSuccessors().size() == 1
-        && finallyBlock.getSuccessors().iterator().next().getSuccessors().isEmpty();
-  }
-
-  private static RoutineNameDeclaration getRoutineNameDeclaration(DelphiNode node) {
-    NameDeclaration nameDeclaration = null;
-    if (node instanceof NameReferenceNode) {
-      nameDeclaration = ((NameReferenceNode) node).getNameDeclaration();
-    }
+  private static RoutineNameDeclaration getRoutineNameDeclaration(NameReferenceNode node) {
+    NameDeclaration nameDeclaration = node.getNameDeclaration();
     if (nameDeclaration instanceof RoutineNameDeclaration) {
       return (RoutineNameDeclaration) nameDeclaration;
     }
     return null;
   }
 
-  private static boolean isContinueOrExit(RoutineNameDeclaration routineNameDeclaration) {
-    String fullyQualifiedName = routineNameDeclaration.fullyQualifiedName();
-    return fullyQualifiedName.equals("System.Continue") || fullyQualifiedName.equals("System.Exit");
+  private static boolean isContinue(RoutineNameDeclaration node) {
+    String name = node.fullyQualifiedName();
+    return name.equals("System.Continue");
   }
 
-  private static boolean isExitWithExpression(
-      RoutineNameDeclaration routineNameDeclaration, DelphiNode statement) {
-    String fullyQualifiedName = routineNameDeclaration.fullyQualifiedName();
-    if (!fullyQualifiedName.equals("System.Exit")) {
+  private static boolean isExitWithoutArgs(RoutineNameDeclaration node, DelphiNode statement) {
+    String name = node.fullyQualifiedName();
+    if (!name.equals("System.Exit")) {
       return false;
     }
 
     var argumentList = statement.getParent().getFirstChildOfType(ArgumentListNode.class);
     int arguments = argumentList == null ? 0 : argumentList.getArgumentNodes().size();
 
-    return arguments > 0;
+    return arguments == 0;
+  }
+
+  private static Block findBlockWithTerminator(ControlFlowGraph cfg, DelphiNode node) {
+    for (Block block : cfg.getBlocks()) {
+      if ((block instanceof Terminated) && ((Terminated) block).getTerminator() == node) {
+        return block;
+      }
+    }
+    return null;
+  }
+
+  private void checkJumpNode(NameReferenceNode node, DelphiCheckContext context) {
+    ControlFlowGraph cfg = ControlFlowGraphUtils.findContainingCFG(node);
+    if (cfg == null) {
+      return;
+    }
+
+    Block terminatedBlock = findBlockWithTerminator(cfg, node);
+    if (!(terminatedBlock instanceof UnconditionalJump)) {
+      // can't be a redundant jump without a jump
+      return;
+    }
+
+    UnconditionalJump jump = (UnconditionalJump) terminatedBlock;
+    Block successor = jump.getSuccessor();
+    if (!successor.equals(jump.getSuccessorIfRemoved())) {
+      // without the jump, the successor block would be different
+      return;
+    }
+
+    if (isViolation(cfg)) {
+      reportIssue(context, jump.getTerminator(), MESSAGE);
+    }
+  }
+
+  private boolean isViolation(ControlFlowGraph cfg) {
+    for (TryStatementNode tryFinally : this.tryFinallyStatements) {
+      Finally finallyBlock = findFinallyBlock(cfg, tryFinally.getFinallyBlock());
+      if (finallyBlock == null) {
+        // if the finally block cannot be found, we have traversed outside the scope of the cfg
+        break;
+      }
+      if (!finallyBlock.getSuccessor().equals(finallyBlock.getExceptionSuccessor())) {
+        // multiple paths after the finally corresponds to code that would be skipped from the jump
+        return false;
+      }
+    }
+    // if no invalidating try-finally blocks are found, the use is a violation
+    return true;
+  }
+
+  private static Finally findFinallyBlock(ControlFlowGraph cfg, FinallyBlockNode element) {
+    if (element == null) {
+      return null;
+    }
+    for (Block block : cfg.getBlocks()) {
+      if ((block instanceof Finally) && ((Finally) block).getTerminator().equals(element)) {
+        return (Finally) block;
+      }
+    }
+    return null;
   }
 }

--- a/delphi-checks/src/main/java/au/com/integradev/delphi/utils/ControlFlowGraphUtils.java
+++ b/delphi-checks/src/main/java/au/com/integradev/delphi/utils/ControlFlowGraphUtils.java
@@ -1,0 +1,66 @@
+/*
+ * Sonar Delphi Plugin
+ * Copyright (C) 2025 Integrated Application Development
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02
+ */
+package au.com.integradev.delphi.utils;
+
+import au.com.integradev.delphi.antlr.ast.node.AnonymousMethodNodeImpl;
+import au.com.integradev.delphi.antlr.ast.node.RoutineImplementationNodeImpl;
+import au.com.integradev.delphi.cfg.ControlFlowGraphFactory;
+import au.com.integradev.delphi.cfg.api.ControlFlowGraph;
+import java.util.function.Supplier;
+import org.sonar.plugins.communitydelphi.api.ast.CompoundStatementNode;
+import org.sonar.plugins.communitydelphi.api.ast.DelphiAst;
+import org.sonar.plugins.communitydelphi.api.ast.DelphiNode;
+import org.sonar.plugins.communitydelphi.api.ast.FinalizationSectionNode;
+import org.sonar.plugins.communitydelphi.api.ast.InitializationSectionNode;
+import org.sonar.plugins.communitydelphi.api.ast.StatementListNode;
+
+public final class ControlFlowGraphUtils {
+  private ControlFlowGraphUtils() {
+    // Utility class
+  }
+
+  private static Supplier<ControlFlowGraph> getCFGSupplier(DelphiNode node) {
+    if (node instanceof RoutineImplementationNodeImpl) {
+      return ((RoutineImplementationNodeImpl) node)::getControlFlowGraph;
+    }
+    if (node instanceof AnonymousMethodNodeImpl) {
+      return ((AnonymousMethodNodeImpl) node)::getControlFlowGraph;
+    }
+    if (node instanceof CompoundStatementNode && node.getParent() instanceof DelphiAst) {
+      return () -> ControlFlowGraphFactory.create((CompoundStatementNode) node);
+    }
+    if (node instanceof StatementListNode
+        && (node.getParent() instanceof InitializationSectionNode
+            || node.getParent() instanceof FinalizationSectionNode)) {
+      return () -> ControlFlowGraphFactory.create((StatementListNode) node);
+    }
+    return null;
+  }
+
+  public static ControlFlowGraph findContainingCFG(DelphiNode node) {
+    while (node != null) {
+      Supplier<ControlFlowGraph> cfgSupplier = getCFGSupplier(node);
+      if (cfgSupplier != null) {
+        return cfgSupplier.get();
+      }
+      node = node.getParent();
+    }
+    return null;
+  }
+}

--- a/delphi-checks/src/test/java/au/com/integradev/delphi/checks/LoopExecutingAtMostOnceCheckTest.java
+++ b/delphi-checks/src/test/java/au/com/integradev/delphi/checks/LoopExecutingAtMostOnceCheckTest.java
@@ -426,6 +426,46 @@ class LoopExecutingAtMostOnceCheckTest {
   }
 
   @Test
+  void testCaseBreakShouldNotAddIssue() {
+    DelphiTestUnitBuilder unitBuilder =
+        new DelphiTestUnitBuilder()
+            .appendImpl("procedure Test;")
+            .appendImpl("begin")
+            .appendImpl("  while A do begin // Compliant")
+            .appendImpl("    case True of")
+            .appendImpl("      True: Break; // Compliant")
+            .appendImpl("    end;")
+            .appendImpl("  end;")
+            .appendImpl("end;");
+
+    CheckVerifier.newVerifier()
+        .withCheck(new LoopExecutingAtMostOnceCheck())
+        .onFile(unitBuilder)
+        .verifyNoIssues();
+  }
+
+  @Test
+  void testCaseBreakElseBreakShouldAddIssue() {
+    DelphiTestUnitBuilder unitBuilder =
+        new DelphiTestUnitBuilder()
+            .appendImpl("procedure Test;")
+            .appendImpl("begin")
+            .appendImpl("  while A do begin // Noncompliant (2) (4)")
+            .appendImpl("    case True of")
+            .appendImpl("      True: Break; // Secondary")
+            .appendImpl("    else")
+            .appendImpl("      Break; // Secondary")
+            .appendImpl("    end;")
+            .appendImpl("  end;")
+            .appendImpl("end;");
+
+    CheckVerifier.newVerifier()
+        .withCheck(new LoopExecutingAtMostOnceCheck())
+        .onFile(unitBuilder)
+        .verifyIssues();
+  }
+
+  @Test
   void testIfNestedShouldNotAddIssue() {
     DelphiTestUnitBuilder unitBuilder =
         new DelphiTestUnitBuilder()

--- a/delphi-checks/src/test/java/au/com/integradev/delphi/checks/RedundantJumpCheckTest.java
+++ b/delphi-checks/src/test/java/au/com/integradev/delphi/checks/RedundantJumpCheckTest.java
@@ -263,6 +263,11 @@ class RedundantJumpCheckTest {
   }
 
   @Test
+  void testExitInExceptShouldAddIssue() {
+    doExitTest(List.of("try", "  Exit; // Noncompliant", "except", "  Foo2;", "end;"), true);
+  }
+
+  @Test
   void testExitInNestedTryFinallyAtEndShouldAddIssue() {
     doExitTest(
         List.of(
@@ -331,6 +336,27 @@ class RedundantJumpCheckTest {
   }
 
   @Test
+  void testExceptExitWithStatementAfterShouldNotAddIssue() {
+    doExitTest(
+        List.of(
+            "try",
+            "  try",
+            "    A;",
+            "  except",
+            "    on E: Exception do begin",
+            "      Exit;",
+            "    end;",
+            "  end;",
+            "finally;",
+            "  if B then begin",
+            "    C;",
+            "  end;",
+            "end;",
+            "C;"),
+        false);
+  }
+
+  @Test
   void testForLoopAfterConditionalTryFinallyExitShouldNotAddIssue() {
     doExitTest(
         List.of(
@@ -360,6 +386,42 @@ class RedundantJumpCheckTest {
             "  end;",
             "end;",
             "B;"),
+        false);
+  }
+
+  @Test
+  void testRedundantTryFinallyNestedAnonymousMethodShouldAddIssue() {
+    doExitTest(
+        List.of(
+            "try",
+            "  var A := procedure",
+            "    begin",
+            "      try",
+            "        Exit; // Noncompliant",
+            "      finally",
+            "      end;",
+            "    end;",
+            "finally",
+            "end;",
+            "A;"),
+        true);
+  }
+
+  @Test
+  void testNonRedundantTryFinallyNestedAnonymousMethodShouldNotAddIssue() {
+    doExitTest(
+        List.of(
+            "try",
+            "  var A := procedure",
+            "    begin",
+            "      try",
+            "        Exit;",
+            "      finally",
+            "      end;",
+            "      A;",
+            "    end;",
+            "finally",
+            "end;"),
         false);
   }
 

--- a/delphi-checks/src/test/java/au/com/integradev/delphi/utils/ControlFlowGraphUtilsTest.java
+++ b/delphi-checks/src/test/java/au/com/integradev/delphi/utils/ControlFlowGraphUtilsTest.java
@@ -1,0 +1,106 @@
+/*
+ * Sonar Delphi Plugin
+ * Copyright (C) 2025 Integrated Application Development
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02
+ */
+package au.com.integradev.delphi.utils;
+
+import static org.assertj.core.api.Assertions.*;
+
+import au.com.integradev.delphi.builders.DelphiTestProgramBuilder;
+import au.com.integradev.delphi.builders.DelphiTestUnitBuilder;
+import au.com.integradev.delphi.cfg.api.ControlFlowGraph;
+import au.com.integradev.delphi.file.DelphiFile;
+import org.junit.jupiter.api.Test;
+import org.sonar.plugins.communitydelphi.api.ast.DelphiNode;
+import org.sonar.plugins.communitydelphi.api.ast.NameReferenceNode;
+
+class ControlFlowGraphUtilsTest {
+  private static final String NAME_TO_FIND = "ABC123";
+
+  private static void testFindCfg(DelphiFile unit) {
+    DelphiNode node =
+        unit.getAst().findDescendantsOfType(NameReferenceNode.class).stream()
+            .filter(n -> n.getIdentifier().getImage().equals(NAME_TO_FIND))
+            .findFirst()
+            .orElseThrow();
+
+    ControlFlowGraph cfg = ControlFlowGraphUtils.findContainingCFG(node);
+    assertThat(cfg).isNotNull();
+    assertThat(cfg.getBlocks().stream().filter(b -> b.getElements().contains(node)).count())
+        .isEqualTo(1);
+  }
+
+  @Test
+  void testFindCfgInRoutine() {
+    testFindCfg(
+        new DelphiTestUnitBuilder()
+            .appendImpl("procedure Test;")
+            .appendImpl("begin")
+            .appendImpl(String.format("  %s;", NAME_TO_FIND))
+            .appendImpl("end;")
+            .delphiFile());
+  }
+
+  @Test
+  void testFindCfgInAnonymousRoutine() {
+    testFindCfg(
+        new DelphiTestUnitBuilder()
+            .appendImpl("procedure Test;")
+            .appendImpl("begin")
+            .appendImpl(String.format("  %s;", NAME_TO_FIND))
+            .appendImpl(String.format("  var Proc := procedure begin %s; end;", NAME_TO_FIND))
+            .appendImpl(String.format("  %s;", NAME_TO_FIND))
+            .appendImpl("end;")
+            .delphiFile());
+  }
+
+  @Test
+  void testFindCfgInUnitBegin() {
+    testFindCfg(
+        new DelphiTestUnitBuilder()
+            .appendImpl("begin")
+            .appendImpl(String.format("  %s;", NAME_TO_FIND))
+            .delphiFile());
+  }
+
+  @Test
+  void testFindCfgInInitialization() {
+    testFindCfg(
+        new DelphiTestUnitBuilder()
+            .appendImpl("initialization")
+            .appendImpl(String.format("  %s;", NAME_TO_FIND))
+            .delphiFile());
+  }
+
+  @Test
+  void testFindCfgInFinalization() {
+    testFindCfg(
+        new DelphiTestUnitBuilder()
+            .appendImpl("initialization")
+            .appendImpl("finalization")
+            .appendImpl(String.format("  %s;", NAME_TO_FIND))
+            .delphiFile());
+  }
+
+  @Test
+  void testFindCfgInProgram() {
+    testFindCfg(
+        new DelphiTestProgramBuilder()
+            .appendImpl(String.format("  %s;", NAME_TO_FIND))
+            .delphiFile());
+  }
+}

--- a/delphi-frontend/src/main/java/au/com/integradev/delphi/cfg/ControlFlowGraphDebug.java
+++ b/delphi-frontend/src/main/java/au/com/integradev/delphi/cfg/ControlFlowGraphDebug.java
@@ -83,7 +83,7 @@ public final class ControlFlowGraphDebug {
   }
 
   private static String getBlockString(Block block) {
-    return "B" + ((BlockImpl) block).getId();
+    return "B" + ((BlockImpl) block).getId() + " - " + ((BlockImpl) block).getBlockType();
   }
 
   private static <T> Optional<T> getAs(Block block, Class<T> clazz) {

--- a/delphi-frontend/src/main/java/au/com/integradev/delphi/cfg/ControlFlowGraphVisitor.java
+++ b/delphi-frontend/src/main/java/au/com/integradev/delphi/cfg/ControlFlowGraphVisitor.java
@@ -531,7 +531,9 @@ class ControlFlowGraphVisitor implements DelphiParserVisitor<ControlFlowGraphBui
     // Finally
     FinallyBlockNode finallyNode = node.getFinallyBlock();
     builder.addBlock(
-        ProtoBlockFactory.finallyBlock(builder.getCurrentBlock(), builder.getExitBlock()));
+        ProtoBlockFactory.finallyBlock(
+            node.getFinallyBlock(), builder.getCurrentBlock(), builder.getExitBlock()));
+
     build(finallyNode.getStatementList(), builder);
     builder.pushLoopContext(builder.getCurrentBlock(), builder.getCurrentBlock());
     builder.pushExitBlock(builder.getCurrentBlock());

--- a/delphi-frontend/src/main/java/au/com/integradev/delphi/cfg/ControlFlowGraphVisitor.java
+++ b/delphi-frontend/src/main/java/au/com/integradev/delphi/cfg/ControlFlowGraphVisitor.java
@@ -524,6 +524,9 @@ class ControlFlowGraphVisitor implements DelphiParserVisitor<ControlFlowGraphBui
 
   private ControlFlowGraphBuilder buildTryFinally(
       TryStatementNode node, ControlFlowGraphBuilder builder) {
+    // to ensure after a `finally` exceptional paths still exist
+    handleExceptionalPaths(builder);
+
     builder.addBlockBeforeCurrent();
     // Finally
     FinallyBlockNode finallyNode = node.getFinallyBlock();

--- a/delphi-frontend/src/main/java/au/com/integradev/delphi/cfg/api/Branch.java
+++ b/delphi-frontend/src/main/java/au/com/integradev/delphi/cfg/api/Branch.java
@@ -18,6 +18,8 @@
  */
 package au.com.integradev.delphi.cfg.api;
 
+import java.util.Collections;
+import java.util.HashSet;
 import java.util.Set;
 
 /** A block where the control flow is dictated by a boolean condition, e.g., {@code if} */
@@ -38,6 +40,9 @@ public interface Branch extends Block, Terminated {
 
   @Override
   default Set<Block> getSuccessors() {
-    return Set.of(getTrueBlock(), getFalseBlock());
+    Set<Block> successors = new HashSet<>();
+    successors.add(getTrueBlock());
+    successors.add(getFalseBlock());
+    return Collections.unmodifiableSet(successors);
   }
 }

--- a/delphi-frontend/src/main/java/au/com/integradev/delphi/cfg/api/Cases.java
+++ b/delphi-frontend/src/main/java/au/com/integradev/delphi/cfg/api/Cases.java
@@ -18,6 +18,8 @@
  */
 package au.com.integradev.delphi.cfg.api;
 
+import java.util.Collections;
+import java.util.HashSet;
 import java.util.Set;
 
 /** A block for the {@code case} statement's behaviour of a possible successor for each arm */
@@ -38,6 +40,8 @@ public interface Cases extends Block, Terminated {
 
   @Override
   default Set<Block> getSuccessors() {
-    return getCaseSuccessors();
+    Set<Block> successors = new HashSet<>(getCaseSuccessors());
+    successors.add(getFallthroughSuccessor());
+    return Collections.unmodifiableSet(successors);
   }
 }

--- a/delphi-frontend/src/main/java/au/com/integradev/delphi/cfg/api/Finally.java
+++ b/delphi-frontend/src/main/java/au/com/integradev/delphi/cfg/api/Finally.java
@@ -23,7 +23,7 @@ import java.util.HashSet;
 import java.util.Set;
 
 /** A {@code finally} block whose control flow depends on the existence of previous exceptions */
-public interface Finally extends Block {
+public interface Finally extends Block, Terminated {
   /**
    * Next block in the {@link ControlFlowGraph} without exceptional circumstances
    *

--- a/delphi-frontend/src/main/java/au/com/integradev/delphi/cfg/block/BlockImpl.java
+++ b/delphi-frontend/src/main/java/au/com/integradev/delphi/cfg/block/BlockImpl.java
@@ -67,4 +67,6 @@ public abstract class BlockImpl implements Block {
   }
 
   public abstract String getDescription();
+
+  public abstract String getBlockType();
 }

--- a/delphi-frontend/src/main/java/au/com/integradev/delphi/cfg/block/ProtoBlockFactory.java
+++ b/delphi-frontend/src/main/java/au/com/integradev/delphi/cfg/block/ProtoBlockFactory.java
@@ -143,6 +143,11 @@ public final class ProtoBlockFactory {
           "%n\tjumps to: %s%n\texceptions to: %s",
           getBlockString(successor), getBlocksString(exceptions));
     }
+
+    @Override
+    public String getBlockType() {
+      return "UnknownException";
+    }
   }
 
   static class CasesImpl extends BlockImpl implements Cases {
@@ -194,6 +199,11 @@ public final class ProtoBlockFactory {
           "%n\tcases to: %s%n\tfallthrough to: %s",
           getBlocksString(cases), getBlockString(fallthrough));
     }
+
+    @Override
+    public String getBlockType() {
+      return "Cases";
+    }
   }
 
   static class UnconditionalJumpImpl extends BlockImpl implements UnconditionalJump {
@@ -243,6 +253,11 @@ public final class ProtoBlockFactory {
           "%n\tjumps to: %s%n\twithout jump to: %s",
           getBlockString(target), getBlockString(withoutJump));
     }
+
+    @Override
+    public String getBlockType() {
+      return "UnconditionalJump";
+    }
   }
 
   static class LinearImpl extends BlockImpl implements Linear {
@@ -269,6 +284,11 @@ public final class ProtoBlockFactory {
     @Override
     public String getDescription() {
       return String.format("%n\tjumps to: %s", getBlockString(successor));
+    }
+
+    @Override
+    public String getBlockType() {
+      return "Linear";
     }
   }
 
@@ -307,6 +327,11 @@ public final class ProtoBlockFactory {
           "%n\tjumps to: %s%n\texits to: %s",
           getBlockString(successor), getBlockString(exceptionSuccessor));
     }
+
+    @Override
+    public String getBlockType() {
+      return "Finally";
+    }
   }
 
   static class HaltImpl extends BlockImpl implements Halt {
@@ -339,6 +364,11 @@ public final class ProtoBlockFactory {
     public String getDescription() {
       return String.format("%n\tno successors");
     }
+
+    @Override
+    public String getBlockType() {
+      return "Halt";
+    }
   }
 
   private static class TerminusImpl extends BlockImpl implements Terminus {
@@ -355,6 +385,11 @@ public final class ProtoBlockFactory {
     @Override
     public String getDescription() {
       return String.format("%n\t(Exit)");
+    }
+
+    @Override
+    public String getBlockType() {
+      return "Terminus";
     }
   }
 
@@ -404,6 +439,11 @@ public final class ProtoBlockFactory {
       return String.format(
           "%n\tjumps to: %s(true) %s(false)",
           getBlockString(trueBlock), getBlockString(falseBlock));
+    }
+
+    @Override
+    public String getBlockType() {
+      return "Branch";
     }
   }
 }

--- a/delphi-frontend/src/test/java/au/com/integradev/delphi/cfg/ControlFlowGraphTest.java
+++ b/delphi-frontend/src/test/java/au/com/integradev/delphi/cfg/ControlFlowGraphTest.java
@@ -59,6 +59,7 @@ import org.sonar.plugins.communitydelphi.api.ast.BinaryExpressionNode;
 import org.sonar.plugins.communitydelphi.api.ast.CaseStatementNode;
 import org.sonar.plugins.communitydelphi.api.ast.CommonDelphiNode;
 import org.sonar.plugins.communitydelphi.api.ast.DelphiNode;
+import org.sonar.plugins.communitydelphi.api.ast.FinallyBlockNode;
 import org.sonar.plugins.communitydelphi.api.ast.ForInStatementNode;
 import org.sonar.plugins.communitydelphi.api.ast.ForToStatementNode;
 import org.sonar.plugins.communitydelphi.api.ast.GotoStatementNode;
@@ -818,7 +819,9 @@ class ControlFlowGraphTest {
         checker(
             block(element(TryStatementNode.class)).succeedsTo(2),
             block(element(NameReferenceNode.class, "Foo")).succeedsToWithExceptions(1, 1),
-            block(element(NameReferenceNode.class, "Bar")).succeedsToWithExit(0, 0)));
+            block(element(NameReferenceNode.class, "Bar"))
+                .withTerminator(FinallyBlockNode.class)
+                .succeedsToWithExit(0, 0)));
   }
 
   @Test
@@ -830,7 +833,9 @@ class ControlFlowGraphTest {
             block(element(NameReferenceNode.class, "E"))
                 .withTerminator(RaiseStatementNode.class, TerminatorKind.RAISE)
                 .jumpsTo(1, 1),
-            block(element(NameReferenceNode.class, "Bar")).succeedsToWithExit(0, 0)));
+            block(element(NameReferenceNode.class, "Bar"))
+                .withTerminator(FinallyBlockNode.class)
+                .succeedsToWithExit(0, 0)));
   }
 
   @Test
@@ -840,7 +845,9 @@ class ControlFlowGraphTest {
         checker(
             block(element(TryStatementNode.class)).succeedsTo(2),
             terminator(StatementTerminator.EXIT).jumpsTo(1, 1),
-            block(element(NameReferenceNode.class, "Bar")).succeedsToWithExit(0, 0)));
+            block(element(NameReferenceNode.class, "Bar"))
+                .withTerminator(FinallyBlockNode.class)
+                .succeedsToWithExit(0, 0)));
   }
 
   @Test
@@ -853,7 +860,9 @@ class ControlFlowGraphTest {
                 .withTerminator(WhileStatementNode.class),
             block(element(TryStatementNode.class)).succeedsTo(2),
             terminator(StatementTerminator.BREAK).jumpsTo(1, 1),
-            block(element(NameReferenceNode.class, "Bar")).succeedsToWithExit(4, 0)));
+            block(element(NameReferenceNode.class, "Bar"))
+                .withTerminator(FinallyBlockNode.class)
+                .succeedsToWithExit(4, 0)));
   }
 
   @Test
@@ -866,7 +875,9 @@ class ControlFlowGraphTest {
                 .withTerminator(WhileStatementNode.class),
             block(element(TryStatementNode.class)).succeedsTo(2),
             terminator(StatementTerminator.CONTINUE).jumpsTo(1, 1),
-            block(element(NameReferenceNode.class, "Bar")).succeedsToWithExit(4, 0)));
+            block(element(NameReferenceNode.class, "Bar"))
+                .withTerminator(FinallyBlockNode.class)
+                .succeedsToWithExit(4, 0)));
   }
 
   @Test
@@ -876,7 +887,9 @@ class ControlFlowGraphTest {
         checker(
             block(element(TryStatementNode.class)).succeedsTo(2),
             terminator(StatementTerminator.HALT).isSink(),
-            block(element(NameReferenceNode.class, "Bar")).succeedsToWithExit(0, 0)));
+            block(element(NameReferenceNode.class, "Bar"))
+                .withTerminator(FinallyBlockNode.class)
+                .succeedsToWithExit(0, 0)));
   }
 
   @Test
@@ -894,7 +907,9 @@ class ControlFlowGraphTest {
             block(element(IntegerLiteralNode.class)).succeedsTo(1),
             block(element(TryStatementNode.class)).succeedsTo(3),
             terminator(StatementTerminator.CONTINUE).jumpsTo(2, 2),
-            block(element(NameReferenceNode.class, "Bar")).succeedsToWithExit(1, 0),
+            block(element(NameReferenceNode.class, "Bar"))
+                .withTerminator(FinallyBlockNode.class)
+                .succeedsToWithExit(1, 0),
             block(element(NameDeclarationNode.class, "A"))
                 .branchesTo(4, 0)
                 .withTerminator(ForToStatementNode.class)));
@@ -915,7 +930,9 @@ class ControlFlowGraphTest {
             block(element(IntegerLiteralNode.class)).succeedsTo(1),
             block(element(TryStatementNode.class)).succeedsTo(3),
             terminator(StatementTerminator.BREAK).jumpsTo(2, 2),
-            block(element(NameReferenceNode.class, "Bar")).succeedsToWithExit(1, 0),
+            block(element(NameReferenceNode.class, "Bar"))
+                .withTerminator(FinallyBlockNode.class)
+                .succeedsToWithExit(1, 0),
             block(element(NameDeclarationNode.class, "A"))
                 .branchesTo(4, 0)
                 .withTerminator(ForToStatementNode.class)));
@@ -936,7 +953,9 @@ class ControlFlowGraphTest {
             block(element(IntegerLiteralNode.class)).succeedsTo(1),
             block(element(TryStatementNode.class)).succeedsTo(3),
             terminator(StatementTerminator.EXIT).jumpsTo(2, 2),
-            block(element(NameReferenceNode.class, "Bar")).succeedsToWithExit(1, 0),
+            block(element(NameReferenceNode.class, "Bar"))
+                .succeedsToWithExit(1, 0)
+                .withTerminator(FinallyBlockNode.class),
             block(element(NameDeclarationNode.class, "A"))
                 .branchesTo(4, 0)
                 .withTerminator(ForToStatementNode.class)));
@@ -957,7 +976,9 @@ class ControlFlowGraphTest {
             block(element(IntegerLiteralNode.class)).succeedsTo(1),
             block(element(TryStatementNode.class)).succeedsTo(3),
             terminator(StatementTerminator.HALT).isSink(),
-            block(element(NameReferenceNode.class, "Bar")).succeedsToWithExit(1, 0),
+            block(element(NameReferenceNode.class, "Bar"))
+                .succeedsToWithExit(1, 0)
+                .withTerminator(FinallyBlockNode.class),
             block(element(NameDeclarationNode.class, "A"))
                 .branchesTo(4, 0)
                 .withTerminator(ForToStatementNode.class)));
@@ -971,7 +992,9 @@ class ControlFlowGraphTest {
         checker(
             block(element(TryStatementNode.class)).succeedsTo(2),
             block(element(NameReferenceNode.class, "Foo")).succeedsToWithExceptions(1, 1),
-            block(element(NameReferenceNode.class, "Bar")).succeedsToWithExit(0, 0)));
+            block(element(NameReferenceNode.class, "Bar"))
+                .withTerminator(FinallyBlockNode.class)
+                .succeedsToWithExit(0, 0)));
   }
 
   @Test
@@ -1128,7 +1151,9 @@ class ControlFlowGraphTest {
             block(element(NameReferenceNode.class, "Foo")).succeedsToWithExceptions(1, 1, 2),
             block(element(NameDeclarationNode.class, "E"), element(NameReferenceNode.class, "Bar"))
                 .succeedsToWithExceptions(1, 1),
-            block(element(NameReferenceNode.class, "Baz")).succeedsToWithExit(0, 0)));
+            block(element(NameReferenceNode.class, "Baz"))
+                .withTerminator(FinallyBlockNode.class)
+                .succeedsToWithExit(0, 0)));
   }
 
   @Test
@@ -1146,7 +1171,7 @@ class ControlFlowGraphTest {
             block(element(TryStatementNode.class)).succeedsTo(5),
             block(element(NameReferenceNode.class, "Foo")).succeedsToWithExceptions(4, 4),
             block(element(NameReferenceNode.class, "Bar")).succeedsToWithExceptions(3, 0, 1),
-            block().succeedsToWithExit(2, 0),
+            terminator(FinallyBlockNode.class).succeedsToWithExit(2, 0),
             block().succeedsToWithExceptions(0, 0, 1),
             block(element(NameDeclarationNode.class, "E"), element(NameReferenceNode.class, "Baz"))
                 .succeedsTo(0)));
@@ -1205,7 +1230,7 @@ class ControlFlowGraphTest {
         "try finally end; A",
         checker(
             block(element(TryStatementNode.class)).succeedsTo(2),
-            block().succeedsToWithExit(1, 0),
+            terminator(FinallyBlockNode.class).succeedsToWithExit(1, 0),
             block(element(NameReferenceNode.class, "A")).succeedsTo(0)));
   }
 
@@ -1568,7 +1593,7 @@ class ControlFlowGraphTest {
                 .succeedsTo(2),
             block(element(TextLiteralNode.class, "'b'"), element(NameReferenceNode.class, "X"))
                 .succeedsTo(2),
-            block().succeedsToWithExit(12, 0),
+            terminator(FinallyBlockNode.class).succeedsToWithExit(12, 0),
             block(element(NameReferenceNode.class, "Foo4")).succeedsTo(0)));
   }
 }

--- a/delphi-frontend/src/test/java/au/com/integradev/delphi/cfg/ControlFlowGraphTest.java
+++ b/delphi-frontend/src/test/java/au/com/integradev/delphi/cfg/ControlFlowGraphTest.java
@@ -1142,10 +1142,12 @@ class ControlFlowGraphTest {
                 "procedure Baz; begin end")),
         "try try Foo finally Bar end except on E: Exception do Baz end;",
         checker(
-            block(element(TryStatementNode.class)).succeedsTo(4),
-            block(element(TryStatementNode.class)).succeedsTo(3),
-            block(element(NameReferenceNode.class, "Foo")).succeedsToWithExceptions(2, 2),
-            block(element(NameReferenceNode.class, "Bar")).succeedsToWithExceptions(0, 0, 1),
+            block(element(TryStatementNode.class)).succeedsTo(6),
+            block(element(TryStatementNode.class)).succeedsTo(5),
+            block(element(NameReferenceNode.class, "Foo")).succeedsToWithExceptions(4, 4),
+            block(element(NameReferenceNode.class, "Bar")).succeedsToWithExceptions(3, 0, 1),
+            block().succeedsToWithExit(2, 0),
+            block().succeedsToWithExceptions(0, 0, 1),
             block(element(NameDeclarationNode.class, "E"), element(NameReferenceNode.class, "Baz"))
                 .succeedsTo(0)));
   }

--- a/delphi-frontend/src/test/java/au/com/integradev/delphi/cfg/checker/BlockChecker.java
+++ b/delphi-frontend/src/test/java/au/com/integradev/delphi/cfg/checker/BlockChecker.java
@@ -85,7 +85,7 @@ public class BlockChecker {
     if (terminatorChecker != null) {
       terminatorChecker.check(block);
     } else {
-      assertThat(block.getSuccessors())
+      assertThat(block)
           .withFailMessage("%s should have its terminator specified", getBlockDisplay(block))
           .isNotInstanceOf(Terminated.class);
     }


### PR DESCRIPTION
This PR fixes various control flow graph bugs (which fixes #340). Additionally, a bug in `RedundantJumpCheck` has been fixed where nested try-finally blocks were erroneously raising issues.