### PR TITLE
Exclude types annotated with attributes in `UnusedType`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Exclude types annotated with attributes in `UnusedType`.
+
 ### Fixed
 
 - Exceptions from empty structures (e.g., `if`) in `LoopExecutingAtMostOnce` and `RedundantJump`.

--- a/delphi-checks/src/main/java/au/com/integradev/delphi/checks/UnusedTypeCheck.java
+++ b/delphi-checks/src/main/java/au/com/integradev/delphi/checks/UnusedTypeCheck.java
@@ -69,6 +69,10 @@ public class UnusedTypeCheck extends DelphiCheck {
       return false;
     }
 
+    if (node.getAttributeList() != null) {
+      return false;
+    }
+
     return node.getTypeNameNode().getUsages().stream()
         .allMatch(occurrence -> isWithinType(occurrence, type));
   }

--- a/delphi-checks/src/test/java/au/com/integradev/delphi/checks/UnusedTypeCheckTest.java
+++ b/delphi-checks/src/test/java/au/com/integradev/delphi/checks/UnusedTypeCheckTest.java
@@ -199,4 +199,17 @@ class UnusedTypeCheckTest {
                 .appendImpl("end;"))
         .verifyIssues();
   }
+
+  @Test
+  void testUnusedTypeWithAttributeShouldNotAddIssue() {
+    CheckVerifier.newVerifier()
+        .withCheck(new UnusedTypeCheck())
+        .onFile(
+            new DelphiTestUnitBuilder()
+                .appendDecl("type")
+                .appendDecl("  [Bar]")
+                .appendDecl("  TFoo = class")
+                .appendDecl("  end;"))
+        .verifyNoIssues();
+  }
 }


### PR DESCRIPTION
This PR adds an exclusion to `UnusedType` for types that are annotated with custom attributes.

It's unclear why this wasn't already the case, as the same exclusion is already present in `UnusedRoutine`, `UnusedProperty`, and `UnusedField`.