### PR TITLE
Define the `WEAK_NATIVEINT` conditional on Delphi 12+

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Support for the `WEAK_NATIVEINT` symbol, which is defined from Delphi 12 onward.
+
 ### Changed
 
 - Exclude types annotated with attributes in `UnusedType`.

--- a/delphi-frontend/src/main/java/au/com/integradev/delphi/compiler/PredefinedConditionals.java
+++ b/delphi-frontend/src/main/java/au/com/integradev/delphi/compiler/PredefinedConditionals.java
@@ -226,6 +226,10 @@ public final class PredefinedConditionals {
       result.add("WEAKINTFREF");
     }
 
+    if (compilerVersion.compareTo(VERSION_ATHENS) >= 0) {
+      result.add("WEAK_NATIVEINT");
+    }
+
     if (checkToolchain(Toolchain.DCCIOSSIMARM64)) {
       result.add("IOSSIMULATOR");
     }

--- a/delphi-frontend/src/test/java/au/com/integradev/delphi/compiler/PredefinedConditionalsTest.java
+++ b/delphi-frontend/src/test/java/au/com/integradev/delphi/compiler/PredefinedConditionalsTest.java
@@ -406,4 +406,11 @@ class PredefinedConditionalsTest {
     assertThat(PredefinedConditionals.getConditionalDefines(toolchain, VERSION_ALEXANDRIA))
         .doesNotContain("LLVM");
   }
+
+  @ParameterizedTest
+  @EnumSource(value = Toolchain.class)
+  void testAllToolchainsAfterDelphiAlexandriaShouldDefineWeakNativeInt(Toolchain toolchain) {
+    assertThat(PredefinedConditionals.getConditionalDefines(toolchain, VERSION_ATHENS))
+        .contains("WEAK_NATIVEINT");
+  }
 }


### PR DESCRIPTION
This PR adds support for the undocumented `WEAK_NATIVEINT` predefined conditional symbol.
It's defined from Delphi 12 onward.

This was discovered due to a strange false positive on Delphi 12:
![image](https://github.com/user-attachments/assets/b3cf3f30-8dd6-4ead-a1ea-f3637e358e3c)

It turns out that the Delphi 12 RTL still declares `TNativeIntHelper` and gates it behind this `WEAK_NATIVEINT` symbol.
Without the symbol defined, the analyzer would see the `TNativeIntHelper` record helper defined and overriding `TIntegerHelper` since (as weak aliases) they are the same type now.

This caused the analyzer to think that `TNativeIntHelper.Parse` was being called, which (of course) returns a `NativeInt` and confuses the `PlatformDependentTruncation` check.