### PR TITLE
Add support for undocumented `varargs` intrinsics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Support for the `WEAK_NATIVEINT` symbol, which is defined from Delphi 12 onward.
+- Support for undocumented intrinsics usable within `varargs` routines:
+  - `VarArgStart`
+  - `VarArgGetValue`
+  - `VarArgCopy`
+  - `VarArgEnd`
 
 ### Changed
 

--- a/delphi-frontend/src/main/java/au/com/integradev/delphi/type/intrinsic/IntrinsicReturnType.java
+++ b/delphi-frontend/src/main/java/au/com/integradev/delphi/type/intrinsic/IntrinsicReturnType.java
@@ -85,8 +85,8 @@ public abstract class IntrinsicReturnType extends TypeImpl {
     return new SliceReturnType(typeFactory);
   }
 
-  public static Type classReferenceValue() {
-    return new ClassReferenceValueType();
+  public static Type classReferenceValue(int argumentIndex) {
+    return new ClassReferenceValueType(argumentIndex);
   }
 
   public static Type argumentByIndex(int index) {
@@ -179,9 +179,15 @@ public abstract class IntrinsicReturnType extends TypeImpl {
   }
 
   private static final class ClassReferenceValueType extends IntrinsicReturnType {
+    private final int argumentIndex;
+
+    private ClassReferenceValueType(int argumentIndex) {
+      this.argumentIndex = argumentIndex;
+    }
+
     @Override
     public Type getReturnType(List<Type> arguments) {
-      Type type = arguments.get(0);
+      Type type = arguments.get(argumentIndex);
       if (type.isClassReference()) {
         return ((ClassReferenceType) type).classType();
       }

--- a/delphi-frontend/src/main/java/au/com/integradev/delphi/type/intrinsic/IntrinsicsInjector.java
+++ b/delphi-frontend/src/main/java/au/com/integradev/delphi/type/intrinsic/IntrinsicsInjector.java
@@ -202,7 +202,7 @@ public final class IntrinsicsInjector {
     routine("Dec").varParam(ANY_TYPED_POINTER).param(type(INTEGER)).required(1);
     routine("Default")
         .param(ANY_CLASS_REFERENCE)
-        .returns(IntrinsicReturnType.classReferenceValue());
+        .returns(IntrinsicReturnType.classReferenceValue(0));
     routine("Delete").varParam(ANY_STRING).param(type(INTEGER)).param(type(INTEGER));
     routine("Delete")
         .varParam(LIKE_DYNAMIC_ARRAY)
@@ -312,6 +312,13 @@ public final class IntrinsicsInjector {
         .param(ANY_STRING)
         .varParam(TypeFactory.untypedType())
         .varParam(ANY_32_BIT_INTEGER);
+    routine("VarArgStart").varParam(TypeFactory.untypedType());
+    routine("VarArgGetValue")
+        .varParam(TypeFactory.untypedType())
+        .param(ANY_CLASS_REFERENCE)
+        .returns(IntrinsicReturnType.classReferenceValue(1));
+    routine("VarArgCopy").varParam(TypeFactory.untypedType()).varParam(TypeFactory.untypedType());
+    routine("VarArgEnd").varParam(TypeFactory.untypedType());
     routine("VarArrayRedim").varParam(ANY_VARIANT).param(type(INTEGER));
     routine("VarCast").varParam(ANY_VARIANT).param(ANY_VARIANT).param(type(INTEGER));
     routine("VarClear").varParam(ANY_VARIANT);

--- a/delphi-frontend/src/test/java/au/com/integradev/delphi/type/intrinsic/IntrinsicReturnTypeTest.java
+++ b/delphi-frontend/src/test/java/au/com/integradev/delphi/type/intrinsic/IntrinsicReturnTypeTest.java
@@ -148,7 +148,7 @@ class IntrinsicReturnTypeTest {
     Type classType = mock(StructType.class);
     Type classReference = TYPE_FACTORY_64_ALEXANDRIA.classOf("Foo", classType);
 
-    var classReferenceValue = (IntrinsicReturnType) IntrinsicReturnType.classReferenceValue();
+    var classReferenceValue = (IntrinsicReturnType) IntrinsicReturnType.classReferenceValue(0);
     assertThat(classReferenceValue.getReturnType(List.of(classReference))).isSameAs(classType);
     assertThat(classReferenceValue.getReturnType(List.of(classType)).isUnknown()).isTrue();
   }


### PR DESCRIPTION
This PR adds support for 4 undocumented intrinsics that are usable within `varargs` routines.

Signatures for these intrinsics can be found in `System`:
```pas
  // procedure VarArgStart(var ArgList: TVarArgList);
  // function  VarArgGetValue(var ArgList: TVarArgList; ArgType: Type): ArgType;
  // procedure VarArgCopy(var DestArgList, SrcArgList: TVarArgList);
  // procedure VarArgEnd(var ArgList: TVarArgList);
```

We can't easily inject intrinsics with specific concrete types like `System.TVarArgList`, so I've opted for the "good enough" solution of using untyped parameters for these. I can't see any obvious way for this to result in a less inaccurate analysis (on source code that successfully compiles).

### See also
* [How to create a Delphi variadic method similar to Write/Writeln without requiring brackets for arguments?](https://en.delphipraxis.net/topic/12789-how-to-create-a-delphi-variadic-method-similar-to-writewriteln-without-requiring-brackets-for-arguments/?do=findComment&comment=99558)
* [\[fpc-devel\] C-block reference syntax (blocker for 3.2)](https://lists.freepascal.org/fpc-devel/2019-December/042285.html)