### PR TITLE
Implement `ParsingError` check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `ParsingError` analysis rule, which flags files where parsing failures occurred.
 - Support for the `WEAK_NATIVEINT` symbol, which is defined from Delphi 12 onward.
 - Support for undocumented intrinsics usable within `varargs` routines:
   - `VarArgStart`

--- a/delphi-checks/src/main/java/au/com/integradev/delphi/checks/CheckList.java
+++ b/delphi-checks/src/main/java/au/com/integradev/delphi/checks/CheckList.java
@@ -115,6 +115,7 @@ public final class CheckList {
           NoSonarCheck.class,
           NonLinearCastCheck.class,
           ObjectTypeCheck.class,
+          ParsingErrorCheck.class,
           PascalStyleResultCheck.class,
           PlatformDependentCastCheck.class,
           PlatformDependentTruncationCheck.class,

--- a/delphi-checks/src/main/java/au/com/integradev/delphi/checks/ParsingErrorCheck.java
+++ b/delphi-checks/src/main/java/au/com/integradev/delphi/checks/ParsingErrorCheck.java
@@ -1,0 +1,34 @@
+/*
+ * Sonar Delphi Plugin
+ * Copyright (C) 2025 Integrated Application Development
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02
+ */
+package au.com.integradev.delphi.checks;
+
+import org.sonar.check.Rule;
+import org.sonar.plugins.communitydelphi.api.ast.DelphiAst;
+import org.sonar.plugins.communitydelphi.api.check.DelphiCheck;
+import org.sonar.plugins.communitydelphi.api.check.DelphiCheckContext;
+
+@Rule(key = "ParsingError")
+public class ParsingErrorCheck extends DelphiCheck {
+  @Override
+  public DelphiCheckContext visit(DelphiAst ast, DelphiCheckContext context) {
+    // Dummy implementation to satisfy the check registrar.
+    // See DelphiSensor::handleParsingError.
+    return context;
+  }
+}

--- a/delphi-checks/src/main/resources/org/sonar/l10n/delphi/rules/community-delphi/ParsingError.html
+++ b/delphi-checks/src/main/resources/org/sonar/l10n/delphi/rules/community-delphi/ParsingError.html
@@ -1,0 +1,6 @@
+<h2>Why is this an issue?</h2>
+<p>
+  When the Delphi parser fails, it is possible to record the failure as a violation on the file.
+  This way, not only it is possible to track the number of files that do not parse but also to
+  easily find out why they do not parse.
+</p>

--- a/delphi-checks/src/main/resources/org/sonar/l10n/delphi/rules/community-delphi/ParsingError.json
+++ b/delphi-checks/src/main/resources/org/sonar/l10n/delphi/rules/community-delphi/ParsingError.json
@@ -1,0 +1,19 @@
+{
+  "title": "Delphi parser failure",
+  "type": "CODE_SMELL",
+  "status": "ready",
+  "remediation": {
+    "func": "Constant/Issue",
+    "constantCost": "30min"
+  },
+  "code": {
+    "attribute": "CONVENTIONAL",
+    "impacts": {
+      "MAINTAINABILITY": "MEDIUM"
+    }
+  },
+  "tags": ["suspicious"],
+  "defaultSeverity": "Major",
+  "scope": "ALL",
+  "quickfix": "unknown"
+}

--- a/delphi-checks/src/test/java/au/com/integradev/delphi/checks/CheckTestNameTest.java
+++ b/delphi-checks/src/test/java/au/com/integradev/delphi/checks/CheckTestNameTest.java
@@ -208,6 +208,8 @@ class CheckTestNameTest {
         .areAssignableTo(DelphiCheck.class)
         .and()
         .doNotHaveModifier(JavaModifier.ABSTRACT)
+        .and()
+        .doNotBelongToAnyOf(ParsingErrorCheck.class)
         .should(HAVE_ASSOCIATED_TEST)
         .allowEmptyShould(true)
         .check(CHECKS_PACKAGE);

--- a/delphi-frontend/src/main/antlr3/au/com/integradev/delphi/antlr/Delphi.g
+++ b/delphi-frontend/src/main/antlr3/au/com/integradev/delphi/antlr/Delphi.g
@@ -143,7 +143,7 @@ import org.apache.commons.lang3.StringUtils;
   public void reportError(RecognitionException e) {
     String hdr = this.getErrorHeader(e);
     String msg = this.getErrorMessage(e, this.getTokenNames());
-    throw new LexerException(hdr + " " + msg, e);
+    throw new LexerException(hdr + " " + msg, e.line, e);
   }
 
   @Override
@@ -152,12 +152,20 @@ import org.apache.commons.lang3.StringUtils;
   }
 
   public static class LexerException extends RuntimeException {
-    public LexerException(String message) {
+    private final int line;
+
+    public LexerException(String message, int line) {
       super(message);
+      this.line = line;
     }
 
-    public LexerException(String message, Throwable cause) {
+    public LexerException(String message, int line, Throwable cause) {
       super(message, cause);
+      this.line = line;
+    }
+
+    public int getLine() {
+      return line;
     }
   }
 
@@ -234,7 +242,8 @@ import org.apache.commons.lang3.StringUtils;
                   + state.tokenStartLine
                   + ":"
                   + state.tokenStartCharPositionInLine
-                  + " unterminated multi-line comment");
+                  + " unterminated multi-line comment",
+              state.tokenStartLine);
 
         default:
           // do nothing
@@ -350,7 +359,7 @@ import org.apache.commons.lang3.StringUtils;
   public void reportError(RecognitionException e) {
     String hdr = this.getErrorHeader(e);
     String msg = this.getErrorMessage(e, this.getTokenNames());
-    throw new ParserException(hdr + " " + msg, e);
+    throw new ParserException(hdr + " " + msg, e.line, e);
   }
 
   @Override
@@ -373,8 +382,15 @@ import org.apache.commons.lang3.StringUtils;
   }
 
   public static class ParserException extends RuntimeException {
-    public ParserException(String message, Throwable cause) {
+    private final int line;
+
+    public ParserException(String message, int line, Throwable cause) {
       super(message, cause);
+      this.line = line;
+    }
+
+    public int getLine() {
+      return line;
     }
   }
 }

--- a/delphi-frontend/src/main/java/au/com/integradev/delphi/file/DelphiFile.java
+++ b/delphi-frontend/src/main/java/au/com/integradev/delphi/file/DelphiFile.java
@@ -183,7 +183,7 @@ public interface DelphiFile {
                     token.getChannel() == Token.HIDDEN_CHANNEL || token.getType() == Token.EOF);
 
     if (isEmptyFile) {
-      throw new EmptyDelphiFileException("Empty files are not allowed.");
+      throw new EmptyDelphiFileException("Empty files are not allowed");
     }
 
     DelphiParser parser = new DelphiParser(tokenStream);


### PR DESCRIPTION
This PR implements a check to flag files where parsing failures have occurred.
The official analyzers from SonarSource have similar rules. Like them, I've opted not to put it in the default quality profile.

Closes #301.