### PR TITLE
Fix overload resolution failures on the variant overload of `Copy`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - False positives from nested finally-except blocks in `RedundantJump`.
 - False positives around wrapped type declarations in `VisibilityKeywordIndentation`.
 - Trailing whitespace within comments not recognized in `TrailingWhitespace`.
+- Overload resolution failures on the variant overload of the `Copy` intrinsic.
 - Several compiler directives were not being recognized:
   - `E`
   - `F`

--- a/delphi-frontend/src/main/java/au/com/integradev/delphi/type/intrinsic/IntrinsicsInjector.java
+++ b/delphi-frontend/src/main/java/au/com/integradev/delphi/type/intrinsic/IntrinsicsInjector.java
@@ -193,6 +193,11 @@ public final class IntrinsicsInjector {
         .param(type(INTEGER))
         .returns(IntrinsicReturnType.copy(typeFactory));
     routine("Copy")
+        .param(ANY_VARIANT)
+        .param(type(INTEGER))
+        .param(type(INTEGER))
+        .returns(IntrinsicReturnType.copy(typeFactory));
+    routine("Copy")
         .param(LIKE_DYNAMIC_ARRAY)
         .param(dynamicArraySizeType())
         .param(dynamicArraySizeType())


### PR DESCRIPTION
This PR fixes an overload resolution issue involving the `Copy` intrinsic.
We didn't previously register the variant overload `Copy(Variant, Integer, Integer)`.

This caused overload resolution failures when calling `Copy` on a variant value.