### PR TITLE
Improve reporting of preprocessor-related parsing failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Exclude types annotated with attributes in `UnusedType`.
+- Improve reporting of parsing failures occurring within include files.
+- Improve reporting of parsing failures occurring within compiler directives.
 
 ### Deprecated
 

--- a/delphi-frontend/src/main/java/au/com/integradev/delphi/antlr/ast/token/DelphiTokenImpl.java
+++ b/delphi-frontend/src/main/java/au/com/integradev/delphi/antlr/ast/token/DelphiTokenImpl.java
@@ -84,11 +84,11 @@ public class DelphiTokenImpl implements DelphiToken {
 
   private void calculatePosition() {
     if (isIncludedToken()) {
-      FilePosition insertionPosition = ((IncludeToken) token).getInsertionPosition();
-      beginLine = insertionPosition.getBeginLine();
-      beginColumn = insertionPosition.getBeginColumn();
-      endLine = insertionPosition.getEndLine();
-      endColumn = insertionPosition.getEndColumn();
+      DelphiToken insertionToken = ((IncludeToken) token).getInsertionToken();
+      beginLine = insertionToken.getBeginLine();
+      beginColumn = insertionToken.getBeginColumn();
+      endLine = insertionToken.getEndLine();
+      endColumn = insertionToken.getEndColumn();
     } else if (isComment() || isCompilerDirective()) {
       TokenLocation location =
           new TokenLocation(token.getLine(), token.getCharPositionInLine(), token.getText());

--- a/delphi-frontend/src/main/java/au/com/integradev/delphi/antlr/ast/token/IncludeToken.java
+++ b/delphi-frontend/src/main/java/au/com/integradev/delphi/antlr/ast/token/IncludeToken.java
@@ -18,20 +18,31 @@
  */
 package au.com.integradev.delphi.antlr.ast.token;
 
+import org.antlr.runtime.CharStream;
 import org.antlr.runtime.CommonToken;
 import org.antlr.runtime.Token;
-import org.sonar.plugins.communitydelphi.api.check.FilePosition;
 import org.sonar.plugins.communitydelphi.api.token.DelphiToken;
 
 public class IncludeToken extends CommonToken {
-  private final FilePosition insertionPosition;
+  private final DelphiToken insertionToken;
+
+  public IncludeToken(
+      CharStream input, int type, int channel, int start, int stop, DelphiToken insertionToken) {
+    super(input, type, channel, start, stop);
+    this.insertionToken = insertionToken;
+  }
 
   public IncludeToken(Token token, DelphiToken insertionToken) {
     super(token);
-    this.insertionPosition = FilePosition.from(insertionToken);
+    this.insertionToken = insertionToken;
   }
 
-  public FilePosition getInsertionPosition() {
-    return insertionPosition;
+  public IncludeToken(IncludeToken other) {
+    super(other);
+    this.insertionToken = other.insertionToken;
+  }
+
+  public DelphiToken getInsertionToken() {
+    return insertionToken;
   }
 }

--- a/delphi-frontend/src/main/java/au/com/integradev/delphi/file/DelphiFile.java
+++ b/delphi-frontend/src/main/java/au/com/integradev/delphi/file/DelphiFile.java
@@ -28,6 +28,7 @@ import au.com.integradev.delphi.antlr.ast.DelphiTreeAdaptor;
 import au.com.integradev.delphi.preprocessor.CompilerSwitchRegistry;
 import au.com.integradev.delphi.preprocessor.DelphiPreprocessor;
 import au.com.integradev.delphi.preprocessor.DelphiPreprocessorFactory;
+import au.com.integradev.delphi.preprocessor.PreprocessorException;
 import au.com.integradev.delphi.preprocessor.TextBlockLineEndingModeRegistry;
 import au.com.integradev.delphi.preprocessor.search.SearchPath;
 import au.com.integradev.delphi.utils.DelphiUtils;
@@ -157,6 +158,7 @@ public interface DelphiFile {
         | RecognitionException
         | LexerException
         | ParserException
+        | PreprocessorException
         | EmptyDelphiFileException e) {
       throw new DelphiFileConstructionException(e);
     }

--- a/delphi-frontend/src/main/java/au/com/integradev/delphi/preprocessor/PreprocessorException.java
+++ b/delphi-frontend/src/main/java/au/com/integradev/delphi/preprocessor/PreprocessorException.java
@@ -1,0 +1,56 @@
+/*
+ * Sonar Delphi Plugin
+ * Copyright (C) 2025 Integrated Application Development
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02
+ */
+package au.com.integradev.delphi.preprocessor;
+
+import au.com.integradev.delphi.antlr.ast.token.DelphiTokenImpl;
+import au.com.integradev.delphi.utils.LocatableException;
+import org.antlr.runtime.Token;
+import org.sonar.plugins.communitydelphi.api.token.DelphiToken;
+
+public class PreprocessorException extends RuntimeException implements LocatableException {
+  private final DelphiToken token;
+
+  public PreprocessorException(String message, DelphiToken token) {
+    this(message, token, null);
+  }
+
+  public PreprocessorException(String message, DelphiToken token, Throwable cause) {
+    super(createMessage(message, token), cause);
+    this.token = token;
+  }
+
+  @Override
+  public int getLine() {
+    return token.getBeginLine();
+  }
+
+  private static String createMessage(String message, DelphiToken token) {
+    Token rawToken = ((DelphiTokenImpl) token).getAntlrToken();
+    int line = rawToken.getLine();
+    int column = rawToken.getCharPositionInLine();
+
+    message = String.format("line %d:%d %s", line, column, message);
+
+    if (token.isIncludedToken()) {
+      message = String.format("included on line %d :: %s", token.getBeginLine(), message);
+    }
+
+    return message;
+  }
+}

--- a/delphi-frontend/src/main/java/au/com/integradev/delphi/preprocessor/directive/CompilerDirectiveParserImpl.java
+++ b/delphi-frontend/src/main/java/au/com/integradev/delphi/preprocessor/directive/CompilerDirectiveParserImpl.java
@@ -22,6 +22,7 @@ import static au.com.integradev.delphi.preprocessor.directive.CompilerDirectiveP
 import static au.com.integradev.delphi.preprocessor.directive.CompilerDirectiveParserImpl.DirectiveBracketType.PAREN;
 
 import au.com.integradev.delphi.compiler.Platform;
+import au.com.integradev.delphi.preprocessor.PreprocessorException;
 import au.com.integradev.delphi.preprocessor.TextBlockLineEndingModeRegistry;
 import au.com.integradev.delphi.preprocessor.directive.expression.Expression;
 import au.com.integradev.delphi.preprocessor.directive.expression.ExpressionLexer;
@@ -308,7 +309,7 @@ public class CompilerDirectiveParserImpl implements CompilerDirectiveParser {
       var tokens = EXPRESSION_LEXER.lex(input.toString());
       return expressionParser().parse(tokens);
     } catch (ExpressionLexerError | ExpressionParserError e) {
-      throw new CompilerDirectiveParserError(e, token);
+      throw new CompilerDirectiveParserError(token, e);
     }
   }
 
@@ -352,9 +353,9 @@ public class CompilerDirectiveParserImpl implements CompilerDirectiveParser {
     return (position < data.length()) ? data.charAt(position) : END_OF_INPUT;
   }
 
-  static final class CompilerDirectiveParserError extends RuntimeException {
-    private CompilerDirectiveParserError(Exception e, DelphiToken token) {
-      super(e.getMessage() + " <Line " + token.getBeginLine() + ">", e);
+  static final class CompilerDirectiveParserError extends PreprocessorException {
+    private CompilerDirectiveParserError(DelphiToken token, Throwable cause) {
+      super(cause.getMessage(), token, cause);
     }
   }
 }

--- a/delphi-frontend/src/main/java/au/com/integradev/delphi/utils/LocatableException.java
+++ b/delphi-frontend/src/main/java/au/com/integradev/delphi/utils/LocatableException.java
@@ -1,0 +1,23 @@
+/*
+ * Sonar Delphi Plugin
+ * Copyright (C) 2025 Integrated Application Development
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02
+ */
+package au.com.integradev.delphi.utils;
+
+public interface LocatableException {
+  public int getLine();
+}

--- a/sonar-delphi-plugin/src/main/java/au/com/integradev/delphi/DelphiSensor.java
+++ b/sonar-delphi-plugin/src/main/java/au/com/integradev/delphi/DelphiSensor.java
@@ -39,9 +39,11 @@ import au.com.integradev.delphi.file.DelphiFile.EmptyDelphiFileException;
 import au.com.integradev.delphi.file.DelphiFileConfig;
 import au.com.integradev.delphi.msbuild.DelphiProjectHelper;
 import au.com.integradev.delphi.preprocessor.DelphiPreprocessorFactory;
+import au.com.integradev.delphi.preprocessor.PreprocessorException;
 import au.com.integradev.delphi.preprocessor.search.SearchPath;
 import au.com.integradev.delphi.symbol.SymbolTable;
 import au.com.integradev.delphi.type.factory.TypeFactoryImpl;
+import au.com.integradev.delphi.utils.LocatableException;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
@@ -162,6 +164,7 @@ public class DelphiSensor implements Sensor {
     Throwable cause = e.getCause();
     if (cause instanceof LexerException
         || cause instanceof ParserException
+        || cause instanceof PreprocessorException
         || cause instanceof EmptyDelphiFileException) {
       NewIssue newIssue =
           context.newIssue().forRule(RuleKey.of("community-delphi", "ParsingError"));
@@ -172,14 +175,8 @@ public class DelphiSensor implements Sensor {
               .on(inputFile)
               .message(String.format("Parse error (%s)", cause.getMessage()));
 
-      int line = 0;
-      if (cause instanceof ParserException) {
-        line = ((ParserException) cause).getLine();
-      } else if (cause instanceof LexerException) {
-        line = ((LexerException) cause).getLine();
-      }
-
-      if (line != 0) {
+      if (cause instanceof LocatableException) {
+        int line = ((LocatableException) cause).getLine();
         primaryLocation.at(inputFile.selectLine(line));
       }
 


### PR DESCRIPTION
Line information was incorrect or incomplete in some cases:
- within include files
- within compiler directives
- when include processing fails due to self-referencing include files

This was discovered due to the new `ParsingError` check triggering file pointer errors when trying to raise issues on included tokens.