### PR TITLE
Add support for `CompilerVersion` in compiler directive expressions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Improve support for evaluating name references in compiler directive expressions.
+
 ## [1.15.0] - 2025-04-03
 
 ### Added

--- a/delphi-checks-testkit/src/main/java/au/com/integradev/delphi/builders/AbstractDelphiTestFile.java
+++ b/delphi-checks-testkit/src/main/java/au/com/integradev/delphi/builders/AbstractDelphiTestFile.java
@@ -89,7 +89,8 @@ abstract class AbstractDelphiTestFile<T extends AbstractDelphiTestFile<T>>
     when(mock.getTypeFactory()).thenReturn(typeFactory);
     when(mock.getSearchPath()).thenReturn(SearchPath.create(Collections.emptyList()));
     when(mock.getDefinitions()).thenReturn(Collections.emptySet());
-    when(mock.getPreprocessorFactory()).thenReturn(new DelphiPreprocessorFactory(Platform.WINDOWS));
+    when(mock.getPreprocessorFactory())
+        .thenReturn(new DelphiPreprocessorFactory(mock(), Platform.WINDOWS));
     return mock;
   }
 }

--- a/delphi-checks-testkit/src/main/java/au/com/integradev/delphi/checks/verifier/CheckVerifierImpl.java
+++ b/delphi-checks-testkit/src/main/java/au/com/integradev/delphi/checks/verifier/CheckVerifierImpl.java
@@ -436,7 +436,7 @@ public class CheckVerifierImpl implements CheckVerifier {
     DelphiInputFile file = testFile.delphiFile();
     SymbolTable symbolTable =
         SymbolTable.builder()
-            .preprocessorFactory(new DelphiPreprocessorFactory(Platform.WINDOWS))
+            .preprocessorFactory(new DelphiPreprocessorFactory(compilerVersion, Platform.WINDOWS))
             .typeFactory(new TypeFactoryImpl(toolchain, compilerVersion))
             .standardLibraryPath(standardLibraryPath)
             .sourceFiles(List.of(file.getSourceCodeFile().toPath()))

--- a/delphi-frontend/src/main/java/au/com/integradev/delphi/preprocessor/DelphiPreprocessor.java
+++ b/delphi-frontend/src/main/java/au/com/integradev/delphi/preprocessor/DelphiPreprocessor.java
@@ -25,6 +25,7 @@ import au.com.integradev.delphi.antlr.DelphiLexer;
 import au.com.integradev.delphi.antlr.DelphiTokenStream;
 import au.com.integradev.delphi.antlr.ast.token.DelphiTokenImpl;
 import au.com.integradev.delphi.antlr.ast.token.IncludeToken;
+import au.com.integradev.delphi.compiler.CompilerVersion;
 import au.com.integradev.delphi.compiler.Platform;
 import au.com.integradev.delphi.file.DelphiFileConfig;
 import au.com.integradev.delphi.preprocessor.directive.BranchDirective;
@@ -63,6 +64,7 @@ public class DelphiPreprocessor {
   private static final Logger LOG = LoggerFactory.getLogger(DelphiPreprocessor.class);
   private final DelphiLexer lexer;
   private final DelphiFileConfig config;
+  private final CompilerVersion compilerVersion;
   private final Platform platform;
   private final Set<String> definitions;
   private final List<CompilerDirective> directives;
@@ -77,10 +79,15 @@ public class DelphiPreprocessor {
   private List<Token> rawTokens;
   private int tokenIndex;
 
-  DelphiPreprocessor(DelphiLexer lexer, DelphiFileConfig config, Platform platform) {
+  DelphiPreprocessor(
+      DelphiLexer lexer,
+      DelphiFileConfig config,
+      CompilerVersion compilerVersion,
+      Platform platform) {
     this(
         lexer,
         config,
+        compilerVersion,
         platform,
         caseInsensitiveSet(config.getDefinitions()),
         new EnumMap<>(SwitchKind.class),
@@ -96,6 +103,7 @@ public class DelphiPreprocessor {
   private DelphiPreprocessor(
       DelphiLexer lexer,
       DelphiFileConfig config,
+      CompilerVersion compilerVersion,
       Platform platform,
       Set<String> definitions,
       Map<SwitchKind, Integer> currentSwitches,
@@ -105,6 +113,7 @@ public class DelphiPreprocessor {
       boolean processingIncludeFile) {
     this.lexer = lexer;
     this.config = config;
+    this.compilerVersion = compilerVersion;
     this.platform = platform;
     this.switchRegistry = switchRegistry;
     this.textBlockLineEndingModeRegistry = textBlockLineEndingModeRegistry;
@@ -258,6 +267,7 @@ public class DelphiPreprocessor {
         new DelphiPreprocessor(
             includeLexer,
             config,
+            compilerVersion,
             platform,
             definitions,
             currentSwitches,
@@ -343,6 +353,10 @@ public class DelphiPreprocessor {
 
   private TextBlockLineEndingMode nativeLineEnding() {
     return platform == Platform.WINDOWS ? TextBlockLineEndingMode.CRLF : TextBlockLineEndingMode.LF;
+  }
+
+  public CompilerVersion getCompilerVersion() {
+    return compilerVersion;
   }
 
   public DelphiTokenStream getTokenStream() {

--- a/delphi-frontend/src/main/java/au/com/integradev/delphi/preprocessor/DelphiPreprocessorFactory.java
+++ b/delphi-frontend/src/main/java/au/com/integradev/delphi/preprocessor/DelphiPreprocessorFactory.java
@@ -19,17 +19,20 @@
 package au.com.integradev.delphi.preprocessor;
 
 import au.com.integradev.delphi.antlr.DelphiLexer;
+import au.com.integradev.delphi.compiler.CompilerVersion;
 import au.com.integradev.delphi.compiler.Platform;
 import au.com.integradev.delphi.file.DelphiFileConfig;
 
 public final class DelphiPreprocessorFactory {
+  private final CompilerVersion compilerVersion;
   private final Platform platform;
 
-  public DelphiPreprocessorFactory(Platform platform) {
+  public DelphiPreprocessorFactory(CompilerVersion compilerVersion, Platform platform) {
+    this.compilerVersion = compilerVersion;
     this.platform = platform;
   }
 
   public DelphiPreprocessor createPreprocessor(DelphiLexer lexer, DelphiFileConfig config) {
-    return new DelphiPreprocessor(lexer, config, platform);
+    return new DelphiPreprocessor(lexer, config, compilerVersion, platform);
   }
 }

--- a/delphi-frontend/src/test/java/au/com/integradev/delphi/antlr/GrammarTest.java
+++ b/delphi-frontend/src/test/java/au/com/integradev/delphi/antlr/GrammarTest.java
@@ -24,6 +24,7 @@ package au.com.integradev.delphi.antlr;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import au.com.integradev.delphi.DelphiProperties;
 import au.com.integradev.delphi.compiler.Platform;
 import au.com.integradev.delphi.file.DelphiFile;
 import au.com.integradev.delphi.file.DelphiFile.DelphiFileConstructionException;
@@ -275,7 +276,8 @@ class GrammarTest {
     fileConfig =
         DelphiFile.createConfig(
             StandardCharsets.UTF_8.name(),
-            new DelphiPreprocessorFactory(Platform.WINDOWS),
+            new DelphiPreprocessorFactory(
+                DelphiProperties.COMPILER_VERSION_DEFAULT, Platform.WINDOWS),
             TypeFactoryUtils.defaultFactory(),
             SearchPath.create(Collections.emptyList()),
             Set.of("Defined"));

--- a/delphi-frontend/src/test/java/au/com/integradev/delphi/cfg/ControlFlowGraphTest.java
+++ b/delphi-frontend/src/test/java/au/com/integradev/delphi/cfg/ControlFlowGraphTest.java
@@ -123,7 +123,9 @@ class ControlFlowGraphTest {
       Path standardLibraryPath = createStandardLibrary();
       SymbolTable symbolTable =
           SymbolTable.builder()
-              .preprocessorFactory(new DelphiPreprocessorFactory(Platform.WINDOWS))
+              .preprocessorFactory(
+                  new DelphiPreprocessorFactory(
+                      DelphiProperties.COMPILER_VERSION_DEFAULT, Platform.WINDOWS))
               .typeFactory(
                   new TypeFactoryImpl(
                       DelphiProperties.COMPILER_TOOLCHAIN_DEFAULT,

--- a/delphi-frontend/src/test/java/au/com/integradev/delphi/executor/DelphiMasterExecutorTest.java
+++ b/delphi-frontend/src/test/java/au/com/integradev/delphi/executor/DelphiMasterExecutorTest.java
@@ -180,7 +180,10 @@ class DelphiMasterExecutorTest {
             DelphiProperties.COMPILER_TOOLCHAIN_DEFAULT, DelphiProperties.COMPILER_VERSION_DEFAULT);
     DelphiFileConfig mock = mock(DelphiFileConfig.class);
     when(mock.getEncoding()).thenReturn(StandardCharsets.UTF_8.name());
-    when(mock.getPreprocessorFactory()).thenReturn(new DelphiPreprocessorFactory(Platform.WINDOWS));
+    when(mock.getPreprocessorFactory())
+        .thenReturn(
+            new DelphiPreprocessorFactory(
+                DelphiProperties.COMPILER_VERSION_DEFAULT, Platform.WINDOWS));
     when(mock.getTypeFactory()).thenReturn(typeFactory);
     when(mock.getSearchPath()).thenReturn(SearchPath.create(Collections.emptyList()));
     when(mock.getDefinitions()).thenReturn(Collections.emptySet());

--- a/delphi-frontend/src/test/java/au/com/integradev/delphi/executor/DelphiMetricsExecutorTest.java
+++ b/delphi-frontend/src/test/java/au/com/integradev/delphi/executor/DelphiMetricsExecutorTest.java
@@ -178,7 +178,10 @@ class DelphiMetricsExecutorTest {
             DelphiProperties.COMPILER_TOOLCHAIN_DEFAULT, DelphiProperties.COMPILER_VERSION_DEFAULT);
     DelphiFileConfig mock = mock(DelphiFileConfig.class);
     when(mock.getEncoding()).thenReturn(StandardCharsets.UTF_8.name());
-    when(mock.getPreprocessorFactory()).thenReturn(new DelphiPreprocessorFactory(Platform.WINDOWS));
+    when(mock.getPreprocessorFactory())
+        .thenReturn(
+            new DelphiPreprocessorFactory(
+                DelphiProperties.COMPILER_VERSION_DEFAULT, Platform.WINDOWS));
     when(mock.getTypeFactory()).thenReturn(typeFactory);
     when(mock.getSearchPath()).thenReturn(SearchPath.create(Collections.emptyList()));
     when(mock.getDefinitions()).thenReturn(Collections.emptySet());

--- a/delphi-frontend/src/test/java/au/com/integradev/delphi/executor/DelphiSymbolTableExecutorTest.java
+++ b/delphi-frontend/src/test/java/au/com/integradev/delphi/executor/DelphiSymbolTableExecutorTest.java
@@ -1474,7 +1474,8 @@ class DelphiSymbolTableExecutorTest {
       throw new UncheckedIOException(e);
     }
 
-    var preprocessorFactory = new DelphiPreprocessorFactory(Platform.WINDOWS);
+    var preprocessorFactory =
+        new DelphiPreprocessorFactory(DelphiProperties.COMPILER_VERSION_DEFAULT, Platform.WINDOWS);
     var typeFactory =
         new TypeFactoryImpl(
             DelphiProperties.COMPILER_TOOLCHAIN_DEFAULT, DelphiProperties.COMPILER_VERSION_DEFAULT);

--- a/delphi-frontend/src/test/java/au/com/integradev/delphi/executor/DelphiTokenExecutorTest.java
+++ b/delphi-frontend/src/test/java/au/com/integradev/delphi/executor/DelphiTokenExecutorTest.java
@@ -233,7 +233,9 @@ class DelphiTokenExecutorTest {
       DelphiFileConfig fileConfig = mock(DelphiFileConfig.class);
       when(fileConfig.getEncoding()).thenReturn(StandardCharsets.UTF_8.name());
       when(fileConfig.getPreprocessorFactory())
-          .thenReturn(new DelphiPreprocessorFactory(Platform.WINDOWS));
+          .thenReturn(
+              new DelphiPreprocessorFactory(
+                  DelphiProperties.COMPILER_VERSION_DEFAULT, Platform.WINDOWS));
       when(fileConfig.getTypeFactory()).thenReturn(typeFactory);
       when(fileConfig.getSearchPath()).thenReturn(SearchPath.create(Collections.emptyList()));
       when(fileConfig.getDefinitions()).thenReturn(Collections.emptySet());

--- a/delphi-frontend/src/test/java/au/com/integradev/delphi/file/DelphiFileTest.java
+++ b/delphi-frontend/src/test/java/au/com/integradev/delphi/file/DelphiFileTest.java
@@ -20,6 +20,7 @@ package au.com.integradev.delphi.file;
 
 import static org.assertj.core.api.Assertions.*;
 
+import au.com.integradev.delphi.DelphiProperties;
 import au.com.integradev.delphi.compiler.Platform;
 import au.com.integradev.delphi.core.Delphi;
 import au.com.integradev.delphi.file.DelphiFile.DelphiFileConstructionException;
@@ -66,7 +67,8 @@ class DelphiFileTest {
     DelphiFileConfig config =
         DelphiFile.createConfig(
             StandardCharsets.UTF_8.name(),
-            new DelphiPreprocessorFactory(Platform.WINDOWS),
+            new DelphiPreprocessorFactory(
+                DelphiProperties.COMPILER_VERSION_DEFAULT, Platform.WINDOWS),
             TypeFactoryUtils.defaultFactory(),
             SearchPath.create(Collections.emptyList()),
             Collections.emptySet());
@@ -82,7 +84,8 @@ class DelphiFileTest {
     DelphiFileConfig config =
         DelphiFile.createConfig(
             StandardCharsets.UTF_8.name(),
-            new DelphiPreprocessorFactory(Platform.WINDOWS),
+            new DelphiPreprocessorFactory(
+                DelphiProperties.COMPILER_VERSION_DEFAULT, Platform.WINDOWS),
             TypeFactoryUtils.defaultFactory(),
             SearchPath.create(Collections.emptyList()),
             Collections.emptySet());
@@ -98,7 +101,8 @@ class DelphiFileTest {
     DelphiFileConfig config =
         DelphiFile.createConfig(
             StandardCharsets.UTF_8.name(),
-            new DelphiPreprocessorFactory(Platform.WINDOWS),
+            new DelphiPreprocessorFactory(
+                DelphiProperties.COMPILER_VERSION_DEFAULT, Platform.WINDOWS),
             TypeFactoryUtils.defaultFactory(),
             SearchPath.create(Collections.emptyList()),
             Collections.emptySet());
@@ -116,7 +120,8 @@ class DelphiFileTest {
     DelphiFileConfig config =
         DelphiFile.createConfig(
             StandardCharsets.UTF_8.name(),
-            new DelphiPreprocessorFactory(Platform.WINDOWS),
+            new DelphiPreprocessorFactory(
+                DelphiProperties.COMPILER_VERSION_DEFAULT, Platform.WINDOWS),
             TypeFactoryUtils.defaultFactory(),
             SearchPath.create(Collections.emptyList()),
             Collections.emptySet(),

--- a/delphi-frontend/src/test/java/au/com/integradev/delphi/preprocessor/DelphiPreprocessorTest.java
+++ b/delphi-frontend/src/test/java/au/com/integradev/delphi/preprocessor/DelphiPreprocessorTest.java
@@ -23,6 +23,7 @@ import static java.util.Collections.emptySet;
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import au.com.integradev.delphi.DelphiProperties;
 import au.com.integradev.delphi.antlr.DelphiFileStream;
 import au.com.integradev.delphi.antlr.DelphiLexer;
 import au.com.integradev.delphi.antlr.DelphiLexer.LexerException;
@@ -135,7 +136,9 @@ class DelphiPreprocessorTest {
     DelphiFileStream fileStream = new DelphiFileStream(filePath, config.getEncoding());
 
     DelphiLexer lexer = new DelphiLexer(fileStream);
-    DelphiPreprocessor preprocessor = new DelphiPreprocessor(lexer, config, Platform.WINDOWS);
+    DelphiPreprocessor preprocessor =
+        new DelphiPreprocessor(
+            lexer, config, DelphiProperties.COMPILER_VERSION_DEFAULT, Platform.WINDOWS);
     preprocessor.process();
 
     assertThatThrownBy(preprocessor::process).isInstanceOf(IllegalStateException.class);
@@ -145,7 +148,8 @@ class DelphiPreprocessorTest {
     DelphiFileConfig config =
         DelphiFile.createConfig(
             UTF_8.name(),
-            new DelphiPreprocessorFactory(Platform.WINDOWS),
+            new DelphiPreprocessorFactory(
+                DelphiProperties.COMPILER_VERSION_DEFAULT, Platform.WINDOWS),
             TypeFactoryUtils.defaultFactory(),
             SearchPath.create(Collections.emptyList()),
             new HashSet<>(Arrays.asList(defines)));
@@ -164,7 +168,8 @@ class DelphiPreprocessorTest {
         filename,
         DelphiFile.createConfig(
             UTF_8.name(),
-            new DelphiPreprocessorFactory(Platform.WINDOWS),
+            new DelphiPreprocessorFactory(
+                DelphiProperties.COMPILER_VERSION_DEFAULT, Platform.WINDOWS),
             typeFactory,
             searchPath,
             emptySet()));

--- a/delphi-frontend/src/test/java/au/com/integradev/delphi/reporting/QuickFixEditTest.java
+++ b/delphi-frontend/src/test/java/au/com/integradev/delphi/reporting/QuickFixEditTest.java
@@ -137,7 +137,8 @@ class QuickFixEditTest {
       throw new UncheckedIOException(e);
     }
 
-    var preprocessorFactory = new DelphiPreprocessorFactory(Platform.WINDOWS);
+    var preprocessorFactory =
+        new DelphiPreprocessorFactory(DelphiProperties.COMPILER_VERSION_DEFAULT, Platform.WINDOWS);
     var typeFactory =
         new TypeFactoryImpl(
             DelphiProperties.COMPILER_TOOLCHAIN_DEFAULT, DelphiProperties.COMPILER_VERSION_DEFAULT);

--- a/delphi-frontend/src/test/java/au/com/integradev/delphi/symbol/SymbolTableBuilderTest.java
+++ b/delphi-frontend/src/test/java/au/com/integradev/delphi/symbol/SymbolTableBuilderTest.java
@@ -25,6 +25,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import au.com.integradev.delphi.DelphiProperties;
 import au.com.integradev.delphi.compiler.Platform;
 import au.com.integradev.delphi.preprocessor.DelphiPreprocessorFactory;
 import au.com.integradev.delphi.preprocessor.search.SearchPath;
@@ -51,7 +52,9 @@ class SymbolTableBuilderTest {
   void testNonexistentStandardLibraryPath(@TempDir Path tempDir) {
     SymbolTableBuilder builder =
         SymbolTable.builder()
-            .preprocessorFactory(new DelphiPreprocessorFactory(Platform.WINDOWS))
+            .preprocessorFactory(
+                new DelphiPreprocessorFactory(
+                    DelphiProperties.COMPILER_VERSION_DEFAULT, Platform.WINDOWS))
             .typeFactory(TypeFactoryUtils.defaultFactory())
             .standardLibraryPath(tempDir.resolve("nonexistent"));
     assertThatThrownBy(builder::build).isInstanceOf(SymbolTableConstructionException.class);
@@ -88,7 +91,10 @@ class SymbolTableBuilderTest {
   @Test
   void testBuildWithoutTypeFactory() {
     SymbolTableBuilder builder =
-        SymbolTable.builder().preprocessorFactory(new DelphiPreprocessorFactory(Platform.WINDOWS));
+        SymbolTable.builder()
+            .preprocessorFactory(
+                new DelphiPreprocessorFactory(
+                    DelphiProperties.COMPILER_VERSION_DEFAULT, Platform.WINDOWS));
     assertThatThrownBy(builder::build).isInstanceOf(SymbolTableConstructionException.class);
   }
 
@@ -96,7 +102,9 @@ class SymbolTableBuilderTest {
   void testEmptyStandardLibrary(@TempDir Path standardLibraryPath) {
     SymbolTableBuilder builder =
         SymbolTable.builder()
-            .preprocessorFactory(new DelphiPreprocessorFactory(Platform.WINDOWS))
+            .preprocessorFactory(
+                new DelphiPreprocessorFactory(
+                    DelphiProperties.COMPILER_VERSION_DEFAULT, Platform.WINDOWS))
             .typeFactory(TypeFactoryUtils.defaultFactory())
             .standardLibraryPath(standardLibraryPath);
 
@@ -115,7 +123,9 @@ class SymbolTableBuilderTest {
 
     SymbolTableBuilder builder =
         SymbolTable.builder()
-            .preprocessorFactory(new DelphiPreprocessorFactory(Platform.WINDOWS))
+            .preprocessorFactory(
+                new DelphiPreprocessorFactory(
+                    DelphiProperties.COMPILER_VERSION_DEFAULT, Platform.WINDOWS))
             .typeFactory(TypeFactoryUtils.defaultFactory())
             .standardLibraryPath(standardLibraryPath);
 
@@ -150,7 +160,9 @@ class SymbolTableBuilderTest {
 
     SymbolTable symbolTable =
         SymbolTable.builder()
-            .preprocessorFactory(new DelphiPreprocessorFactory(Platform.WINDOWS))
+            .preprocessorFactory(
+                new DelphiPreprocessorFactory(
+                    DelphiProperties.COMPILER_VERSION_DEFAULT, Platform.WINDOWS))
             .typeFactory(TypeFactoryUtils.defaultFactory())
             .standardLibraryPath(standardLibraryPath)
             .sourceFiles(List.of(sourceFilePath))
@@ -176,7 +188,9 @@ class SymbolTableBuilderTest {
 
     SymbolTable symbolTable =
         SymbolTable.builder()
-            .preprocessorFactory(new DelphiPreprocessorFactory(Platform.WINDOWS))
+            .preprocessorFactory(
+                new DelphiPreprocessorFactory(
+                    DelphiProperties.COMPILER_VERSION_DEFAULT, Platform.WINDOWS))
             .typeFactory(TypeFactoryUtils.defaultFactory())
             .standardLibraryPath(standardLibraryPath)
             .searchPath(SearchPath.create(List.of(searchPathRoot)))
@@ -199,7 +213,9 @@ class SymbolTableBuilderTest {
 
     SymbolTable symbolTable =
         SymbolTable.builder()
-            .preprocessorFactory(new DelphiPreprocessorFactory(Platform.WINDOWS))
+            .preprocessorFactory(
+                new DelphiPreprocessorFactory(
+                    DelphiProperties.COMPILER_VERSION_DEFAULT, Platform.WINDOWS))
             .typeFactory(TypeFactoryUtils.defaultFactory())
             .standardLibraryPath(standardLibraryPath)
             .searchPath(SearchPath.create(List.of(searchPathRoot)))
@@ -236,7 +252,9 @@ class SymbolTableBuilderTest {
 
     SymbolTableBuilder symbolTable =
         SymbolTable.builder()
-            .preprocessorFactory(new DelphiPreprocessorFactory(Platform.WINDOWS))
+            .preprocessorFactory(
+                new DelphiPreprocessorFactory(
+                    DelphiProperties.COMPILER_VERSION_DEFAULT, Platform.WINDOWS))
             .typeFactory(TypeFactoryUtils.defaultFactory())
             .standardLibraryPath(standardLibraryPath)
             .sourceFiles(List.of(sourceFilePath))

--- a/delphi-frontend/src/test/java/au/com/integradev/delphi/utils/files/DelphiFileUtils.java
+++ b/delphi-frontend/src/test/java/au/com/integradev/delphi/utils/files/DelphiFileUtils.java
@@ -21,6 +21,7 @@ package au.com.integradev.delphi.utils.files;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import au.com.integradev.delphi.DelphiProperties;
 import au.com.integradev.delphi.compiler.Platform;
 import au.com.integradev.delphi.file.DelphiFileConfig;
 import au.com.integradev.delphi.preprocessor.DelphiPreprocessorFactory;
@@ -37,7 +38,10 @@ public final class DelphiFileUtils {
   public static DelphiFileConfig mockConfig() {
     DelphiFileConfig mock = mock(DelphiFileConfig.class);
     when(mock.getEncoding()).thenReturn(StandardCharsets.UTF_8.name());
-    when(mock.getPreprocessorFactory()).thenReturn(new DelphiPreprocessorFactory(Platform.WINDOWS));
+    when(mock.getPreprocessorFactory())
+        .thenReturn(
+            new DelphiPreprocessorFactory(
+                DelphiProperties.COMPILER_VERSION_DEFAULT, Platform.WINDOWS));
     when(mock.getTypeFactory()).thenReturn(TypeFactoryUtils.defaultFactory());
     when(mock.getSearchPath()).thenReturn(SearchPath.create(Collections.emptyList()));
     when(mock.getDefinitions()).thenReturn(Collections.emptySet());

--- a/sonar-delphi-plugin/src/main/java/au/com/integradev/delphi/DelphiSensor.java
+++ b/sonar-delphi-plugin/src/main/java/au/com/integradev/delphi/DelphiSensor.java
@@ -102,7 +102,7 @@ public class DelphiSensor implements Sensor {
     LOG.info("Compiler version: {}", compilerVersion.number());
     LOG.info("Conditional defines: {}", delphiProjectHelper.getConditionalDefines());
 
-    var preprocessorFactory = new DelphiPreprocessorFactory(toolchain.platform);
+    var preprocessorFactory = new DelphiPreprocessorFactory(compilerVersion, toolchain.platform);
     var typeFactory = new TypeFactoryImpl(toolchain, compilerVersion);
     Iterable<InputFile> inputFiles = delphiProjectHelper.inputFiles();
     List<Path> sourceFiles = inputFilesToPaths(inputFiles);


### PR DESCRIPTION
This PR adds support for the `CompilerVersion` constant in compiler directive expressions.

It also improves the evaluation of:
- `System.True`
- `System.False`
- `System.Defined`
- `System.SizeOf`

This is more of a bolt-on hack than anything. It's worth doing for now because `CompilerVersion` is frequently used in directive expressions and can be statically known from configuration (`sonar.delphi.compilerVersion`).

For more accurate evaluation of compiler directive expressions, we're still blocked on #261.