### PR TITLE
Raise issues for tab-indented multiline strings in `TabulationCharacter`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Detect tab-indented multiline strings in `TabulationCharacter`.
 - Improve support for evaluating name references in compiler directive expressions.
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Improve support for evaluating name references in compiler directive expressions.
 
+### Fixed
+
+- Incorrect file position calculation for multiline string tokens.
+
 ## [1.15.0] - 2025-04-03
 
 ### Added

--- a/delphi-checks/src/main/java/au/com/integradev/delphi/checks/TabulationCharacterCheck.java
+++ b/delphi-checks/src/main/java/au/com/integradev/delphi/checks/TabulationCharacterCheck.java
@@ -25,6 +25,7 @@ import org.sonar.plugins.communitydelphi.api.ast.DelphiAst;
 import org.sonar.plugins.communitydelphi.api.check.DelphiCheck;
 import org.sonar.plugins.communitydelphi.api.check.DelphiCheckContext;
 import org.sonar.plugins.communitydelphi.api.token.DelphiToken;
+import org.sonar.plugins.communitydelphi.api.token.DelphiTokenType;
 import org.sonarsource.analyzer.commons.annotations.DeprecatedRuleKey;
 
 @DeprecatedRuleKey(ruleKey = "TabulationCharactersRule", repositoryKey = "delph")
@@ -53,6 +54,22 @@ public class TabulationCharacterCheck extends DelphiCheck {
   public void visitToken(DelphiToken token, DelphiCheckContext context) {
     if (token.isWhitespace()) {
       tabCount += countMatches(token.getImage(), '\t');
+    }
+
+    if (token.getType() == DelphiTokenType.MULTILINE_STRING) {
+      String lastLine = context.getFileLines().get(token.getEndLine() - 1);
+      int tabs = 0;
+
+      for (int i = 0; i < lastLine.length(); ++i) {
+        char c = lastLine.charAt(i);
+        if (c == '\t') {
+          ++tabs;
+        } else if (c == '\'') {
+          break;
+        }
+      }
+
+      tabCount += tabs * (token.getEndLine() - token.getBeginLine());
     }
   }
 }

--- a/delphi-checks/src/test/java/au/com/integradev/delphi/checks/TabulationCharacterCheckTest.java
+++ b/delphi-checks/src/test/java/au/com/integradev/delphi/checks/TabulationCharacterCheckTest.java
@@ -52,4 +52,17 @@ class TabulationCharacterCheckTest {
                 .appendDecl("\t"))
         .verifyIssueOnFile();
   }
+
+  @Test
+  void testFileWithTabsInMultilineStringIndentationShouldAddIssue() {
+    CheckVerifier.newVerifier()
+        .withCheck(new TabulationCharacterCheck())
+        .onFile(
+            new DelphiTestUnitBuilder()
+                .appendDecl("const")
+                .appendDecl(" Foo = '''")
+                .appendDecl("\t\tBar")
+                .appendDecl("\t\t''';"))
+        .verifyIssueOnFile();
+  }
 }

--- a/delphi-frontend/src/main/java/au/com/integradev/delphi/antlr/ast/token/DelphiTokenImpl.java
+++ b/delphi-frontend/src/main/java/au/com/integradev/delphi/antlr/ast/token/DelphiTokenImpl.java
@@ -89,7 +89,9 @@ public class DelphiTokenImpl implements DelphiToken {
       beginColumn = insertionToken.getBeginColumn();
       endLine = insertionToken.getEndLine();
       endColumn = insertionToken.getEndColumn();
-    } else if (isComment() || isCompilerDirective()) {
+    } else if (isComment()
+        || isCompilerDirective()
+        || tokenType == DelphiTokenType.MULTILINE_STRING) {
       TokenLocation location =
           new TokenLocation(token.getLine(), token.getCharPositionInLine(), token.getText());
       beginLine = location.startLine();

--- a/delphi-tokens-generator-maven-plugin/src/main/java/au/com/integradev/delphi/DelphiTokensGenerator.java
+++ b/delphi-tokens-generator-maven-plugin/src/main/java/au/com/integradev/delphi/DelphiTokensGenerator.java
@@ -76,7 +76,8 @@ public class DelphiTokensGenerator {
   }
 
   private void generateEnum(List<TokenTypeRecord> tokenTypes) throws IOException {
-    Path outputPath = outputDirectory.toPath().resolve("org/sonar/plugins/delphi/api/token");
+    Path outputPath =
+        outputDirectory.toPath().resolve("org/sonar/plugins/communitydelphi/api/token");
 
     Files.createDirectories(outputPath);
 

--- a/delphi-tokens-generator-maven-plugin/src/test/java/au/com/integradev/delphi/DelphiTokensGeneratorTest.java
+++ b/delphi-tokens-generator-maven-plugin/src/test/java/au/com/integradev/delphi/DelphiTokensGeneratorTest.java
@@ -291,7 +291,7 @@ class DelphiTokensGeneratorTest {
   private static String getTokenEnum(Path root) {
     try {
       return Files.readString(
-          root.resolve("out/org/sonar/plugins/delphi/api/token/DelphiTokenType.java"));
+          root.resolve("out/org/sonar/plugins/communitydelphi/api/token/DelphiTokenType.java"));
     } catch (IOException e) {
       throw new UncheckedIOException(e);
     }


### PR DESCRIPTION
This PR adds handling for multiline strings in the `TabulationCharacter` rule.
We now raise issues on multiline strings using tabs for indentation, where we previously only looked at whitespace tokens.

I've also fixed a couple bugs that came up along the way:
- The `DelphiTokenType` generated class was going to the wrong path.
- File position for multiline strings were being calculated incorrectly (as if they weren't multiline tokens).