### PR TITLE
Fix FPs around enumerators in `UnusedRoutine` and `UnusedProperty`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,13 +7,33 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **API:** `EnumeratorOccurrence` type.
+- **API:** `EnumeratorOccurrence::getGetEnumerator` method.
+- **API:** `EnumeratorOccurrence::getMoveNext` method.
+- **API:** `EnumeratorOccurrence::getCurrent` method.
+- **API:** `ForInStatementNode.getEnumeratorOccurrence` method.
+
 ### Changed
 
 - Detect tab-indented multiline strings in `TabulationCharacter`.
 - Improve support for evaluating name references in compiler directive expressions.
 
+### Deprecated
+
+- **API:** `ForInStatementNode::getGetEnumeratorDeclaration` method, get the declaration through
+  `getEnumeratorOccurrence` instead.
+- **API:** `ForInStatementNode::getMoveNextDeclaration` method, get the declaration through
+  `getEnumeratorOccurrence` instead.
+- **API:** `ForInStatementNode::getCurrentDeclaration` method, get the declaration through
+  `getEnumeratorOccurrence` instead.
+
 ### Fixed
 
+- False positives on enumerable method `GetEnumerator` in `UnusedRoutine`.
+- False positives on enumerator method `MoveNext` in `UnusedRoutine`.
+- False positives on enumerator property `Current` in `UnusedProperty`.
 - Name resolution failures in legacy initialization sections referencing the implementation section.
 - Incorrect file position calculation for multiline string tokens.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Name resolution failures in legacy initialization sections referencing the implementation section.
 - Incorrect file position calculation for multiline string tokens.
 
 ## [1.15.0] - 2025-04-03

--- a/delphi-checks/src/test/java/au/com/integradev/delphi/checks/UnusedPropertyCheckTest.java
+++ b/delphi-checks/src/test/java/au/com/integradev/delphi/checks/UnusedPropertyCheckTest.java
@@ -265,4 +265,32 @@ class UnusedPropertyCheckTest {
                 .appendImpl("end;"))
         .verifyIssues();
   }
+
+  @Test
+  void testUsedEnumeratorPropertiesShouldNotAddIssue() {
+    CheckVerifier.newVerifier()
+        .withCheck(new UnusedPropertyCheck())
+        .onFile(
+            new DelphiTestUnitBuilder()
+                .appendDecl("type")
+                .appendDecl("  TFooEnumerator = record")
+                .appendDecl("    function MoveNext: Boolean;")
+                .appendDecl("    property Current: string read FCurrent;")
+                .appendDecl("  end;")
+                .appendDecl("  TFoo = record")
+                .appendDecl("  private")
+                .appendDecl("    FCurrent: string;")
+                .appendDecl("  public")
+                .appendDecl("    function GetEnumerator: TFooEnumerator;")
+                .appendDecl("  end;")
+                .appendImpl("procedure Bar(Foo: TFoo);")
+                .appendImpl("var")
+                .appendImpl("  Baz: string;")
+                .appendImpl("begin")
+                .appendImpl("  for Baz in Foo do begin")
+                .appendImpl("    WriteLn(Baz);")
+                .appendImpl("  end;")
+                .appendImpl("end;"))
+        .verifyNoIssues();
+  }
 }

--- a/delphi-checks/src/test/java/au/com/integradev/delphi/checks/UnusedRoutineCheckTest.java
+++ b/delphi-checks/src/test/java/au/com/integradev/delphi/checks/UnusedRoutineCheckTest.java
@@ -409,4 +409,31 @@ class UnusedRoutineCheckTest {
                 .appendImpl("end;"))
         .verifyIssues();
   }
+
+  @Test
+  void testUsedEnumeratorMethodsShouldNotAddIssue() {
+    CheckVerifier.newVerifier()
+        .withCheck(new UnusedRoutineCheck())
+        .onFile(
+            new DelphiTestUnitBuilder()
+                .appendDecl("type")
+                .appendDecl("  TFooEnumerator = record")
+                .appendDecl("    function MoveNext: Boolean;")
+                .appendDecl("    property Current: string read FCurrent;")
+                .appendDecl("  end;")
+                .appendDecl("  TFoo = record")
+                .appendDecl("  private")
+                .appendDecl("    FCurrent: string;")
+                .appendDecl("  public")
+                .appendDecl("    function GetEnumerator: TFooEnumerator;")
+                .appendDecl("  end;")
+                .appendImpl("var")
+                .appendImpl("  Foo: TFoo;")
+                .appendImpl("  Bar: string;")
+                .appendImpl("begin")
+                .appendImpl("  for Bar in Foo do begin")
+                .appendImpl("    WriteLn(Bar);")
+                .appendImpl("  end;"))
+        .verifyNoIssues();
+  }
 }

--- a/delphi-frontend/src/main/java/au/com/integradev/delphi/antlr/ast/visitors/DependencyAnalysisVisitor.java
+++ b/delphi-frontend/src/main/java/au/com/integradev/delphi/antlr/ast/visitors/DependencyAnalysisVisitor.java
@@ -35,6 +35,7 @@ import org.sonar.plugins.communitydelphi.api.ast.PrimaryExpressionNode;
 import org.sonar.plugins.communitydelphi.api.ast.RoutineImplementationNode;
 import org.sonar.plugins.communitydelphi.api.ast.TypeDeclarationNode;
 import org.sonar.plugins.communitydelphi.api.ast.utils.ExpressionNodeUtils;
+import org.sonar.plugins.communitydelphi.api.symbol.EnumeratorOccurrence;
 import org.sonar.plugins.communitydelphi.api.symbol.NameOccurrence;
 import org.sonar.plugins.communitydelphi.api.symbol.declaration.NameDeclaration;
 import org.sonar.plugins.communitydelphi.api.symbol.declaration.PropertyNameDeclaration;
@@ -184,17 +185,22 @@ public abstract class DependencyAnalysisVisitor implements DelphiParserVisitor<D
 
   @Override
   public Data visit(ForInStatementNode forInStatementNode, Data data) {
-    RoutineNameDeclaration enumerator = forInStatementNode.getGetEnumeratorDeclaration();
-    addDependenciesForDeclaration(enumerator, data);
-    handleInlineRoutines(enumerator, data);
+    EnumeratorOccurrence enumerator = forInStatementNode.getEnumeratorOccurrence();
 
-    RoutineNameDeclaration moveNext = forInStatementNode.getMoveNextDeclaration();
-    addDependenciesForDeclaration(moveNext, data);
-    handleInlineRoutines(moveNext, data);
+    if (enumerator != null) {
+      var getEnumerator =
+          (RoutineNameDeclaration) enumerator.getGetEnumerator().getNameDeclaration();
+      addDependenciesForDeclaration(getEnumerator, data);
+      handleInlineRoutines(getEnumerator, data);
 
-    PropertyNameDeclaration current = forInStatementNode.getCurrentDeclaration();
-    addDependenciesForDeclaration(current, data);
-    handleInlineRoutines(current, data);
+      var moveNext = (RoutineNameDeclaration) enumerator.getMoveNext().getNameDeclaration();
+      addDependenciesForDeclaration(moveNext, data);
+      handleInlineRoutines(moveNext, data);
+
+      var current = (PropertyNameDeclaration) enumerator.getCurrent().getNameDeclaration();
+      addDependenciesForDeclaration(current, data);
+      handleInlineRoutines(current, data);
+    }
 
     return DelphiParserVisitor.super.visit(forInStatementNode, data);
   }

--- a/delphi-frontend/src/main/java/au/com/integradev/delphi/antlr/ast/visitors/SymbolAssociationVisitor.java
+++ b/delphi-frontend/src/main/java/au/com/integradev/delphi/antlr/ast/visitors/SymbolAssociationVisitor.java
@@ -27,6 +27,7 @@ import com.google.common.base.Preconditions;
 import org.sonar.plugins.communitydelphi.api.ast.ArrayAccessorNode;
 import org.sonar.plugins.communitydelphi.api.ast.DelphiAst;
 import org.sonar.plugins.communitydelphi.api.ast.DelphiNode;
+import org.sonar.plugins.communitydelphi.api.ast.ForInStatementNode;
 import org.sonar.plugins.communitydelphi.api.ast.NameDeclarationNode;
 import org.sonar.plugins.communitydelphi.api.ast.NameReferenceNode;
 import org.sonar.plugins.communitydelphi.api.ast.RoutineNameNode;
@@ -95,6 +96,12 @@ public class SymbolAssociationVisitor implements DelphiParserVisitor<Data> {
 
   @Override
   public Data visit(RoutineNameNode node, Data data) {
+    data.fileScope.attach(node);
+    return DelphiParserVisitor.super.visit(node, data);
+  }
+
+  @Override
+  public Data visit(ForInStatementNode node, Data data) {
     data.fileScope.attach(node);
     return DelphiParserVisitor.super.visit(node, data);
   }

--- a/delphi-frontend/src/main/java/au/com/integradev/delphi/antlr/ast/visitors/SymbolTableVisitor.java
+++ b/delphi-frontend/src/main/java/au/com/integradev/delphi/antlr/ast/visitors/SymbolTableVisitor.java
@@ -620,6 +620,8 @@ public abstract class SymbolTableVisitor implements DelphiParserVisitor<Data> {
     node.getEnumerable().accept(this, data);
     node.getVariable().accept(this, data);
 
+    data.nameResolutionHelper.resolve(node);
+
     return visitScopeFromRoot(node.getStatement(), data);
   }
 

--- a/delphi-frontend/src/main/java/au/com/integradev/delphi/antlr/ast/visitors/SymbolTableVisitor.java
+++ b/delphi-frontend/src/main/java/au/com/integradev/delphi/antlr/ast/visitors/SymbolTableVisitor.java
@@ -277,6 +277,11 @@ public abstract class SymbolTableVisitor implements DelphiParserVisitor<Data> {
       public Data visit(FinalizationSectionNode node, Data data) {
         return data;
       }
+
+      @Override
+      public Data visit(CompoundStatementNode node, Data data) {
+        return data;
+      }
     };
   }
 

--- a/delphi-frontend/src/main/java/au/com/integradev/delphi/symbol/declaration/VariableNameDeclarationImpl.java
+++ b/delphi-frontend/src/main/java/au/com/integradev/delphi/symbol/declaration/VariableNameDeclarationImpl.java
@@ -36,6 +36,7 @@ import org.sonar.plugins.communitydelphi.api.ast.TypeNode;
 import org.sonar.plugins.communitydelphi.api.ast.VarDeclarationNode;
 import org.sonar.plugins.communitydelphi.api.ast.VarStatementNode;
 import org.sonar.plugins.communitydelphi.api.ast.Visibility;
+import org.sonar.plugins.communitydelphi.api.symbol.EnumeratorOccurrence;
 import org.sonar.plugins.communitydelphi.api.symbol.declaration.NameDeclaration;
 import org.sonar.plugins.communitydelphi.api.symbol.declaration.VariableNameDeclaration;
 import org.sonar.plugins.communitydelphi.api.symbol.scope.DelphiScope;
@@ -148,7 +149,12 @@ public final class VariableNameDeclarationImpl extends NameDeclarationImpl
     if (loop instanceof ForToStatementNode) {
       typed = ((ForToStatementNode) loop).getInitializerExpression();
     } else {
-      typed = ((ForInStatementNode) loop).getCurrentDeclaration();
+      EnumeratorOccurrence enumerator = ((ForInStatementNode) loop).getEnumeratorOccurrence();
+      if (enumerator != null) {
+        typed = (Typed) enumerator.getCurrent().getNameDeclaration();
+      } else {
+        typed = null;
+      }
     }
 
     return getDeclaredTypeWithTypeInferenceFallback(

--- a/delphi-frontend/src/main/java/au/com/integradev/delphi/symbol/occurrence/EnumeratorOccurrenceImpl.java
+++ b/delphi-frontend/src/main/java/au/com/integradev/delphi/symbol/occurrence/EnumeratorOccurrenceImpl.java
@@ -1,0 +1,50 @@
+/*
+ * Sonar Delphi Plugin
+ * Copyright (C) 2025 Integrated Application Development
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02
+ */
+package au.com.integradev.delphi.symbol.occurrence;
+
+import org.sonar.plugins.communitydelphi.api.symbol.EnumeratorOccurrence;
+import org.sonar.plugins.communitydelphi.api.symbol.NameOccurrence;
+
+public class EnumeratorOccurrenceImpl implements EnumeratorOccurrence {
+  private final NameOccurrence getEnumerator;
+  private final NameOccurrence moveNext;
+  private final NameOccurrence current;
+
+  public EnumeratorOccurrenceImpl(
+      NameOccurrence getEnumerator, NameOccurrence moveNext, NameOccurrence current) {
+    this.getEnumerator = getEnumerator;
+    this.moveNext = moveNext;
+    this.current = current;
+  }
+
+  @Override
+  public NameOccurrence getGetEnumerator() {
+    return getEnumerator;
+  }
+
+  @Override
+  public NameOccurrence getMoveNext() {
+    return moveNext;
+  }
+
+  @Override
+  public NameOccurrence getCurrent() {
+    return current;
+  }
+}

--- a/delphi-frontend/src/main/java/org/sonar/plugins/communitydelphi/api/ast/ForInStatementNode.java
+++ b/delphi-frontend/src/main/java/org/sonar/plugins/communitydelphi/api/ast/ForInStatementNode.java
@@ -19,18 +19,35 @@
 package org.sonar.plugins.communitydelphi.api.ast;
 
 import javax.annotation.Nullable;
+import org.sonar.plugins.communitydelphi.api.symbol.EnumeratorOccurrence;
 import org.sonar.plugins.communitydelphi.api.symbol.declaration.PropertyNameDeclaration;
 import org.sonar.plugins.communitydelphi.api.symbol.declaration.RoutineNameDeclaration;
 
 public interface ForInStatementNode extends ForStatementNode {
+
+  /**
+   * @deprecated Get via {@link ForInStatementNode#getEnumeratorOccurrence} instead.
+   */
+  @Deprecated(forRemoval = true)
   @Nullable
   RoutineNameDeclaration getGetEnumeratorDeclaration();
 
+  /**
+   * @deprecated Get via {@link ForInStatementNode#getEnumeratorOccurrence} instead.
+   */
+  @Deprecated(forRemoval = true)
   @Nullable
   RoutineNameDeclaration getMoveNextDeclaration();
 
+  /**
+   * @deprecated Get via {@link ForInStatementNode#getEnumeratorOccurrence} instead.
+   */
+  @Deprecated(forRemoval = true)
   @Nullable
   PropertyNameDeclaration getCurrentDeclaration();
 
   ExpressionNode getEnumerable();
+
+  @Nullable
+  EnumeratorOccurrence getEnumeratorOccurrence();
 }

--- a/delphi-frontend/src/main/java/org/sonar/plugins/communitydelphi/api/symbol/EnumeratorOccurrence.java
+++ b/delphi-frontend/src/main/java/org/sonar/plugins/communitydelphi/api/symbol/EnumeratorOccurrence.java
@@ -1,0 +1,27 @@
+/*
+ * Sonar Delphi Plugin
+ * Copyright (C) 2025 Integrated Application Development
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02
+ */
+package org.sonar.plugins.communitydelphi.api.symbol;
+
+public interface EnumeratorOccurrence {
+  NameOccurrence getGetEnumerator();
+
+  NameOccurrence getMoveNext();
+
+  NameOccurrence getCurrent();
+}

--- a/delphi-frontend/src/test/resources/au/com/integradev/delphi/symbol/dependencies/imports/UnitWithGetEnumeratorForTObject.pas
+++ b/delphi-frontend/src/test/resources/au/com/integradev/delphi/symbol/dependencies/imports/UnitWithGetEnumeratorForTObject.pas
@@ -5,6 +5,8 @@ interface
 type
   TObjectHelper = class helper for TObject
     function GetEnumerator: TObject;
+    function MoveNext: Boolean;
+    property Current: TObject read Foo;
   end;
 
 implementation


### PR DESCRIPTION
There are a few magic enumerator-related declarations:
- `GetEnumerator` enumerable method
- `MoveNext` enumerator method
- `Current` enumerator property

These are implicitly used by for-in loops, but we weren't previously encoding that information in the symbol table.
As a result, the `Unused*` rules were raising issues on them.

I've also fixed a symbol table visitor bug causing name resolution failures in legacy initialization sections, which came up while testing the changes around enumerator usages.