### PR TITLE
Add `ORCHESTRATOR_SONAR_VERSION` override for integration tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,6 @@ on:
       - '**.png'
       - 'LICENSE.txt'
       - 'NOTICE.txt'
-      - '.git*'
 
 jobs:
   install:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,7 +27,12 @@ jobs:
           distribution: 'temurin'
           cache: maven
       - name: Maven Install
-        run: mvn clean install -Pci --batch-mode --no-transfer-progress
+        env:
+          ORCHESTRATOR_SONAR_VERSION: ${{ vars.ORCHESTRATOR_SONAR_VERSION || 'LATEST_RELEASE' }}
+        run: >
+          mvn clean install
+          -Dsonar.runtimeVersion=$ORCHESTRATOR_SONAR_VERSION
+          -Pci --batch-mode --no-transfer-progress
       - name: Upload plugin jar
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -28,7 +28,9 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+          ORCHESTRATOR_SONAR_VERSION: ${{ vars.ORCHESTRATOR_SONAR_VERSION || 'LATEST_RELEASE' }}
         run: >
           mvn clean install -Pci
+          -Dsonar.runtimeVersion=$ORCHESTRATOR_SONAR_VERSION
           org.sonarsource.scanner.maven:sonar-maven-plugin:sonar -Dsonar.projectKey=integrated-application-development_sonar-delphi
           --batch-mode --no-transfer-progress


### PR DESCRIPTION
It's been days since SonarSource released 25.4.0.105899 to maven central, and the `sonarqube-application` zip artifact is still missing. This is causing our integration tests to fail because we always pass `LATEST_RELEASE` to the orchestrator.

This PR introduces a repository-level `ORCHESTRATOR_SONAR_VERSION` variable which can override the SonarQube version we use in integration tests.

See:
- [25.4.0.105899 is missing on Maven Central](https://community.sonarsource.com/t/25-4-0-105899-is-missing-on-maven-central/138625)