### PR TITLE
Fix analysis errors around `type of` types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **API:** `EnumeratorOccurrence::getMoveNext` method.
 - **API:** `EnumeratorOccurrence::getCurrent` method.
 - **API:** `ForInStatementNode.getEnumeratorOccurrence` method.
+- **API:** `TypeOfTypeNode::getTypeReferenceNode` method.
 
 ### Changed
 
@@ -37,6 +38,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - False positives on enums that are never referenced by name (but have used values) in `UnusedType`.
 - Name resolution failures in legacy initialization sections referencing the implementation section.
 - Incorrect file position calculation for multiline string tokens.
+- Analysis errors around `type of` type declarations.
 
 ## [1.15.0] - 2025-04-03
 

--- a/delphi-frontend/src/main/antlr3/au/com/integradev/delphi/antlr/Delphi.g
+++ b/delphi-frontend/src/main/antlr3/au/com/integradev/delphi/antlr/Delphi.g
@@ -646,7 +646,7 @@ simpleProcedureType          : procedureTypeHeading -> ^(TkProcedureType<Procedu
 procedureTypeHeading         : FUNCTION<ProcedureTypeHeadingNodeImpl>^ routineParameters? routineReturnType? ((';')? interfaceDirective)*
                              | PROCEDURE<ProcedureTypeHeadingNodeImpl>^ routineParameters? ((';')? interfaceDirective)*
                              ;
-typeOfType                   : TYPE<TypeOfTypeNodeImpl>^ OF typeDecl
+typeOfType                   : TYPE<TypeOfTypeNodeImpl>^ OF typeReference
                              ;
 strongAliasType              : TYPE<StrongAliasTypeNodeImpl>^ typeReferenceOrStringOrFile codePageExpression?
                              ;

--- a/delphi-frontend/src/main/java/au/com/integradev/delphi/antlr/ast/node/TypeOfTypeNodeImpl.java
+++ b/delphi-frontend/src/main/java/au/com/integradev/delphi/antlr/ast/node/TypeOfTypeNodeImpl.java
@@ -21,8 +21,9 @@ package au.com.integradev.delphi.antlr.ast.node;
 import au.com.integradev.delphi.antlr.ast.visitors.DelphiParserVisitor;
 import javax.annotation.Nonnull;
 import org.antlr.runtime.Token;
-import org.sonar.plugins.communitydelphi.api.ast.TypeNode;
+import org.sonar.plugins.communitydelphi.api.ast.TypeDeclarationNode;
 import org.sonar.plugins.communitydelphi.api.ast.TypeOfTypeNode;
+import org.sonar.plugins.communitydelphi.api.ast.TypeReferenceNode;
 import org.sonar.plugins.communitydelphi.api.type.Type;
 
 public final class TypeOfTypeNodeImpl extends TypeNodeImpl implements TypeOfTypeNode {
@@ -36,8 +37,18 @@ public final class TypeOfTypeNodeImpl extends TypeNodeImpl implements TypeOfType
   }
 
   @Override
+  public TypeReferenceNode getTypeReferenceNode() {
+    return (TypeReferenceNode) getChild(1);
+  }
+
+  @Override
   @Nonnull
   protected Type createType() {
-    return ((TypeNode) getChild(0)).getType();
+    String image = null;
+    if (parent instanceof TypeDeclarationNode) {
+      image = ((TypeDeclarationNode) parent).fullyQualifiedName();
+    }
+    Type type = getTypeReferenceNode().getType();
+    return getTypeFactory().classOf(image, type);
   }
 }

--- a/delphi-frontend/src/main/java/org/sonar/plugins/communitydelphi/api/ast/TypeOfTypeNode.java
+++ b/delphi-frontend/src/main/java/org/sonar/plugins/communitydelphi/api/ast/TypeOfTypeNode.java
@@ -18,4 +18,6 @@
  */
 package org.sonar.plugins.communitydelphi.api.ast;
 
-public interface TypeOfTypeNode extends TypeNode {}
+public interface TypeOfTypeNode extends TypeNode {
+  TypeReferenceNode getTypeReferenceNode();
+}

--- a/delphi-frontend/src/test/java/au/com/integradev/delphi/executor/DelphiSymbolTableExecutorTest.java
+++ b/delphi-frontend/src/test/java/au/com/integradev/delphi/executor/DelphiSymbolTableExecutorTest.java
@@ -422,6 +422,12 @@ class DelphiSymbolTableExecutorTest {
   }
 
   @Test
+  void testClassReferenceTypeOf() {
+    execute("classReferences/TypeOf.pas");
+    verifyUsages(10, 10, reference(17, 2));
+  }
+
+  @Test
   void testSimpleForwardDeclarations() {
     execute("forwardDeclarations/Simple.pas");
     verifyUsages(22, 26, reference(24, 14));

--- a/delphi-frontend/src/test/resources/au/com/integradev/delphi/symbol/classReferences/TypeOf.pas
+++ b/delphi-frontend/src/test/resources/au/com/integradev/delphi/symbol/classReferences/TypeOf.pas
@@ -1,0 +1,20 @@
+unit TypeOf;
+
+interface
+
+type
+  TIntegerType = type of Integer;
+
+implementation
+
+procedure Foo(T: TIntegerType);
+begin
+  // do nothing
+end;
+
+procedure Test;
+begin
+  Foo(Integer);
+end;
+
+end.


### PR DESCRIPTION
This PR:
- fixes the `ClassCastException` in `TypeOfTypeNode::createType`
- models the type as a class reference type (like `class of`)

Fixes #361.