### PR TITLE
Fix FPs around enums that are never referenced by name in `UnusedType`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - False positives on enumerable method `GetEnumerator` in `UnusedRoutine`.
 - False positives on enumerator method `MoveNext` in `UnusedRoutine`.
 - False positives on enumerator property `Current` in `UnusedProperty`.
+- False positives on enums that are never referenced by name (but have used values) in `UnusedType`.
 - Name resolution failures in legacy initialization sections referencing the implementation section.
 - Incorrect file position calculation for multiline string tokens.
 

--- a/delphi-checks/src/test/java/au/com/integradev/delphi/checks/UnusedTypeCheckTest.java
+++ b/delphi-checks/src/test/java/au/com/integradev/delphi/checks/UnusedTypeCheckTest.java
@@ -212,4 +212,34 @@ class UnusedTypeCheckTest {
                 .appendDecl("  end;"))
         .verifyNoIssues();
   }
+
+  @Test
+  void testUnusedEnumWithUsedElementsShouldNotAddIssue() {
+    CheckVerifier.newVerifier()
+        .withCheck(new UnusedTypeCheck())
+        .onFile(
+            new DelphiTestUnitBuilder()
+                .appendImpl("function Foo: Integer;")
+                .appendImpl("type")
+                .appendImpl("  TBar = (Baz, Flarp);")
+                .appendImpl("begin")
+                .appendImpl("  Result := Ord(Baz) + 123;")
+                .appendImpl("end;"))
+        .verifyNoIssues();
+  }
+
+  @Test
+  void testUnusedEnumWithUnusedElementsShouldAddIssue() {
+    CheckVerifier.newVerifier()
+        .withCheck(new UnusedTypeCheck())
+        .onFile(
+            new DelphiTestUnitBuilder()
+                .appendImpl("function Foo: Integer;")
+                .appendImpl("type")
+                .appendImpl("  TBar = (Baz, Flarp); // Noncompliant")
+                .appendImpl("begin")
+                .appendImpl("  Result := 123;")
+                .appendImpl("end;"))
+        .verifyIssues();
+  }
 }


### PR DESCRIPTION
This PR fixes false positives in the `UnusedType` rule around enums.

If an enum type is never referenced by name, that doesn't mean the whole type is unused.
We now also check if any of its values are used.