### PR TITLE
Disable integration tests until SonarSource fixes the orchestrator

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -478,7 +478,7 @@
       <id>ci</id>
       <properties>
         <license.failIfMissing>true</license.failIfMissing>
-        <skipITs>false</skipITs>
+        <skipITs>true</skipITs>
       </properties>
     </profile>
 


### PR DESCRIPTION
See: https://community.sonarsource.com/t/fail-to-load-versions-of-org-sonarsource-sonarqube-sonar-application/138865