### PR TITLE
Improve handling of generic specialization and constraints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,7 +51,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - False positives on enumerator property `Current` in `UnusedProperty`.
 - False positives on enums that are never referenced by name (but have used values) in `UnusedType`.
 - Name resolution failures in legacy initialization sections referencing the implementation section.
-- Name resolution failures whena accessing ancestors of enclosing types from nested type methods.
+- Name resolution failures when accessing ancestors of enclosing types from nested type methods.
 - Name resolution failures on invocations of methods with generic open array parameters.
 - Name resolution failures around `Create` calls on types with `constructor` constraints.
 - Incorrect file position calculation for multiline string tokens.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,9 +10,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - **API:** `EnumeratorOccurrence` type.
-- **API:** `EnumeratorOccurrence::getGetEnumerator` method.
-- **API:** `EnumeratorOccurrence::getMoveNext` method.
-- **API:** `EnumeratorOccurrence::getCurrent` method.
 - **API:** `ForInStatementNode.getEnumeratorOccurrence` method.
 - **API:** `TypeOfTypeNode::getTypeReferenceNode` method.
 - **API:** `NameReferenceNode::getFirstName` method.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - False positives on enums that are never referenced by name (but have used values) in `UnusedType`.
 - Name resolution failures in legacy initialization sections referencing the implementation section.
 - Name resolution failures whena accessing ancestors of enclosing types from nested type methods.
+- Name resolution failures on invocations of methods with generic open array parameters.
 - Incorrect file position calculation for multiline string tokens.
 - Analysis errors around `type of` type declarations.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,11 +15,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **API:** `EnumeratorOccurrence::getCurrent` method.
 - **API:** `ForInStatementNode.getEnumeratorOccurrence` method.
 - **API:** `TypeOfTypeNode::getTypeReferenceNode` method.
+- **API:** `NameReferenceNode::getFirstName` method.
+- **API:** `DelphiTokenType.TYPE_CONSTRAINT` token type.
+- **API:** `ConstraintNode` node type.
+- **API:** `ClassConstraintNode` node type.
+- **API:** `ConstructorConstraintNode` node type.
+- **API:** `RecordConstraintNode` node type.
+- **API:** `TypeConstraintNode` node type.
+- **API:** `TypeParameterNode::getConstraintNodes` method.
+- **API:** `TypeParameterType::constraintItems` method.
+- **API:** `Constraint` type.
+- **API:** `Constraint.ClassConstraint` type.
+- **API:** `Constraint.ConstructorConstraint` type.
+- **API:** `Constraint.RecordConstraint` type.
+- **API:** `Constraint.TypeConstraint` type.
 
 ### Changed
 
 - Detect tab-indented multiline strings in `TabulationCharacter`.
 - Improve support for evaluating name references in compiler directive expressions.
+- Improve overload resolution in cases involving generic type parameter constraints.
 
 ### Deprecated
 
@@ -29,6 +44,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `getEnumeratorOccurrence` instead.
 - **API:** `ForInStatementNode::getCurrentDeclaration` method, get the declaration through
   `getEnumeratorOccurrence` instead.
+- **API:** `TypeParameterNode::getTypeConstraintNodes` method, use `getConstraintNodes` instead.
+- **API:** `TypeParameterType::constraints` method, use `constraintItems` instead.
 
 ### Fixed
 
@@ -39,6 +56,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Name resolution failures in legacy initialization sections referencing the implementation section.
 - Name resolution failures whena accessing ancestors of enclosing types from nested type methods.
 - Name resolution failures on invocations of methods with generic open array parameters.
+- Name resolution failures around `Create` calls on types with `constructor` constraints.
 - Incorrect file position calculation for multiline string tokens.
 - Analysis errors around `type of` type declarations.
 

--- a/delphi-frontend/src/main/antlr3/au/com/integradev/delphi/antlr/Delphi.g
+++ b/delphi-frontend/src/main/antlr3/au/com/integradev/delphi/antlr/Delphi.g
@@ -64,6 +64,7 @@ tokens {
   TkCompilerDirective;
   TkRealNumber;
   TkTypeParameter;
+  TkTypeConstraint;
   TkForLoopVar;
   TkArrayAccessorNode;
   TkArrayConstructor;
@@ -780,10 +781,10 @@ typeParameter                :  nameDeclaration (',' nameDeclaration)* (':' gene
                                     nameDeclaration (nameDeclaration)* (genericConstraint genericConstraint*)?
                                  )
                              ;
-genericConstraint            : typeReference
-                             | RECORD
-                             | CLASS
-                             | CONSTRUCTOR
+genericConstraint            : typeReference -> ^(TkTypeConstraint<TypeConstraintNodeImpl> typeReference)
+                             | RECORD<RecordConstraintNodeImpl>^
+                             | CLASS<ClassConstraintNodeImpl>^
+                             | CONSTRUCTOR<ConstructorConstraintNodeImpl>^
                              ;
 genericArguments             : '<' typeReferenceOrStringOrFile (',' typeReferenceOrStringOrFile)* '>'
                              -> ^(TkGenericArguments<GenericArgumentsNodeImpl> '<' typeReferenceOrStringOrFile (',' typeReferenceOrStringOrFile)* '>')

--- a/delphi-frontend/src/main/java/au/com/integradev/delphi/antlr/ast/node/ClassConstraintNodeImpl.java
+++ b/delphi-frontend/src/main/java/au/com/integradev/delphi/antlr/ast/node/ClassConstraintNodeImpl.java
@@ -1,0 +1,41 @@
+/*
+ * Sonar Delphi Plugin
+ * Copyright (C) 2025 Integrated Application Development
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02
+ */
+package au.com.integradev.delphi.antlr.ast.node;
+
+import au.com.integradev.delphi.antlr.ast.visitors.DelphiParserVisitor;
+import au.com.integradev.delphi.type.generic.constraint.ClassConstraintImpl;
+import org.antlr.runtime.Token;
+import org.sonar.plugins.communitydelphi.api.ast.ClassConstraintNode;
+import org.sonar.plugins.communitydelphi.api.type.Constraint;
+
+public final class ClassConstraintNodeImpl extends DelphiNodeImpl implements ClassConstraintNode {
+  public ClassConstraintNodeImpl(Token token) {
+    super(token);
+  }
+
+  @Override
+  public <T> T accept(DelphiParserVisitor<T> visitor, T data) {
+    return visitor.visit(this, data);
+  }
+
+  @Override
+  public Constraint getConstraint() {
+    return ClassConstraintImpl.instance();
+  }
+}

--- a/delphi-frontend/src/main/java/au/com/integradev/delphi/antlr/ast/node/ConstructorConstraintNodeImpl.java
+++ b/delphi-frontend/src/main/java/au/com/integradev/delphi/antlr/ast/node/ConstructorConstraintNodeImpl.java
@@ -1,0 +1,42 @@
+/*
+ * Sonar Delphi Plugin
+ * Copyright (C) 2025 Integrated Application Development
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02
+ */
+package au.com.integradev.delphi.antlr.ast.node;
+
+import au.com.integradev.delphi.antlr.ast.visitors.DelphiParserVisitor;
+import au.com.integradev.delphi.type.generic.constraint.ConstructorConstraintImpl;
+import org.antlr.runtime.Token;
+import org.sonar.plugins.communitydelphi.api.ast.ConstructorConstraintNode;
+import org.sonar.plugins.communitydelphi.api.type.Constraint;
+
+public final class ConstructorConstraintNodeImpl extends DelphiNodeImpl
+    implements ConstructorConstraintNode {
+  public ConstructorConstraintNodeImpl(Token token) {
+    super(token);
+  }
+
+  @Override
+  public <T> T accept(DelphiParserVisitor<T> visitor, T data) {
+    return visitor.visit(this, data);
+  }
+
+  @Override
+  public Constraint getConstraint() {
+    return ConstructorConstraintImpl.instance();
+  }
+}

--- a/delphi-frontend/src/main/java/au/com/integradev/delphi/antlr/ast/node/GenericDefinitionNodeImpl.java
+++ b/delphi-frontend/src/main/java/au/com/integradev/delphi/antlr/ast/node/GenericDefinitionNodeImpl.java
@@ -24,13 +24,13 @@ import com.google.common.collect.ImmutableList;
 import java.util.List;
 import java.util.stream.Collectors;
 import org.antlr.runtime.Token;
+import org.sonar.plugins.communitydelphi.api.ast.ConstraintNode;
 import org.sonar.plugins.communitydelphi.api.ast.DelphiNode;
 import org.sonar.plugins.communitydelphi.api.ast.GenericDefinitionNode;
 import org.sonar.plugins.communitydelphi.api.ast.NameDeclarationNode;
 import org.sonar.plugins.communitydelphi.api.ast.TypeParameterNode;
-import org.sonar.plugins.communitydelphi.api.type.Type;
+import org.sonar.plugins.communitydelphi.api.type.Constraint;
 import org.sonar.plugins.communitydelphi.api.type.Type.TypeParameterType;
-import org.sonar.plugins.communitydelphi.api.type.Typed;
 
 public final class GenericDefinitionNodeImpl extends DelphiNodeImpl
     implements GenericDefinitionNode {
@@ -56,9 +56,9 @@ public final class GenericDefinitionNodeImpl extends DelphiNodeImpl
       ImmutableList.Builder<TypeParameter> builder = ImmutableList.builder();
 
       for (TypeParameterNode parameterNode : getTypeParameterNodes()) {
-        List<Type> constraints =
-            parameterNode.getTypeConstraintNodes().stream()
-                .map(Typed::getType)
+        List<Constraint> constraints =
+            parameterNode.getConstraintNodes().stream()
+                .map(ConstraintNode::getConstraint)
                 .collect(Collectors.toUnmodifiableList());
 
         for (NameDeclarationNode name : parameterNode.getTypeParameterNameNodes()) {

--- a/delphi-frontend/src/main/java/au/com/integradev/delphi/antlr/ast/node/NameReferenceNodeImpl.java
+++ b/delphi-frontend/src/main/java/au/com/integradev/delphi/antlr/ast/node/NameReferenceNodeImpl.java
@@ -156,6 +156,15 @@ public final class NameReferenceNodeImpl extends DelphiNodeImpl implements NameR
   }
 
   @Override
+  public NameReferenceNode getFirstName() {
+    NameReferenceNode result = this;
+    while (result.getParent() instanceof NameReferenceNode) {
+      result = (NameReferenceNode) result.getParent();
+    }
+    return result;
+  }
+
+  @Override
   public NameReferenceNode getLastName() {
     List<NameReferenceNode> flatNames = flatten();
     return flatNames.get(flatNames.size() - 1);

--- a/delphi-frontend/src/main/java/au/com/integradev/delphi/antlr/ast/node/RecordConstraintNodeImpl.java
+++ b/delphi-frontend/src/main/java/au/com/integradev/delphi/antlr/ast/node/RecordConstraintNodeImpl.java
@@ -1,0 +1,41 @@
+/*
+ * Sonar Delphi Plugin
+ * Copyright (C) 2025 Integrated Application Development
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02
+ */
+package au.com.integradev.delphi.antlr.ast.node;
+
+import au.com.integradev.delphi.antlr.ast.visitors.DelphiParserVisitor;
+import au.com.integradev.delphi.type.generic.constraint.RecordConstraintImpl;
+import org.antlr.runtime.Token;
+import org.sonar.plugins.communitydelphi.api.ast.RecordConstraintNode;
+import org.sonar.plugins.communitydelphi.api.type.Constraint;
+
+public final class RecordConstraintNodeImpl extends DelphiNodeImpl implements RecordConstraintNode {
+  public RecordConstraintNodeImpl(Token token) {
+    super(token);
+  }
+
+  @Override
+  public <T> T accept(DelphiParserVisitor<T> visitor, T data) {
+    return visitor.visit(this, data);
+  }
+
+  @Override
+  public Constraint getConstraint() {
+    return RecordConstraintImpl.instance();
+  }
+}

--- a/delphi-frontend/src/main/java/au/com/integradev/delphi/antlr/ast/node/TypeConstraintNodeImpl.java
+++ b/delphi-frontend/src/main/java/au/com/integradev/delphi/antlr/ast/node/TypeConstraintNodeImpl.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Delphi Plugin
- * Copyright (C) 2019 Integrated Application Development
+ * Copyright (C) 2025 Integrated Application Development
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -19,21 +19,20 @@
 package au.com.integradev.delphi.antlr.ast.node;
 
 import au.com.integradev.delphi.antlr.ast.visitors.DelphiParserVisitor;
-import java.util.List;
-import java.util.stream.Collectors;
+import au.com.integradev.delphi.type.generic.constraint.TypeConstraintImpl;
 import org.antlr.runtime.Token;
-import org.sonar.plugins.communitydelphi.api.ast.ConstraintNode;
-import org.sonar.plugins.communitydelphi.api.ast.NameDeclarationNode;
 import org.sonar.plugins.communitydelphi.api.ast.TypeConstraintNode;
-import org.sonar.plugins.communitydelphi.api.ast.TypeParameterNode;
 import org.sonar.plugins.communitydelphi.api.ast.TypeReferenceNode;
+import org.sonar.plugins.communitydelphi.api.type.Constraint;
 
-public final class TypeParameterNodeImpl extends DelphiNodeImpl implements TypeParameterNode {
-  public TypeParameterNodeImpl(Token token) {
+public final class TypeConstraintNodeImpl extends DelphiNodeImpl implements TypeConstraintNode {
+  private Constraint constraint;
+
+  public TypeConstraintNodeImpl(Token token) {
     super(token);
   }
 
-  public TypeParameterNodeImpl(int tokenType) {
+  public TypeConstraintNodeImpl(int tokenType) {
     super(tokenType);
   }
 
@@ -43,22 +42,15 @@ public final class TypeParameterNodeImpl extends DelphiNodeImpl implements TypeP
   }
 
   @Override
-  public List<NameDeclarationNode> getTypeParameterNameNodes() {
-    return findChildrenOfType(NameDeclarationNode.class);
-  }
-
-  @SuppressWarnings("removal")
-  @Override
-  public List<TypeReferenceNode> getTypeConstraintNodes() {
-    return getConstraintNodes().stream()
-        .filter(TypeConstraintNode.class::isInstance)
-        .map(TypeConstraintNode.class::cast)
-        .map(TypeConstraintNode::getTypeNode)
-        .collect(Collectors.toList());
+  public TypeReferenceNode getTypeNode() {
+    return (TypeReferenceNode) getChild(0);
   }
 
   @Override
-  public List<ConstraintNode> getConstraintNodes() {
-    return findChildrenOfType(ConstraintNode.class);
+  public Constraint getConstraint() {
+    if (constraint == null) {
+      constraint = new TypeConstraintImpl(getTypeNode().getType());
+    }
+    return constraint;
   }
 }

--- a/delphi-frontend/src/main/java/au/com/integradev/delphi/antlr/ast/visitors/DelphiParserVisitor.java
+++ b/delphi-frontend/src/main/java/au/com/integradev/delphi/antlr/ast/visitors/DelphiParserVisitor.java
@@ -40,6 +40,7 @@ import org.sonar.plugins.communitydelphi.api.ast.AttributeNode;
 import org.sonar.plugins.communitydelphi.api.ast.BinaryExpressionNode;
 import org.sonar.plugins.communitydelphi.api.ast.CaseItemStatementNode;
 import org.sonar.plugins.communitydelphi.api.ast.CaseStatementNode;
+import org.sonar.plugins.communitydelphi.api.ast.ClassConstraintNode;
 import org.sonar.plugins.communitydelphi.api.ast.ClassHelperTypeNode;
 import org.sonar.plugins.communitydelphi.api.ast.ClassReferenceTypeNode;
 import org.sonar.plugins.communitydelphi.api.ast.ClassTypeNode;
@@ -49,6 +50,8 @@ import org.sonar.plugins.communitydelphi.api.ast.ConstArrayElementTypeNode;
 import org.sonar.plugins.communitydelphi.api.ast.ConstDeclarationNode;
 import org.sonar.plugins.communitydelphi.api.ast.ConstSectionNode;
 import org.sonar.plugins.communitydelphi.api.ast.ConstStatementNode;
+import org.sonar.plugins.communitydelphi.api.ast.ConstraintNode;
+import org.sonar.plugins.communitydelphi.api.ast.ConstructorConstraintNode;
 import org.sonar.plugins.communitydelphi.api.ast.ContainsClauseNode;
 import org.sonar.plugins.communitydelphi.api.ast.DelphiAst;
 import org.sonar.plugins.communitydelphi.api.ast.DelphiNode;
@@ -117,6 +120,7 @@ import org.sonar.plugins.communitydelphi.api.ast.QualifiedNameDeclarationNode;
 import org.sonar.plugins.communitydelphi.api.ast.RaiseStatementNode;
 import org.sonar.plugins.communitydelphi.api.ast.RangeExpressionNode;
 import org.sonar.plugins.communitydelphi.api.ast.RealLiteralNode;
+import org.sonar.plugins.communitydelphi.api.ast.RecordConstraintNode;
 import org.sonar.plugins.communitydelphi.api.ast.RecordExpressionItemNode;
 import org.sonar.plugins.communitydelphi.api.ast.RecordExpressionNode;
 import org.sonar.plugins.communitydelphi.api.ast.RecordHelperTypeNode;
@@ -144,6 +148,7 @@ import org.sonar.plugins.communitydelphi.api.ast.StructTypeNode;
 import org.sonar.plugins.communitydelphi.api.ast.SubRangeTypeNode;
 import org.sonar.plugins.communitydelphi.api.ast.TextLiteralNode;
 import org.sonar.plugins.communitydelphi.api.ast.TryStatementNode;
+import org.sonar.plugins.communitydelphi.api.ast.TypeConstraintNode;
 import org.sonar.plugins.communitydelphi.api.ast.TypeDeclarationNode;
 import org.sonar.plugins.communitydelphi.api.ast.TypeNode;
 import org.sonar.plugins.communitydelphi.api.ast.TypeOfTypeNode;
@@ -744,5 +749,26 @@ public interface DelphiParserVisitor<T> {
 
   default T visit(WithStatementNode node, T data) {
     return visit((StatementNode) node, data);
+  }
+
+  /* Constraints */
+  default T visit(ConstraintNode node, T data) {
+    return visit((DelphiNode) node, data);
+  }
+
+  default T visit(ClassConstraintNode node, T data) {
+    return visit((ConstraintNode) node, data);
+  }
+
+  default T visit(ConstructorConstraintNode node, T data) {
+    return visit((ConstraintNode) node, data);
+  }
+
+  default T visit(RecordConstraintNode node, T data) {
+    return visit((ConstraintNode) node, data);
+  }
+
+  default T visit(TypeConstraintNode node, T data) {
+    return visit((ConstraintNode) node, data);
   }
 }

--- a/delphi-frontend/src/main/java/au/com/integradev/delphi/antlr/ast/visitors/SymbolTableVisitor.java
+++ b/delphi-frontend/src/main/java/au/com/integradev/delphi/antlr/ast/visitors/SymbolTableVisitor.java
@@ -24,6 +24,7 @@ import au.com.integradev.delphi.antlr.ast.DelphiAstImpl;
 import au.com.integradev.delphi.antlr.ast.node.MutableDelphiNode;
 import au.com.integradev.delphi.antlr.ast.node.NameDeclarationNodeImpl;
 import au.com.integradev.delphi.antlr.ast.node.RoutineNameNodeImpl;
+import au.com.integradev.delphi.antlr.ast.node.TypeConstraintNodeImpl;
 import au.com.integradev.delphi.antlr.ast.node.WithStatementNodeImpl;
 import au.com.integradev.delphi.antlr.ast.visitors.SymbolTableVisitor.Data;
 import au.com.integradev.delphi.preprocessor.CompilerSwitchRegistry;
@@ -392,7 +393,11 @@ public abstract class SymbolTableVisitor implements DelphiParserVisitor<Data> {
       @Nullable GenericDefinitionNode definition, Data data) {
     if (definition != null) {
       for (TypeParameterNode parameterNode : definition.getTypeParameterNodes()) {
-        parameterNode.getTypeConstraintNodes().forEach(data.nameResolutionHelper::resolve);
+        parameterNode.getConstraintNodes().stream()
+            .filter(TypeConstraintNodeImpl.class::isInstance)
+            .map(TypeConstraintNodeImpl.class::cast)
+            .map(TypeConstraintNodeImpl::getTypeNode)
+            .forEach(data.nameResolutionHelper::resolve);
       }
 
       for (TypeParameter typeParameter : definition.getTypeParameters()) {

--- a/delphi-frontend/src/main/java/au/com/integradev/delphi/symbol/resolve/NameResolver.java
+++ b/delphi-frontend/src/main/java/au/com/integradev/delphi/symbol/resolve/NameResolver.java
@@ -656,7 +656,7 @@ public class NameResolver {
   private boolean isExplicitArrayConstructorInvocation(NameReferenceNode reference) {
     return Iterables.getLast(resolvedDeclarations, null) instanceof TypeNameDeclaration
         && isDynamicArrayReference(currentType)
-        && reference.getLastName().getImage().equalsIgnoreCase("Create");
+        && reference.getIdentifier().getImage().equalsIgnoreCase("Create");
   }
 
   private static boolean isDynamicArrayReference(Type type) {
@@ -890,7 +890,7 @@ public class NameResolver {
   private boolean handleExplicitArrayConstructorInvocation(ArgumentListNode node) {
     Node previous = node.getParent().getChild(node.getChildIndex() - 1);
     if (previous instanceof NameReferenceNode
-        && isExplicitArrayConstructorInvocation(((NameReferenceNode) previous))) {
+        && isExplicitArrayConstructorInvocation(((NameReferenceNode) previous).getLastName())) {
       updateType(((ClassReferenceType) currentType).classType());
       node.getArgumentNodes().stream()
           .map(ArgumentNode::getExpression)

--- a/delphi-frontend/src/main/java/au/com/integradev/delphi/symbol/resolve/NameResolver.java
+++ b/delphi-frontend/src/main/java/au/com/integradev/delphi/symbol/resolve/NameResolver.java
@@ -644,7 +644,6 @@ public class NameResolver {
   private void specializeDeclarations(NameOccurrence occurrence) {
     declarations =
         declarations.stream()
-            .map(NameDeclaration.class::cast)
             .map(
                 declaration -> {
                   List<Type> typeArguments = occurrence.getTypeArguments();

--- a/delphi-frontend/src/main/java/au/com/integradev/delphi/type/generic/TypeSpecializationContextImpl.java
+++ b/delphi-frontend/src/main/java/au/com/integradev/delphi/type/generic/TypeSpecializationContextImpl.java
@@ -29,6 +29,7 @@ import org.sonar.plugins.communitydelphi.api.symbol.declaration.GenerifiableDecl
 import org.sonar.plugins.communitydelphi.api.symbol.declaration.NameDeclaration;
 import org.sonar.plugins.communitydelphi.api.symbol.declaration.TypedDeclaration;
 import org.sonar.plugins.communitydelphi.api.type.Type;
+import org.sonar.plugins.communitydelphi.api.type.Type.TypeParameterType;
 import org.sonar.plugins.communitydelphi.api.type.TypeSpecializationContext;
 
 public final class TypeSpecializationContextImpl implements TypeSpecializationContext {
@@ -55,8 +56,22 @@ public final class TypeSpecializationContextImpl implements TypeSpecializationCo
     for (int i = 0; i < typeParameters.size(); ++i) {
       Type parameter = typeParameters.get(i);
       Type argument = typeArguments.get(i);
+
+      if (constraintViolated(parameter, argument)) {
+        argumentsByParameter.clear();
+        break;
+      }
+
       argumentsByParameter.put(parameter, argument);
     }
+  }
+
+  private static boolean constraintViolated(Type parameter, Type argument) {
+    return parameter.isTypeParameter()
+        && ((TypeParameterType) parameter)
+            .constraintItems().stream()
+                .map(constraint -> constraint.satisfiedBy(argument))
+                .anyMatch(s -> !s);
   }
 
   @Override

--- a/delphi-frontend/src/main/java/au/com/integradev/delphi/type/generic/constraint/ClassConstraintImpl.java
+++ b/delphi-frontend/src/main/java/au/com/integradev/delphi/type/generic/constraint/ClassConstraintImpl.java
@@ -1,0 +1,59 @@
+/*
+ * Sonar Delphi Plugin
+ * Copyright (C) 2025 Integrated Application Development
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02
+ */
+package au.com.integradev.delphi.type.generic.constraint;
+
+import org.sonar.plugins.communitydelphi.api.type.Constraint.ClassConstraint;
+import org.sonar.plugins.communitydelphi.api.type.Type;
+import org.sonar.plugins.communitydelphi.api.type.Type.PointerType;
+
+public class ClassConstraintImpl extends ConstraintImpl implements ClassConstraint {
+  private static final ClassConstraintImpl INSTANCE = new ClassConstraintImpl();
+
+  private ClassConstraintImpl() {
+    // Hide constructor
+  }
+
+  @Override
+  protected ConstraintCheckResult check(Type type) {
+    if (type.isClass() || (type.isPointer() && ((PointerType) type).isNilPointer())) {
+      return ConstraintCheckResult.SATISFIED;
+    } else {
+      return ConstraintCheckResult.VIOLATED;
+    }
+  }
+
+  @Override
+  protected ConstraintCheckResult check(ClassConstraint constraint) {
+    return ConstraintCheckResult.SATISFIED;
+  }
+
+  @Override
+  protected ConstraintCheckResult check(ConstructorConstraint constraint) {
+    return ConstraintCheckResult.COMPATIBLE;
+  }
+
+  @Override
+  protected ConstraintCheckResult check(RecordConstraint constraint) {
+    return ConstraintCheckResult.VIOLATED;
+  }
+
+  public static ClassConstraintImpl instance() {
+    return INSTANCE;
+  }
+}

--- a/delphi-frontend/src/main/java/au/com/integradev/delphi/type/generic/constraint/ConstraintImpl.java
+++ b/delphi-frontend/src/main/java/au/com/integradev/delphi/type/generic/constraint/ConstraintImpl.java
@@ -1,0 +1,83 @@
+/*
+ * Sonar Delphi Plugin
+ * Copyright (C) 2025 Integrated Application Development
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02
+ */
+package au.com.integradev.delphi.type.generic.constraint;
+
+import org.sonar.plugins.communitydelphi.api.type.Constraint;
+import org.sonar.plugins.communitydelphi.api.type.Type;
+import org.sonar.plugins.communitydelphi.api.type.Type.TypeParameterType;
+
+abstract class ConstraintImpl implements Constraint {
+  protected enum ConstraintCheckResult {
+    VIOLATED,
+    COMPATIBLE,
+    SATISFIED
+  }
+
+  @Override
+  public final boolean satisfiedBy(Type type) {
+    if (type instanceof TypeParameterType) {
+      ConstraintCheckResult result = ConstraintCheckResult.COMPATIBLE;
+      for (Constraint constraint : ((TypeParameterType) type).constraintItems()) {
+        switch (check(constraint)) {
+          case VIOLATED:
+            return false;
+          case COMPATIBLE:
+            break;
+          case SATISFIED:
+            result = ConstraintCheckResult.SATISFIED;
+            break;
+        }
+      }
+      return result == ConstraintCheckResult.SATISFIED;
+    } else {
+      return check(type) == ConstraintCheckResult.SATISFIED;
+    }
+  }
+
+  private ConstraintCheckResult check(Constraint constraint) {
+    if (constraint instanceof TypeConstraint) {
+      return check(((TypeConstraint) constraint).type());
+    }
+
+    if (constraint instanceof ClassConstraint) {
+      return check((ClassConstraint) constraint);
+    }
+
+    if (constraint instanceof ConstructorConstraint) {
+      return check((ConstructorConstraint) constraint);
+    }
+
+    if (constraint instanceof RecordConstraint) {
+      return check((RecordConstraint) constraint);
+    }
+
+    return ConstraintCheckResult.VIOLATED;
+  }
+
+  protected abstract ConstraintCheckResult check(Type type);
+
+  @SuppressWarnings("overloads")
+  protected abstract ConstraintCheckResult check(ClassConstraint constraint);
+
+  @SuppressWarnings("overloads")
+  protected abstract ConstraintCheckResult check(ConstructorConstraint constraint);
+
+  @SuppressWarnings("overloads")
+  protected abstract ConstraintCheckResult check(RecordConstraint constraint);
+}

--- a/delphi-frontend/src/main/java/au/com/integradev/delphi/type/generic/constraint/ConstructorConstraintImpl.java
+++ b/delphi-frontend/src/main/java/au/com/integradev/delphi/type/generic/constraint/ConstructorConstraintImpl.java
@@ -1,0 +1,91 @@
+/*
+ * Sonar Delphi Plugin
+ * Copyright (C) 2025 Integrated Application Development
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02
+ */
+package au.com.integradev.delphi.type.generic.constraint;
+
+import org.sonar.plugins.communitydelphi.api.ast.Visibility.VisibilityType;
+import org.sonar.plugins.communitydelphi.api.symbol.declaration.RoutineKind;
+import org.sonar.plugins.communitydelphi.api.symbol.declaration.RoutineNameDeclaration;
+import org.sonar.plugins.communitydelphi.api.type.Constraint.ConstructorConstraint;
+import org.sonar.plugins.communitydelphi.api.type.Type;
+import org.sonar.plugins.communitydelphi.api.type.Type.PointerType;
+import org.sonar.plugins.communitydelphi.api.type.Type.ScopedType;
+
+public class ConstructorConstraintImpl extends ConstraintImpl implements ConstructorConstraint {
+  private static final ConstructorConstraintImpl INSTANCE = new ConstructorConstraintImpl();
+
+  private ConstructorConstraintImpl() {
+    // Hide constructor
+  }
+
+  @Override
+  protected ConstraintCheckResult check(Type type) {
+    if (type.isDynamicArray()
+        || type.isFixedArray()
+        || (type.isPointer() && ((PointerType) type).isNilPointer())
+        || declaresPublicDefaultConstructor(type)) {
+      return ConstraintCheckResult.SATISFIED;
+    } else {
+      return ConstraintCheckResult.VIOLATED;
+    }
+  }
+
+  @Override
+  protected ConstraintCheckResult check(ClassConstraint constraint) {
+    return ConstraintCheckResult.COMPATIBLE;
+  }
+
+  @Override
+  protected ConstraintCheckResult check(ConstructorConstraint constraint) {
+    return ConstraintCheckResult.SATISFIED;
+  }
+
+  @Override
+  protected ConstraintCheckResult check(RecordConstraint constraint) {
+    return ConstraintCheckResult.VIOLATED;
+  }
+
+  private static boolean declaresPublicDefaultConstructor(Type type) {
+    while (type.isClass()) {
+      VisibilityType constructorVisibility =
+          ((ScopedType) type)
+              .typeScope().getRoutineDeclarations().stream()
+                  .filter(ConstructorConstraintImpl::isDefaultConstructor)
+                  .map(RoutineNameDeclaration::getVisibility)
+                  .findFirst()
+                  .orElse(null);
+
+      if (constructorVisibility != null) {
+        return constructorVisibility == VisibilityType.PUBLIC;
+      }
+
+      type = type.parent();
+    }
+    return false;
+  }
+
+  private static boolean isDefaultConstructor(RoutineNameDeclaration routine) {
+    return routine.getRoutineKind() == RoutineKind.CONSTRUCTOR
+        && routine.getParametersCount() == 0
+        && routine.getName().equalsIgnoreCase("Create");
+  }
+
+  public static ConstructorConstraintImpl instance() {
+    return INSTANCE;
+  }
+}

--- a/delphi-frontend/src/main/java/au/com/integradev/delphi/type/generic/constraint/RecordConstraintImpl.java
+++ b/delphi-frontend/src/main/java/au/com/integradev/delphi/type/generic/constraint/RecordConstraintImpl.java
@@ -1,0 +1,64 @@
+/*
+ * Sonar Delphi Plugin
+ * Copyright (C) 2025 Integrated Application Development
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02
+ */
+package au.com.integradev.delphi.type.generic.constraint;
+
+import org.sonar.plugins.communitydelphi.api.type.Constraint.RecordConstraint;
+import org.sonar.plugins.communitydelphi.api.type.Type;
+
+public class RecordConstraintImpl extends ConstraintImpl implements RecordConstraint {
+  private static final RecordConstraintImpl INSTANCE = new RecordConstraintImpl();
+
+  private RecordConstraintImpl() {
+    // Hide constructor
+  }
+
+  @Override
+  protected ConstraintCheckResult check(Type type) {
+    if (type.isRecord()
+        || type.isBoolean()
+        || type.isReal()
+        || type.isInteger()
+        || type.isEnum()
+        || type.isSubrange()
+        || type.isChar()) {
+      return ConstraintCheckResult.SATISFIED;
+    } else {
+      return ConstraintCheckResult.VIOLATED;
+    }
+  }
+
+  @Override
+  protected ConstraintCheckResult check(ClassConstraint constraint) {
+    return ConstraintCheckResult.VIOLATED;
+  }
+
+  @Override
+  protected ConstraintCheckResult check(ConstructorConstraint constraint) {
+    return ConstraintCheckResult.VIOLATED;
+  }
+
+  @Override
+  protected ConstraintCheckResult check(RecordConstraint constraint) {
+    return ConstraintCheckResult.SATISFIED;
+  }
+
+  public static RecordConstraintImpl instance() {
+    return INSTANCE;
+  }
+}

--- a/delphi-frontend/src/main/java/au/com/integradev/delphi/type/generic/constraint/TypeConstraintImpl.java
+++ b/delphi-frontend/src/main/java/au/com/integradev/delphi/type/generic/constraint/TypeConstraintImpl.java
@@ -1,0 +1,66 @@
+/*
+ * Sonar Delphi Plugin
+ * Copyright (C) 2025 Integrated Application Development
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02
+ */
+package au.com.integradev.delphi.type.generic.constraint;
+
+import org.sonar.plugins.communitydelphi.api.type.Constraint.TypeConstraint;
+import org.sonar.plugins.communitydelphi.api.type.Type;
+import org.sonar.plugins.communitydelphi.api.type.Type.ClassReferenceType;
+
+public class TypeConstraintImpl extends ConstraintImpl implements TypeConstraint {
+  private final Type type;
+
+  public TypeConstraintImpl(Type type) {
+    this.type = type;
+  }
+
+  @Override
+  public Type type() {
+    return type;
+  }
+
+  @Override
+  protected ConstraintCheckResult check(Type type) {
+    if (type.isClassReference()) {
+      // This is a compiler bug.
+      // See: https://embt.atlassian.net/servicedesk/customer/portal/1/RSS-3319
+      type = ((ClassReferenceType) type).classType();
+    }
+
+    if (type.is(this.type) || type.isDescendantOf(this.type)) {
+      return ConstraintCheckResult.SATISFIED;
+    } else {
+      return ConstraintCheckResult.VIOLATED;
+    }
+  }
+
+  @Override
+  protected ConstraintCheckResult check(ClassConstraint constraint) {
+    return ConstraintCheckResult.COMPATIBLE;
+  }
+
+  @Override
+  protected ConstraintCheckResult check(ConstructorConstraint constraint) {
+    return ConstraintCheckResult.COMPATIBLE;
+  }
+
+  @Override
+  protected ConstraintCheckResult check(RecordConstraint constraint) {
+    return ConstraintCheckResult.VIOLATED;
+  }
+}

--- a/delphi-frontend/src/main/java/org/sonar/plugins/communitydelphi/api/ast/ClassConstraintNode.java
+++ b/delphi-frontend/src/main/java/org/sonar/plugins/communitydelphi/api/ast/ClassConstraintNode.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Delphi Plugin
- * Copyright (C) 2023 Integrated Application Development
+ * Copyright (C) 2025 Integrated Application Development
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -18,16 +18,4 @@
  */
 package org.sonar.plugins.communitydelphi.api.ast;
 
-import java.util.List;
-
-public interface TypeParameterNode extends DelphiNode {
-  List<NameDeclarationNode> getTypeParameterNameNodes();
-
-  /**
-   * @deprecated Use {@link TypeParameterNode#getConstraintNodes} instead.
-   */
-  @Deprecated(forRemoval = true)
-  List<TypeReferenceNode> getTypeConstraintNodes();
-
-  List<ConstraintNode> getConstraintNodes();
-}
+public interface ClassConstraintNode extends ConstraintNode {}

--- a/delphi-frontend/src/main/java/org/sonar/plugins/communitydelphi/api/ast/ConstraintNode.java
+++ b/delphi-frontend/src/main/java/org/sonar/plugins/communitydelphi/api/ast/ConstraintNode.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Delphi Plugin
- * Copyright (C) 2023 Integrated Application Development
+ * Copyright (C) 2025 Integrated Application Development
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -18,16 +18,8 @@
  */
 package org.sonar.plugins.communitydelphi.api.ast;
 
-import java.util.List;
+import org.sonar.plugins.communitydelphi.api.type.Constraint;
 
-public interface TypeParameterNode extends DelphiNode {
-  List<NameDeclarationNode> getTypeParameterNameNodes();
-
-  /**
-   * @deprecated Use {@link TypeParameterNode#getConstraintNodes} instead.
-   */
-  @Deprecated(forRemoval = true)
-  List<TypeReferenceNode> getTypeConstraintNodes();
-
-  List<ConstraintNode> getConstraintNodes();
+public interface ConstraintNode extends DelphiNode {
+  Constraint getConstraint();
 }

--- a/delphi-frontend/src/main/java/org/sonar/plugins/communitydelphi/api/ast/ConstructorConstraintNode.java
+++ b/delphi-frontend/src/main/java/org/sonar/plugins/communitydelphi/api/ast/ConstructorConstraintNode.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Delphi Plugin
- * Copyright (C) 2023 Integrated Application Development
+ * Copyright (C) 2025 Integrated Application Development
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -18,16 +18,4 @@
  */
 package org.sonar.plugins.communitydelphi.api.ast;
 
-import java.util.List;
-
-public interface TypeParameterNode extends DelphiNode {
-  List<NameDeclarationNode> getTypeParameterNameNodes();
-
-  /**
-   * @deprecated Use {@link TypeParameterNode#getConstraintNodes} instead.
-   */
-  @Deprecated(forRemoval = true)
-  List<TypeReferenceNode> getTypeConstraintNodes();
-
-  List<ConstraintNode> getConstraintNodes();
-}
+public interface ConstructorConstraintNode extends ConstraintNode {}

--- a/delphi-frontend/src/main/java/org/sonar/plugins/communitydelphi/api/ast/NameReferenceNode.java
+++ b/delphi-frontend/src/main/java/org/sonar/plugins/communitydelphi/api/ast/NameReferenceNode.java
@@ -39,6 +39,8 @@ public interface NameReferenceNode extends DelphiNode, Qualifiable, Typed {
 
   NameDeclaration getNameDeclaration();
 
+  NameReferenceNode getFirstName();
+
   NameReferenceNode getLastName();
 
   boolean isExplicitArrayConstructorInvocation();

--- a/delphi-frontend/src/main/java/org/sonar/plugins/communitydelphi/api/ast/RecordConstraintNode.java
+++ b/delphi-frontend/src/main/java/org/sonar/plugins/communitydelphi/api/ast/RecordConstraintNode.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Delphi Plugin
- * Copyright (C) 2023 Integrated Application Development
+ * Copyright (C) 2025 Integrated Application Development
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -18,16 +18,4 @@
  */
 package org.sonar.plugins.communitydelphi.api.ast;
 
-import java.util.List;
-
-public interface TypeParameterNode extends DelphiNode {
-  List<NameDeclarationNode> getTypeParameterNameNodes();
-
-  /**
-   * @deprecated Use {@link TypeParameterNode#getConstraintNodes} instead.
-   */
-  @Deprecated(forRemoval = true)
-  List<TypeReferenceNode> getTypeConstraintNodes();
-
-  List<ConstraintNode> getConstraintNodes();
-}
+public interface RecordConstraintNode extends ConstraintNode {}

--- a/delphi-frontend/src/main/java/org/sonar/plugins/communitydelphi/api/ast/TypeConstraintNode.java
+++ b/delphi-frontend/src/main/java/org/sonar/plugins/communitydelphi/api/ast/TypeConstraintNode.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Delphi Plugin
- * Copyright (C) 2023 Integrated Application Development
+ * Copyright (C) 2025 Integrated Application Development
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -18,16 +18,6 @@
  */
 package org.sonar.plugins.communitydelphi.api.ast;
 
-import java.util.List;
-
-public interface TypeParameterNode extends DelphiNode {
-  List<NameDeclarationNode> getTypeParameterNameNodes();
-
-  /**
-   * @deprecated Use {@link TypeParameterNode#getConstraintNodes} instead.
-   */
-  @Deprecated(forRemoval = true)
-  List<TypeReferenceNode> getTypeConstraintNodes();
-
-  List<ConstraintNode> getConstraintNodes();
+public interface TypeConstraintNode extends ConstraintNode {
+  TypeReferenceNode getTypeNode();
 }

--- a/delphi-frontend/src/main/java/org/sonar/plugins/communitydelphi/api/type/Constraint.java
+++ b/delphi-frontend/src/main/java/org/sonar/plugins/communitydelphi/api/type/Constraint.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Delphi Plugin
- * Copyright (C) 2023 Integrated Application Development
+ * Copyright (C) 2025 Integrated Application Development
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -16,18 +16,18 @@
  * License along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02
  */
-package org.sonar.plugins.communitydelphi.api.ast;
+package org.sonar.plugins.communitydelphi.api.type;
 
-import java.util.List;
+public interface Constraint {
+  boolean satisfiedBy(Type type);
 
-public interface TypeParameterNode extends DelphiNode {
-  List<NameDeclarationNode> getTypeParameterNameNodes();
+  interface ClassConstraint extends Constraint {}
 
-  /**
-   * @deprecated Use {@link TypeParameterNode#getConstraintNodes} instead.
-   */
-  @Deprecated(forRemoval = true)
-  List<TypeReferenceNode> getTypeConstraintNodes();
+  interface ConstructorConstraint extends Constraint {}
 
-  List<ConstraintNode> getConstraintNodes();
+  interface RecordConstraint extends Constraint {}
+
+  interface TypeConstraint extends Constraint {
+    Type type();
+  }
 }

--- a/delphi-frontend/src/main/java/org/sonar/plugins/communitydelphi/api/type/Type.java
+++ b/delphi-frontend/src/main/java/org/sonar/plugins/communitydelphi/api/type/Type.java
@@ -564,18 +564,26 @@ public interface Type {
   }
 
   interface TypeParameterType extends Type {
-
     /**
-     * The set of constraint types for this type parameter.
-     *
-     * <p>For example, if we're constrained by a class type, then a generic specialization will
-     * require the type argument to be assignment-compatible with that class type.
+     * The constraint types for this type parameter.
      *
      * @return list of constraint types
-     * @see <a href="http://docwiki.embarcadero.com/RADStudio/Rio/en/Constraints_in_Generics">
+     * @deprecated Use {@link TypeParameterType#constraintItems} instead.
+     */
+    @Deprecated(forRemoval = true)
+    List<Type> constraints();
+
+    /**
+     * The constraints for this type parameter.
+     *
+     * <p>For example, if we're constrained by TFoo, then generic specialization will require the
+     * type argument to be assignment-compatible with TFoo.
+     *
+     * @return list of constraints
+     * @see <a href="http://docwiki.embarcadero.com/RADStudio/en/Constraints_in_Generics">
      *     Constraints in Generics</a>
      */
-    List<Type> constraints();
+    List<Constraint> constraintItems();
   }
 
   interface IntegerType extends Type {

--- a/delphi-frontend/src/test/java/au/com/integradev/delphi/executor/DelphiSymbolTableExecutorTest.java
+++ b/delphi-frontend/src/test/java/au/com/integradev/delphi/executor/DelphiSymbolTableExecutorTest.java
@@ -1085,13 +1085,19 @@ class DelphiSymbolTableExecutorTest {
   }
 
   @Test
-  void testGenericTypeParameterConflicts() {
+  void testGenericTypeParameterNameConflict() {
     execute("generics/TypeParameterNameConflict.pas");
     verifyUsages(7, 14, reference(25, 8));
     verifyUsages(11, 14, reference(26, 6), reference(27, 9));
     verifyUsages(14, 11, reference(15, 11), reference(21, 19));
     verifyUsages(
         16, 19, reference(16, 33), reference(21, 27), reference(21, 35), reference(23, 10));
+  }
+
+  @Test
+  void testGenericTypeParameterConstructor() {
+    execute("generics/TypeParameterConstructor.pas");
+    verifyUsages(10, 19, reference(17, 20), reference(24, 21), reference(25, 23));
   }
 
   @Test

--- a/delphi-frontend/src/test/java/au/com/integradev/delphi/executor/DelphiSymbolTableExecutorTest.java
+++ b/delphi-frontend/src/test/java/au/com/integradev/delphi/executor/DelphiSymbolTableExecutorTest.java
@@ -1053,7 +1053,8 @@ class DelphiSymbolTableExecutorTest {
   @Test
   void testGenericImplicitSpecializations() {
     execute("generics/ImplicitSpecialization.pas");
-    verifyUsages(14, 14, reference(19, 20), reference(26, 2), reference(27, 2), reference(28, 2));
+    verifyUsages(15, 14, reference(21, 20), reference(37, 2), reference(38, 2), reference(39, 2));
+    verifyUsages(16, 14, reference(26, 20), reference(48, 2), reference(49, 2), reference(50, 2));
   }
 
   @Test

--- a/delphi-frontend/src/test/java/au/com/integradev/delphi/type/factory/TypeAliasGeneratorTest.java
+++ b/delphi-frontend/src/test/java/au/com/integradev/delphi/type/factory/TypeAliasGeneratorTest.java
@@ -25,6 +25,7 @@ import static org.mockito.Mockito.when;
 
 import au.com.integradev.delphi.type.UnresolvedTypeImpl;
 import au.com.integradev.delphi.type.generic.TypeParameterTypeImpl;
+import au.com.integradev.delphi.type.generic.constraint.TypeConstraintImpl;
 import au.com.integradev.delphi.utils.types.TypeFactoryUtils;
 import au.com.integradev.delphi.utils.types.TypeMocker;
 import java.util.Collections;
@@ -127,7 +128,8 @@ class TypeAliasGeneratorTest {
           Arguments.of(FACTORY.subrange(ALIASED_NAME, BYTE), SubrangeType.class),
           Arguments.of(FACTORY.classOf(ALIASED_NAME, BYTE), ClassReferenceType.class),
           Arguments.of(
-              TypeParameterTypeImpl.create(ALIASED_NAME, List.of(BYTE)), TypeParameterType.class),
+              TypeParameterTypeImpl.create(ALIASED_NAME, List.of(new TypeConstraintImpl(BYTE))),
+              TypeParameterType.class),
           Arguments.of(BYTE, IntegerType.class),
           Arguments.of(FACTORY.getIntrinsic(IntrinsicType.DOUBLE), RealType.class),
           Arguments.of(FACTORY.getIntrinsic(IntrinsicType.BOOLEAN), BooleanType.class),
@@ -214,6 +216,7 @@ class TypeAliasGeneratorTest {
         .isInstanceOf(AssertionError.class);
   }
 
+  @SuppressWarnings("removal")
   private static void assertAliasImplementsTypeThroughDelegation(Type alias, Type aliased) {
     assertDelegated(Type::parent, alias, aliased);
     assertDelegated(Type::ancestorList, alias, aliased);
@@ -300,6 +303,7 @@ class TypeAliasGeneratorTest {
 
     if (aliased instanceof TypeParameterType) {
       assertDelegated(TypeParameterType::constraints, alias, aliased);
+      assertDelegated(TypeParameterType::constraintItems, alias, aliased);
     }
 
     if (aliased instanceof IntegerType) {

--- a/delphi-frontend/src/test/java/au/com/integradev/delphi/type/generic/constraint/ClassConstraintTest.java
+++ b/delphi-frontend/src/test/java/au/com/integradev/delphi/type/generic/constraint/ClassConstraintTest.java
@@ -1,0 +1,101 @@
+/*
+ * Sonar Delphi Plugin
+ * Copyright (C) 2025 Integrated Application Development
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02
+ */
+package au.com.integradev.delphi.type.generic.constraint;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.sonar.plugins.communitydelphi.api.type.StructKind.CLASS;
+import static org.sonar.plugins.communitydelphi.api.type.StructKind.RECORD;
+
+import au.com.integradev.delphi.type.generic.TypeParameterTypeImpl;
+import au.com.integradev.delphi.utils.types.TypeFactoryUtils;
+import au.com.integradev.delphi.utils.types.TypeMocker;
+import java.util.List;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.ArgumentsProvider;
+import org.junit.jupiter.params.provider.ArgumentsSource;
+import org.sonar.plugins.communitydelphi.api.type.Constraint;
+import org.sonar.plugins.communitydelphi.api.type.IntrinsicType;
+import org.sonar.plugins.communitydelphi.api.type.Type;
+import org.sonar.plugins.communitydelphi.api.type.TypeFactory;
+
+class ClassConstraintTest {
+  private static final TypeFactory FACTORY = TypeFactoryUtils.defaultFactory();
+
+  private static class SatisfiedArgumentsProvider implements ArgumentsProvider {
+    @Override
+    public Stream<Arguments> provideArguments(ExtensionContext context) {
+      return Stream.of(
+          Arguments.of(TypeMocker.struct("TBar", CLASS)),
+          Arguments.of(TypeParameterTypeImpl.create("T", List.of(ClassConstraintImpl.instance()))),
+          Arguments.of(
+              TypeParameterTypeImpl.create(
+                  "T",
+                  List.of(ClassConstraintImpl.instance(), ConstructorConstraintImpl.instance()))),
+          Arguments.of(
+              TypeParameterTypeImpl.create(
+                  "T",
+                  List.of(
+                      new TypeConstraintImpl(TypeMocker.struct("TBar", CLASS)),
+                      ClassConstraintImpl.instance(),
+                      ConstructorConstraintImpl.instance()))));
+    }
+  }
+
+  private static class ViolatedArgumentsProvider implements ArgumentsProvider {
+    @Override
+    public Stream<Arguments> provideArguments(ExtensionContext context) {
+      return Stream.of(
+          Arguments.of(FACTORY.getIntrinsic(IntrinsicType.BYTE)),
+          Arguments.of(FACTORY.getIntrinsic(IntrinsicType.STRING)),
+          Arguments.of(TypeMocker.struct("TFoo", RECORD)),
+          Arguments.of(TypeParameterTypeImpl.create("T")),
+          Arguments.of(TypeParameterTypeImpl.create("T", List.of(mock(Constraint.class)))),
+          Arguments.of(TypeParameterTypeImpl.create("T", List.of(RecordConstraintImpl.instance()))),
+          Arguments.of(
+              TypeParameterTypeImpl.create("T", List.of(ConstructorConstraintImpl.instance()))),
+          Arguments.of(
+              TypeParameterTypeImpl.create(
+                  "T",
+                  List.of(RecordConstraintImpl.instance(), ConstructorConstraintImpl.instance()))),
+          Arguments.of(
+              TypeParameterTypeImpl.create(
+                  "T",
+                  List.of(
+                      RecordConstraintImpl.instance(),
+                      ConstructorConstraintImpl.instance(),
+                      ClassConstraintImpl.instance()))));
+    }
+  }
+
+  @ParameterizedTest
+  @ArgumentsSource(SatisfiedArgumentsProvider.class)
+  void testSatisfied(Type argumentType) {
+    assertThat(ClassConstraintImpl.instance().satisfiedBy(argumentType)).isTrue();
+  }
+
+  @ParameterizedTest
+  @ArgumentsSource(ViolatedArgumentsProvider.class)
+  void testViolated(Type argumentType) {
+    assertThat(ClassConstraintImpl.instance().satisfiedBy(argumentType)).isFalse();
+  }
+}

--- a/delphi-frontend/src/test/java/au/com/integradev/delphi/type/generic/constraint/ConstructorConstraintTest.java
+++ b/delphi-frontend/src/test/java/au/com/integradev/delphi/type/generic/constraint/ConstructorConstraintTest.java
@@ -1,0 +1,177 @@
+/*
+ * Sonar Delphi Plugin
+ * Copyright (C) 2025 Integrated Application Development
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02
+ */
+package au.com.integradev.delphi.type.generic.constraint;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.sonar.plugins.communitydelphi.api.type.StructKind.CLASS;
+import static org.sonar.plugins.communitydelphi.api.type.StructKind.RECORD;
+
+import au.com.integradev.delphi.symbol.SymbolicNode;
+import au.com.integradev.delphi.symbol.declaration.RoutineNameDeclarationImpl;
+import au.com.integradev.delphi.symbol.scope.DelphiScopeImpl;
+import au.com.integradev.delphi.type.factory.TypeFactoryImpl;
+import au.com.integradev.delphi.type.factory.VoidTypeImpl;
+import au.com.integradev.delphi.type.generic.TypeParameterTypeImpl;
+import au.com.integradev.delphi.utils.types.TypeFactoryUtils;
+import au.com.integradev.delphi.utils.types.TypeMocker;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.ArgumentsProvider;
+import org.junit.jupiter.params.provider.ArgumentsSource;
+import org.sonar.plugins.communitydelphi.api.ast.Visibility.VisibilityType;
+import org.sonar.plugins.communitydelphi.api.symbol.declaration.NameDeclaration;
+import org.sonar.plugins.communitydelphi.api.symbol.declaration.RoutineKind;
+import org.sonar.plugins.communitydelphi.api.symbol.declaration.RoutineNameDeclaration;
+import org.sonar.plugins.communitydelphi.api.symbol.scope.DelphiScope;
+import org.sonar.plugins.communitydelphi.api.type.Constraint;
+import org.sonar.plugins.communitydelphi.api.type.IntrinsicType;
+import org.sonar.plugins.communitydelphi.api.type.Parameter;
+import org.sonar.plugins.communitydelphi.api.type.Type;
+import org.sonar.plugins.communitydelphi.api.type.Type.ProceduralType.ProceduralKind;
+import org.sonar.plugins.communitydelphi.api.type.Type.StructType;
+import org.sonar.plugins.communitydelphi.api.type.TypeFactory;
+
+class ConstructorConstraintTest {
+  private static final TypeFactory FACTORY = TypeFactoryUtils.defaultFactory();
+
+  private static class SatisfiedArgumentsProvider implements ArgumentsProvider {
+    @Override
+    public Stream<Arguments> provideArguments(ExtensionContext context) {
+      var defaultConstructor = constructor("Create", VisibilityType.PUBLIC);
+      var lowercaseDefaultConstructor = constructor("create", VisibilityType.PUBLIC);
+      return Stream.of(
+          Arguments.of(addDeclaration(mockClass(), defaultConstructor)),
+          Arguments.of(addDeclaration(mockClass(), lowercaseDefaultConstructor)),
+          Arguments.of(mockClass(addDeclaration(mockClass(), defaultConstructor))),
+          Arguments.of(
+              TypeParameterTypeImpl.create("T", List.of(ConstructorConstraintImpl.instance()))),
+          Arguments.of(
+              TypeParameterTypeImpl.create(
+                  "T",
+                  List.of(ClassConstraintImpl.instance(), ConstructorConstraintImpl.instance()))),
+          Arguments.of(
+              TypeParameterTypeImpl.create(
+                  "T",
+                  List.of(
+                      new TypeConstraintImpl(addDeclaration(mockClass(), defaultConstructor)),
+                      ClassConstraintImpl.instance(),
+                      ConstructorConstraintImpl.instance()))));
+    }
+  }
+
+  private static class ViolatedArgumentsProvider implements ArgumentsProvider {
+    @Override
+    public Stream<Arguments> provideArguments(ExtensionContext context) {
+      var defaultConstructor = constructor("Create", VisibilityType.PUBLIC);
+      var classWithDefaultConstructor = addDeclaration(mockClass(), defaultConstructor);
+
+      var privateConstructor = constructor("Create", VisibilityType.PRIVATE);
+      var protectedConstructor = constructor("Create", VisibilityType.PROTECTED);
+      var publishedConstructor = constructor("Create", VisibilityType.PUBLISHED);
+      var wrongNameConstructor = constructor("NotCreate", VisibilityType.PUBLIC);
+      var parametersConstructor = constructor("Create", VisibilityType.PUBLIC, true);
+
+      return Stream.of(
+          Arguments.of(FACTORY.getIntrinsic(IntrinsicType.BYTE)),
+          Arguments.of(FACTORY.getIntrinsic(IntrinsicType.STRING)),
+          Arguments.of(TypeMocker.struct("TFoo", RECORD)),
+          Arguments.of(mockClass()),
+          Arguments.of(addDeclaration(mockClass(), privateConstructor)),
+          Arguments.of(addDeclaration(mockClass(), protectedConstructor)),
+          Arguments.of(addDeclaration(mockClass(), publishedConstructor)),
+          Arguments.of(addDeclaration(mockClass(), wrongNameConstructor)),
+          Arguments.of(addDeclaration(mockClass(), parametersConstructor)),
+          Arguments.of(addDeclaration(mockClass(), parametersConstructor)),
+          Arguments.of(addDeclaration(mockClass(classWithDefaultConstructor), privateConstructor)),
+          Arguments.of(TypeParameterTypeImpl.create("T")),
+          Arguments.of(TypeParameterTypeImpl.create("T", List.of(mock(Constraint.class)))),
+          Arguments.of(TypeParameterTypeImpl.create("T", List.of(RecordConstraintImpl.instance()))),
+          Arguments.of(TypeParameterTypeImpl.create("T", List.of(ClassConstraintImpl.instance()))),
+          Arguments.of(
+              TypeParameterTypeImpl.create(
+                  "T",
+                  List.of(RecordConstraintImpl.instance(), ConstructorConstraintImpl.instance()))),
+          Arguments.of(
+              TypeParameterTypeImpl.create(
+                  "T",
+                  List.of(
+                      RecordConstraintImpl.instance(),
+                      ConstructorConstraintImpl.instance(),
+                      ClassConstraintImpl.instance()))),
+          Arguments.of(
+              TypeParameterTypeImpl.create("T", List.of(new TypeConstraintImpl(mockClass())))));
+    }
+  }
+
+  private static StructType mockClass() {
+    return TypeMocker.struct("TFoo", CLASS);
+  }
+
+  private static StructType mockClass(Type parent) {
+    return TypeMocker.struct("TFoo", CLASS, parent);
+  }
+
+  private static StructType addDeclaration(StructType type, NameDeclaration declaration) {
+    ((DelphiScopeImpl) type.typeScope()).addDeclaration(declaration);
+    return type;
+  }
+
+  private static RoutineNameDeclaration constructor(String name, VisibilityType visibility) {
+    return constructor(name, visibility, false);
+  }
+
+  private static RoutineNameDeclaration constructor(
+      String name, VisibilityType visibility, boolean hasParameters) {
+    return new RoutineNameDeclarationImpl(
+        SymbolicNode.imaginary(name, DelphiScope.unknownScope()),
+        "Test.TFoo." + name,
+        VoidTypeImpl.instance(),
+        Collections.emptySet(),
+        false,
+        true,
+        RoutineKind.CONSTRUCTOR,
+        ((TypeFactoryImpl) FACTORY)
+            .createProcedural(
+                ProceduralKind.ROUTINE,
+                hasParameters ? List.of(mock(Parameter.class)) : Collections.emptyList(),
+                VoidTypeImpl.instance(),
+                Collections.emptySet()),
+        null,
+        visibility,
+        Collections.emptyList(),
+        Collections.emptyList());
+  }
+
+  @ParameterizedTest
+  @ArgumentsSource(SatisfiedArgumentsProvider.class)
+  void testSatisfied(Type argumentType) {
+    assertThat(ConstructorConstraintImpl.instance().satisfiedBy(argumentType)).isTrue();
+  }
+
+  @ParameterizedTest
+  @ArgumentsSource(ViolatedArgumentsProvider.class)
+  void testViolated(Type argumentType) {
+    assertThat(ConstructorConstraintImpl.instance().satisfiedBy(argumentType)).isFalse();
+  }
+}

--- a/delphi-frontend/src/test/java/au/com/integradev/delphi/type/generic/constraint/RecordConstraintTest.java
+++ b/delphi-frontend/src/test/java/au/com/integradev/delphi/type/generic/constraint/RecordConstraintTest.java
@@ -1,0 +1,102 @@
+/*
+ * Sonar Delphi Plugin
+ * Copyright (C) 2025 Integrated Application Development
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02
+ */
+package au.com.integradev.delphi.type.generic.constraint;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.Mockito.mock;
+import static org.sonar.plugins.communitydelphi.api.type.StructKind.CLASS;
+import static org.sonar.plugins.communitydelphi.api.type.StructKind.RECORD;
+
+import au.com.integradev.delphi.type.factory.TypeFactoryImpl;
+import au.com.integradev.delphi.type.generic.TypeParameterTypeImpl;
+import au.com.integradev.delphi.utils.types.TypeFactoryUtils;
+import au.com.integradev.delphi.utils.types.TypeMocker;
+import java.util.List;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.ArgumentsProvider;
+import org.junit.jupiter.params.provider.ArgumentsSource;
+import org.sonar.plugins.communitydelphi.api.symbol.scope.DelphiScope;
+import org.sonar.plugins.communitydelphi.api.type.Constraint;
+import org.sonar.plugins.communitydelphi.api.type.IntrinsicType;
+import org.sonar.plugins.communitydelphi.api.type.Type;
+import org.sonar.plugins.communitydelphi.api.type.TypeFactory;
+
+class RecordConstraintTest {
+  private static final TypeFactory FACTORY = TypeFactoryUtils.defaultFactory();
+
+  private static class SatisfiedArgumentsProvider implements ArgumentsProvider {
+    @Override
+    public Stream<Arguments> provideArguments(ExtensionContext context) {
+      Type integer = FACTORY.getIntrinsic(IntrinsicType.INTEGER);
+      Type enumeration = ((TypeFactoryImpl) FACTORY).enumeration("", DelphiScope.unknownScope());
+      return Stream.of(
+          Arguments.of(integer),
+          Arguments.of(enumeration),
+          Arguments.of(FACTORY.subrange("", integer)),
+          Arguments.of(FACTORY.subrange("", enumeration)),
+          Arguments.of(FACTORY.getIntrinsic(IntrinsicType.BOOLEAN)),
+          Arguments.of(FACTORY.getIntrinsic(IntrinsicType.DOUBLE)),
+          Arguments.of(FACTORY.getIntrinsic(IntrinsicType.ANSICHAR)),
+          Arguments.of(FACTORY.getIntrinsic(IntrinsicType.WIDECHAR)),
+          Arguments.of(TypeMocker.struct("TFoo", RECORD)),
+          Arguments.of(
+              TypeParameterTypeImpl.create("T", List.of(RecordConstraintImpl.instance()))));
+    }
+  }
+
+  private static class ViolatedArgumentsProvider implements ArgumentsProvider {
+    @Override
+    public Stream<Arguments> provideArguments(ExtensionContext context) {
+      return Stream.of(
+          Arguments.of(FACTORY.getIntrinsic(IntrinsicType.STRING)),
+          Arguments.of(TypeMocker.struct("TBar", CLASS)),
+          Arguments.of(TypeParameterTypeImpl.create("T")),
+          Arguments.of(TypeParameterTypeImpl.create("T", List.of(mock(Constraint.class)))),
+          Arguments.of(TypeParameterTypeImpl.create("T", List.of(ClassConstraintImpl.instance()))),
+          Arguments.of(
+              TypeParameterTypeImpl.create("T", List.of(ConstructorConstraintImpl.instance()))),
+          Arguments.of(
+              TypeParameterTypeImpl.create(
+                  "T",
+                  List.of(ClassConstraintImpl.instance(), ConstructorConstraintImpl.instance()))),
+          Arguments.of(
+              TypeParameterTypeImpl.create(
+                  "T",
+                  List.of(
+                      RecordConstraintImpl.instance(),
+                      ConstructorConstraintImpl.instance(),
+                      ClassConstraintImpl.instance()))));
+    }
+  }
+
+  @ParameterizedTest
+  @ArgumentsSource(SatisfiedArgumentsProvider.class)
+  void testSatisfied(Type argumentType) {
+    assertThat(RecordConstraintImpl.instance().satisfiedBy(argumentType)).isTrue();
+  }
+
+  @ParameterizedTest
+  @ArgumentsSource(ViolatedArgumentsProvider.class)
+  void testViolated(Type argumentType) {
+    assertThat(RecordConstraintImpl.instance().satisfiedBy(argumentType)).isFalse();
+  }
+}

--- a/delphi-frontend/src/test/java/au/com/integradev/delphi/type/generic/constraint/TypeConstraintTest.java
+++ b/delphi-frontend/src/test/java/au/com/integradev/delphi/type/generic/constraint/TypeConstraintTest.java
@@ -1,0 +1,105 @@
+/*
+ * Sonar Delphi Plugin
+ * Copyright (C) 2025 Integrated Application Development
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02
+ */
+package au.com.integradev.delphi.type.generic.constraint;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.Mockito.mock;
+import static org.sonar.plugins.communitydelphi.api.type.StructKind.CLASS;
+import static org.sonar.plugins.communitydelphi.api.type.StructKind.RECORD;
+
+import au.com.integradev.delphi.type.generic.TypeParameterTypeImpl;
+import au.com.integradev.delphi.utils.types.TypeFactoryUtils;
+import au.com.integradev.delphi.utils.types.TypeMocker;
+import java.util.List;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.ArgumentsProvider;
+import org.junit.jupiter.params.provider.ArgumentsSource;
+import org.sonar.plugins.communitydelphi.api.type.Constraint;
+import org.sonar.plugins.communitydelphi.api.type.Constraint.TypeConstraint;
+import org.sonar.plugins.communitydelphi.api.type.IntrinsicType;
+import org.sonar.plugins.communitydelphi.api.type.Type;
+import org.sonar.plugins.communitydelphi.api.type.TypeFactory;
+
+class TypeConstraintTest {
+  private static final TypeFactory FACTORY = TypeFactoryUtils.defaultFactory();
+
+  private static final Type TFOO = TypeMocker.struct("TFoo", CLASS);
+  private static final Type TBAR = TypeMocker.struct("TBar", CLASS, TFOO);
+  private static final Type TBAZ = TypeMocker.struct("TBaz", CLASS, TBAR);
+  private static final TypeConstraint CONSTRAINT = new TypeConstraintImpl(TBAR);
+
+  private static class SatisfiedArgumentsProvider implements ArgumentsProvider {
+    @Override
+    public Stream<Arguments> provideArguments(ExtensionContext context) {
+      return Stream.of(
+          Arguments.of(TBAR),
+          Arguments.of(TBAZ),
+          Arguments.of(FACTORY.classOf(null, TBAR)),
+          Arguments.of(FACTORY.classOf(null, TBAZ)),
+          Arguments.of(TBAR),
+          Arguments.of(
+              TypeParameterTypeImpl.create(
+                  "T",
+                  List.of(
+                      new TypeConstraintImpl(TypeMocker.struct("TBar", CLASS)),
+                      ClassConstraintImpl.instance(),
+                      ConstructorConstraintImpl.instance()))));
+    }
+  }
+
+  private static class ViolatedArgumentsProvider implements ArgumentsProvider {
+    @Override
+    public Stream<Arguments> provideArguments(ExtensionContext context) {
+      return Stream.of(
+          Arguments.of(FACTORY.getIntrinsic(IntrinsicType.BYTE)),
+          Arguments.of(FACTORY.getIntrinsic(IntrinsicType.STRING)),
+          Arguments.of(TFOO),
+          Arguments.of(TypeMocker.struct("TFlarp", RECORD)),
+          Arguments.of(TypeMocker.struct("TFlimFlam", CLASS)),
+          Arguments.of(TypeParameterTypeImpl.create("T")),
+          Arguments.of(TypeParameterTypeImpl.create("T", List.of(mock(Constraint.class)))),
+          Arguments.of(TypeParameterTypeImpl.create("T", List.of(ClassConstraintImpl.instance()))),
+          Arguments.of(
+              TypeParameterTypeImpl.create("T", List.of(ConstructorConstraintImpl.instance()))),
+          Arguments.of(TypeParameterTypeImpl.create("T", List.of(RecordConstraintImpl.instance()))),
+          Arguments.of(
+              TypeParameterTypeImpl.create(
+                  "T",
+                  List.of(
+                      ClassConstraintImpl.instance(),
+                      ConstructorConstraintImpl.instance(),
+                      RecordConstraintImpl.instance()))));
+    }
+  }
+
+  @ParameterizedTest
+  @ArgumentsSource(SatisfiedArgumentsProvider.class)
+  void testSatisfied(Type argumentType) {
+    assertThat(CONSTRAINT.satisfiedBy(argumentType)).isTrue();
+  }
+
+  @ParameterizedTest
+  @ArgumentsSource(ViolatedArgumentsProvider.class)
+  void testViolated(Type argumentType) {
+    assertThat(CONSTRAINT.satisfiedBy(argumentType)).isFalse();
+  }
+}

--- a/delphi-frontend/src/test/java/au/com/integradev/delphi/utils/types/TypeMocker.java
+++ b/delphi-frontend/src/test/java/au/com/integradev/delphi/utils/types/TypeMocker.java
@@ -22,9 +22,9 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
-import static org.sonar.plugins.communitydelphi.api.symbol.scope.DelphiScope.unknownScope;
 import static org.sonar.plugins.communitydelphi.api.type.TypeFactory.unknownType;
 
+import au.com.integradev.delphi.symbol.scope.TypeScopeImpl;
 import au.com.integradev.delphi.type.factory.HelperTypeImpl;
 import au.com.integradev.delphi.type.factory.StructTypeImpl;
 import org.sonar.plugins.communitydelphi.api.type.Parameter;
@@ -53,10 +53,15 @@ public final class TypeMocker {
         type = mock(StructTypeImpl.class);
     }
 
-    when(type.typeScope()).thenReturn(unknownScope());
+    var typeScope = new TypeScopeImpl();
+    typeScope.setType(type);
+
+    when(type.typeScope()).thenReturn(typeScope);
     when(type.isStruct()).thenReturn(true);
+    when(type.isClass()).thenReturn(kind == StructKind.CLASS);
     when(type.isInterface()).thenReturn(kind == StructKind.INTERFACE);
     when(type.isRecord()).thenReturn(kind == StructKind.RECORD);
+    when(type.isClass()).thenReturn(kind == StructKind.CLASS);
     when(type.isHelper())
         .thenReturn(kind == StructKind.RECORD_HELPER || kind == StructKind.CLASS_HELPER);
     when(type.getImage()).thenReturn(image);

--- a/delphi-frontend/src/test/resources/au/com/integradev/delphi/symbol/generics/ImplicitSpecialization.pas
+++ b/delphi-frontend/src/test/resources/au/com/integradev/delphi/symbol/generics/ImplicitSpecialization.pas
@@ -41,7 +41,7 @@ end;
 
 procedure TConsumer.Test(Consumables: array of TConsumable);
 var
-  DynamicConsumables: TArray<TConsumable>;
+  DynamicConsumables: array of TConsumable;
 begin
   DynamicConsumables := [TConsumable.Create];
 

--- a/delphi-frontend/src/test/resources/au/com/integradev/delphi/symbol/generics/ImplicitSpecialization.pas
+++ b/delphi-frontend/src/test/resources/au/com/integradev/delphi/symbol/generics/ImplicitSpecialization.pas
@@ -4,14 +4,16 @@ interface
 
 type
   TConsumable = class
-    constructor Create; override;
+    constructor Create;
     procedure GetEaten;
     class function Pizza: TConsumable;
   end;
 
   TConsumer = class
-    procedure Test(Consumable: TConsumable);
-    procedure Consume<T: TConsumable>(Tasty: T);
+    procedure Test(Consumable: TConsumable); overload;
+    procedure Test(Consumables: array of TConsumable); overload;
+    procedure Consume<T: TConsumable>(Consumable: T); overload;
+    procedure Consume<T: TConsumable>(Consumables: array of T); overload;
   end;
 
 implementation
@@ -21,11 +23,31 @@ begin
   Consumable.GetEaten;
 end;
 
+procedure TConsumer.Consume<T>(Consumables: array of T);
+var
+  Consumable: T;
+begin
+  for Consumable in Consumables do begin
+    Consume(Consumable);
+  end;
+end;
+
 procedure TConsumer.Test(Consumable: TConsumable);
 begin
   Consume(Consumable);
   Consume(TConsumable.Pizza);
   Consume(TConsumable.Create);
+end;
+
+procedure TConsumer.Test(Consumables: array of TConsumable);
+var
+  DynamicConsumables: TArray<TConsumable>;
+begin
+  DynamicConsumables := [TConsumable.Create];
+
+  Consume(Consumables);
+  Consume(DynamicConsumables);
+  Consume([TConsumable.Pizza]);
 end;
 
 end.

--- a/delphi-frontend/src/test/resources/au/com/integradev/delphi/symbol/generics/TypeParameterConstructor.pas
+++ b/delphi-frontend/src/test/resources/au/com/integradev/delphi/symbol/generics/TypeParameterConstructor.pas
@@ -1,0 +1,28 @@
+unit TypeParameterConstructor;
+
+interface
+
+implementation
+
+type
+  TFoo = class
+  public
+    class function Bar: Boolean;
+  end;
+
+  TTest = class
+    class function Test<T: TFoo, constructor>: Boolean;
+  end;
+
+class function TFoo.Bar: Boolean;
+begin
+  Result := True;
+end;
+
+class function TTest.Test<T>: Boolean;
+begin
+  Result := T.Create.Bar;
+  Result := T.Create().Bar;
+end;
+
+end.


### PR DESCRIPTION
This PR was prompted by a name resolution failure caused by an implicit specialization failure, which involved a dynamic array being passed to a generic open array. It was meant to be a small improvement to the analyzer's support for implicit specialization, adding support for routines with generic open array parameters.

In testing that change, I realized that there were cases in generic specialization that necessitate full support for constraints.
Consider the following example:
```pas
type
  TFoo = class
    procedure Bar<T: class>(Baz: T); overload;
    procedure Bar<T>(Baz: array of T); overload;
  end;
```
With the existing behavior (no handling for the `class` constraint), we're unable to disambiguate a call to `TFoo.Bar` with a `TArray<TObject>` argument. We need to eliminate the first overload due to the `class` constraint being violated.

Naturally, this had API implications (but it wasn't too big a mess):
- new `ConstraintNode` AST nodes
- new `Constraint` type hierarchy
- deprecated existing API methods that naively assumed all constraints were class/interface constraints (type references)