### PR TITLE
Upgrade google-java-format to 1.26.0

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -20,5 +20,5 @@ jobs:
       - uses: actions/checkout@v4
       - uses: axel-op/googlejavaformat-action@c1134ebd196c4cbffb077f9476585b0be8b6afcd # v4.0.0
         with:
-          release-name: v1.19.2
+          release-name: v1.26.0
           args: "--set-exit-if-changed --dry-run"

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ read the [contributing guide](docs/CONTRIBUTING.md).
 
 ## Development
 
-SonarDelphi can be built with JDK 11+ using [Maven](https://maven.apache.org/).
+SonarDelphi can be built with JDK 17+ using [Maven](https://maven.apache.org/).
 
 To build the project and run unit tests, execute the following command from the project's root directory:
 

--- a/delphi-frontend/src/main/java/au/com/integradev/delphi/msbuild/condition/BinaryExpression.java
+++ b/delphi-frontend/src/main/java/au/com/integradev/delphi/msbuild/condition/BinaryExpression.java
@@ -45,12 +45,11 @@ class BinaryExpression implements Expression {
         return isEqual(evaluator);
       case NOT_EQUAL:
         return isEqual(evaluator).map(value -> !value);
-        // NOTE:
-        // When comparing numerics against versions, if the number is the same as the "major"
-        // version,
-        // then that means we are comparing something like "6.X.Y.Z" to "6".
-        // Version treats the objects with more dots as "larger" regardless of what those dots are
-        // (e.g. 6.0.0.0 > 6 is a true statement)
+      // NOTE:
+      // When comparing numerics against versions, if the number is the same as the "major" version,
+      // then that means we are comparing something like "6.X.Y.Z" to "6".
+      // Version treats the objects with more dots as "larger" regardless of what those dots are
+      // (e.g. 6.0.0.0 > 6 is a true statement)
       case GREATER_THAN:
         return compare(
             evaluator,

--- a/pom.xml
+++ b/pom.xml
@@ -103,7 +103,7 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.min.version>3.3.9</maven.min.version>
-    <jdk.min.version>11</jdk.min.version>
+    <jdk.min.version>17</jdk.min.version>
     <skipITs>true</skipITs>
     <!-- SonarCloud scan -->
     <sonar.organization>integrated-application-development</sonar.organization>
@@ -463,7 +463,7 @@
         <configuration>
           <java>
             <googleJavaFormat>
-              <version>1.19.2</version>
+              <version>1.26.0</version>
               <style>GOOGLE</style>
               <reflowLongStrings>true</reflowLongStrings>
             </googleJavaFormat>


### PR DESCRIPTION
This also bumps our minimum JDK requirement to 17, as it's a requirement starting from google-java-format 1.25.0.