### PR TITLE
Tidy up `ExpressionEvaluator`

### DIFF
--- a/delphi-frontend/src/main/java/au/com/integradev/delphi/msbuild/expression/ExpressionEvaluator.java
+++ b/delphi-frontend/src/main/java/au/com/integradev/delphi/msbuild/expression/ExpressionEvaluator.java
@@ -126,12 +126,15 @@ public class ExpressionEvaluator {
   }
 
   private Optional<String> parseItem() {
-    if (nextChar() != '@') return Optional.empty();
-    if (nextChar() != '(') return Optional.empty();
+    if (nextChar() != '@' || nextChar() != '(') {
+      return Optional.empty();
+    }
 
     skipWhitespace();
     Optional<String> ident = parseIdentifier();
-    if (ident.isEmpty()) return Optional.empty();
+    if (ident.isEmpty()) {
+      return Optional.empty();
+    }
     skipWhitespace();
 
     Function<MSBuildItem, String> transform = MSBuildItem::getIdentity;
@@ -139,7 +142,9 @@ public class ExpressionEvaluator {
 
     if (peekChar() == '-') {
       var maybeTransform = parseItemTransform();
-      if (maybeTransform.isEmpty()) return Optional.empty();
+      if (maybeTransform.isEmpty()) {
+        return Optional.empty();
+      }
       transform = maybeTransform.get();
 
       skipWhitespace();
@@ -154,12 +159,16 @@ public class ExpressionEvaluator {
       nextChar();
       skipWhitespace();
       var maybeSeparator = parseSimpleString();
-      if (maybeSeparator.isEmpty()) return Optional.empty();
+      if (maybeSeparator.isEmpty()) {
+        return Optional.empty();
+      }
       separator = maybeSeparator.get();
       skipWhitespace();
     }
 
-    if (nextChar() != ')') return Optional.empty();
+    if (nextChar() != ')') {
+      return Optional.empty();
+    }
 
     return Optional.of(concatItems(ident.get(), transform, separator));
   }
@@ -170,8 +179,9 @@ public class ExpressionEvaluator {
   }
 
   private Optional<Function<MSBuildItem, String>> parseItemTransform() {
-    if (nextChar() != '-') return Optional.empty();
-    if (nextChar() != '>') return Optional.empty();
+    if (nextChar() != '-' || nextChar() != '>') {
+      return Optional.empty();
+    }
 
     return parseItemTransformExpression();
   }
@@ -182,9 +192,15 @@ public class ExpressionEvaluator {
       return Optional.empty();
     }
 
-    if (nextChar() != '\'') return Optional.empty();
+    if (nextChar() != '\'') {
+      return Optional.empty();
+    }
+
     String expression = parseTopLevel(true, false);
-    if (nextChar() != '\'') return Optional.empty();
+
+    if (nextChar() != '\'') {
+      return Optional.empty();
+    }
 
     return Optional.of(item -> expandMetadataValues(item, expression));
   }
@@ -196,8 +212,10 @@ public class ExpressionEvaluator {
   }
 
   private Optional<String> parseProperty() {
-    if (nextChar() != '$') return Optional.empty();
-    if (nextChar() != '(') return Optional.empty();
+    if (nextChar() != '$' || nextChar() != '(') {
+      return Optional.empty();
+    }
+
     if (peekChar() == '[') {
       unsupportedFeature("static property function");
       return Optional.empty();
@@ -215,7 +233,9 @@ public class ExpressionEvaluator {
     }
 
     discard = skipWhitespace() || discard;
-    if (nextChar() != ')') return Optional.empty();
+    if (nextChar() != ')') {
+      return Optional.empty();
+    }
 
     if (discard) {
       // Whitespace is significant inside property expressions, but it's impossible to
@@ -227,16 +247,21 @@ public class ExpressionEvaluator {
   }
 
   private Optional<String> parseMetadata() {
-    if (nextChar() != '%') return Optional.empty();
-    if (nextChar() != '(') return Optional.empty();
+    if (nextChar() != '%' || nextChar() != '(') {
+      return Optional.empty();
+    }
 
     var discard = skipWhitespace();
     Optional<String> ident = parseIdentifier();
-    if (ident.isEmpty()) return Optional.empty();
+    if (ident.isEmpty()) {
+      return Optional.empty();
+    }
 
     discard = skipWhitespace() || discard;
 
-    if (nextChar() != ')') return Optional.empty();
+    if (nextChar() != ')') {
+      return Optional.empty();
+    }
 
     if (discard) {
       // Whitespace is significant inside metadata expressions, but it's impossible to
@@ -258,7 +283,9 @@ public class ExpressionEvaluator {
   }
 
   private Optional<String> parseSimpleString() {
-    if (nextChar() != '\'') return Optional.empty();
+    if (nextChar() != '\'') {
+      return Optional.empty();
+    }
 
     StringBuilder builder = new StringBuilder();
 
@@ -271,7 +298,9 @@ public class ExpressionEvaluator {
   }
 
   private Optional<String> parseIdentifier() {
-    if (!isSimpleStringStart(peekChar())) return Optional.empty();
+    if (!isSimpleStringStart(peekChar())) {
+      return Optional.empty();
+    }
 
     StringBuilder builder = new StringBuilder();
 

--- a/delphi-frontend/src/main/java/au/com/integradev/delphi/msbuild/expression/ExpressionEvaluator.java
+++ b/delphi-frontend/src/main/java/au/com/integradev/delphi/msbuild/expression/ExpressionEvaluator.java
@@ -238,8 +238,8 @@ public class ExpressionEvaluator {
     }
 
     if (discard) {
-      // Whitespace is significant inside property expressions, but it's impossible to
-      // define properties with spaces, so expressions with spaces always evaluate to "".
+      // Whitespace is significant inside property expressions, but it's impossible to define
+      // properties with spaces, so expressions with spaces always evaluate to "".
       return Optional.of("");
     } else {
       return Optional.of(state.getProperty(ident.get()));
@@ -264,8 +264,8 @@ public class ExpressionEvaluator {
     }
 
     if (discard) {
-      // Whitespace is significant inside metadata expressions, but it's impossible to
-      // define metadata with spaces, so expressions with spaces always evaluate to "".
+      // Whitespace is significant inside metadata expressions, but it's impossible to define
+      // metadata with spaces, so expressions with spaces always evaluate to "".
       return Optional.of("");
     } else if (metadataProvider != null) {
       return Optional.of(metadataProvider.apply(ident.get()));
@@ -324,10 +324,9 @@ public class ExpressionEvaluator {
 
   private void unsupportedFeature(String feature) {
     // We don't know the relative importance of this expression - it could be an expression that
-    // SonarDelphi
-    // never needs to read. Making this a warning despite having a well-defined behaviour for when
-    // an unsupported
-    // feature is encountered (to interpret it literally) would probably be overkill.
+    // SonarDelphi never needs to read. Making this a warning despite having a well-defined
+    // behaviour for when an unsupported feature is encountered (to interpret it literally) would
+    // probably be overkill.
     LOG.debug("Unsupported MSBuild feature '{}' ignored in expression: {}", feature, text);
   }
 }


### PR DESCRIPTION
This PR does some minor QA in the recently-added `ExpressionEvaluator`.

I've also enabled the "Control structures should use curly braces" rule on SonarCloud. It shouldn't raise any issues, as the rest of the codebase consistently uses curly braces.