### PR TITLE
Disambiguate index property read/write methods correctly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Name resolution failures when accessing ancestors of enclosing types from nested type methods.
 - Name resolution failures on invocations of methods with generic open array parameters.
 - Name resolution failures around `Create` calls on types with `constructor` constraints.
+- Name resolution failures on `read` and `write` specifiers of indexed properties.
 - Incorrect file position calculation for multiline string tokens.
 - Analysis errors around `type of` type declarations.
 

--- a/delphi-frontend/src/test/java/au/com/integradev/delphi/executor/DelphiSymbolTableExecutorTest.java
+++ b/delphi-frontend/src/test/java/au/com/integradev/delphi/executor/DelphiSymbolTableExecutorTest.java
@@ -104,6 +104,27 @@ class DelphiSymbolTableExecutorTest {
   }
 
   @Test
+  void testProperties() {
+    execute("Properties.pas");
+    // Field
+    verifyUsages(10, 4, reference(19, 33), reference(19, 46));
+    // Normal getter
+    verifyUsages(16, 13, reference(20, 33), reference(21, 33));
+    // Normal setter
+    verifyUsages(14, 14, reference(20, 50));
+    // Const setter
+    verifyUsages(12, 14, reference(21, 50));
+    // Alias setter
+    verifyUsages(13, 14, reference(22, 55));
+    // Alias getter
+    verifyUsages(17, 13, reference(22, 33));
+    // Index getter
+    verifyUsages(29, 13, reference(32, 41));
+    // Index setter
+    verifyUsages(30, 14, reference(32, 58));
+  }
+
+  @Test
   void testRecords() {
     execute("Records.pas");
     verifyUsages(6, 2, reference(16, 21));

--- a/delphi-frontend/src/test/resources/au/com/integradev/delphi/symbol/Properties.pas
+++ b/delphi-frontend/src/test/resources/au/com/integradev/delphi/symbol/Properties.pas
@@ -1,0 +1,37 @@
+unit Properties;
+
+interface
+
+type
+  TIntAlias = Integer;
+
+  TMyObj = class(TObject)
+  private
+    FField: Integer;
+
+    procedure SetMyFieldConst(const Val: Integer);
+    procedure SetMyFieldAlias(Val: TIntAlias);
+    procedure SetMyField(Val: Integer);
+
+    function GetMyField: Integer;
+    function GetMyFieldAlias: TIntAlias;
+  public
+    property Prop1: Integer read FField write FField;
+    property Prop2: Integer read GetMyField write SetMyField;
+    property Prop3: Integer read GetMyField write SetMyFieldConst;
+    property Prop4: Integer read GetMyFieldAlias write SetMyFieldAlias;
+  end;
+
+  TIndexObj = class(TObject)
+  private
+    FField: TObject;
+
+    function GetMyField(Index: Integer): TObject;
+    procedure SetMyField(Index: Integer; Value: TObject);
+  public
+    property Prop1: TObject index 0 read GetMyField write SetMyField;
+  end;
+
+implementation
+
+end.


### PR DESCRIPTION
When a property has an `index` specifier, its `read` specifier must be a function with an `Integer` final argument, and its `write` specifier must be a procedure with an `Integer` second-last argument. We were not previously modelling this behaviour, causing `read` and `write` specifier methods to fail to resolve when an `index` property is present.