### PR TITLE
Fix various name resolution errors around routine references

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Name resolution failures on invocations of methods with generic open array parameters.
 - Name resolution failures around `Create` calls on types with `constructor` constraints.
 - Name resolution failures on `read`, `write`, and `stored` specifiers of indexed properties.
+- Name resolution failures on routine references assigned to a `var`/`const` declaration.
+- Name resolution failures on routine references in constant arrays.
 - Type resolution failures on array expressions nested within multidimensional constant arrays.
 - Incorrect file position calculation for multiline string tokens.
 - Analysis errors around `type of` type declarations.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Name resolution failures on invocations of methods with generic open array parameters.
 - Name resolution failures around `Create` calls on types with `constructor` constraints.
 - Name resolution failures on `read`, `write`, and `stored` specifiers of indexed properties.
+- Type resolution failures on array expressions nested within multidimensional constant arrays.
 - Incorrect file position calculation for multiline string tokens.
 - Analysis errors around `type of` type declarations.
 

--- a/delphi-frontend/src/test/java/au/com/integradev/delphi/executor/DelphiSymbolTableExecutorTest.java
+++ b/delphi-frontend/src/test/java/au/com/integradev/delphi/executor/DelphiSymbolTableExecutorTest.java
@@ -423,6 +423,27 @@ class DelphiSymbolTableExecutorTest {
   }
 
   @Test
+  void testRoutineReferenceAssignedToProcedural() {
+    execute("RoutineReferenceAssignedToProcedural.pas");
+    verifyUsages(
+        10,
+        9,
+        reference(21, 17),
+        reference(25, 35),
+        reference(27, 5),
+        reference(28, 10),
+        reference(32, 28));
+    verifyUsages(
+        15,
+        9,
+        reference(22, 19),
+        reference(25, 40),
+        reference(27, 10),
+        reference(28, 5),
+        reference(33, 31));
+  }
+
+  @Test
   void testClassReferenceMethodResolution() {
     execute("classReferences/MethodResolution.pas");
     verifyUsages(9, 14, reference(18, 6));

--- a/delphi-frontend/src/test/resources/au/com/integradev/delphi/symbol/RoutineReferenceAssignedToProcedural.pas
+++ b/delphi-frontend/src/test/resources/au/com/integradev/delphi/symbol/RoutineReferenceAssignedToProcedural.pas
@@ -1,0 +1,35 @@
+unit RoutineReferenceAssignedToProcedural;
+
+interface
+
+implementation
+
+type
+  TFoo = function(const A: Integer; B: string; var C: Variant): Boolean;
+
+function Bar(const A: Integer; B: string; var C: Variant): Boolean;
+begin
+  Result := True;
+end;
+
+function Baz(const A: Integer; B: string; var C: Variant): Boolean;
+begin
+  Result := False;
+end;
+
+var
+  VarFoo: TFoo = Bar;
+  ConstFoo: TFoo = Baz;
+
+const
+  FooArray: array[0..1] of TFoo = (Bar, Baz);
+  MultiFooArray: array[0..1, 0..1] of TFoo = (
+    (Bar, Baz),
+    (Baz, Bar)
+   );
+
+initialization
+  var InlineVarFoo: TFoo := Bar;
+  const InlineConstFoo: TFoo = Baz;
+
+end.


### PR DESCRIPTION
This PR improves name resolution on routine references in:
- assignment to inline `var`/`const` declarations
- assignment to standard `var` declarations
- assignment to standard typed `const` declarations
- constant arrays
  - This required improvements to type resolution for constant array expressions.
    Multidimensional constant arrays are especially improved, as their subarrays couldn't **ever** resolve properly before.