### PR TITLE
Improve handling for various intrinsics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Support for the `AtomicCmpExchange128` intrinsic routine.
+- Support for the `GetTypeKind` intrinsic routine.
 - **API:** `TypeParameterNode::getTypeParameters` method.
 - **API:** `InterfaceTypeNode::getGuidExpression` method.
 - **API:** `AttributeNode::getExpression` method.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Issue locations no longer span the entire routine declaration in `RoutineName`.
+- Improve type modeling around the `VarArg*` intrinsic routines.
 
 ### Deprecated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Support for the `AtomicCmpExchange128` intrinsic routine.
 - **API:** `TypeParameterNode::getTypeParameters` method.
 - **API:** `InterfaceTypeNode::getGuidExpression` method.
 - **API:** `AttributeNode::getExpression` method.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Type resolution failures on `as` casts where the type is returned from a routine invocation.
 - Inaccurate type resolution when calling a constructor on a class reference type.
 - Grammar ambiguity causing attributes to be misinterpreted as interface GUIDs.
+- Failure to resolve invocations of `System.IsManagedType` where a value is passed.
 
 ## [1.16.0] - 2025-05-09
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Support for the `AtomicCmpExchange128` intrinsic routine.
 - Support for the `GetTypeKind` intrinsic routine.
+- Support for the `OpenString` intrinsic type.
 - **API:** `TypeParameterNode::getTypeParameters` method.
 - **API:** `InterfaceTypeNode::getGuidExpression` method.
 - **API:** `AttributeNode::getExpression` method.

--- a/delphi-checks-testkit/src/main/java/au/com/integradev/delphi/checks/verifier/CheckVerifierImpl.java
+++ b/delphi-checks-testkit/src/main/java/au/com/integradev/delphi/checks/verifier/CheckVerifierImpl.java
@@ -793,6 +793,12 @@ public class CheckVerifierImpl implements CheckVerifier {
               + "  TVarArgList = record\n"
               + "  end;\n"
               + "\n"
+              + "  TTypeKind = (\n"
+              + "    tkUnknown, tkInteger, tkChar, tkEnumeration, tkFloat, tkString, tkSet,\n"
+              + "    tkClass, tkMethod, tkWChar, tkLString, tkWString, tkVariant, tkArray,\n"
+              + "    tkClassRef, tkPointer, tkProcedure, tkMRecord\n"
+              + "  );\n"
+              + "\n"
               + "implementation\n"
               + "\n"
               + "end.");

--- a/delphi-checks-testkit/src/main/java/au/com/integradev/delphi/checks/verifier/CheckVerifierImpl.java
+++ b/delphi-checks-testkit/src/main/java/au/com/integradev/delphi/checks/verifier/CheckVerifierImpl.java
@@ -790,6 +790,9 @@ public class CheckVerifierImpl implements CheckVerifier {
               + "  TCustomAttribute = class(TObject)\n"
               + "  end;\n"
               + "\n"
+              + "  TVarArgList = record\n"
+              + "  end;\n"
+              + "\n"
               + "implementation\n"
               + "\n"
               + "end.");

--- a/delphi-frontend/src/main/java/au/com/integradev/delphi/antlr/ast/visitors/SymbolTableVisitor.java
+++ b/delphi-frontend/src/main/java/au/com/integradev/delphi/antlr/ast/visitors/SymbolTableVisitor.java
@@ -54,6 +54,7 @@ import au.com.integradev.delphi.symbol.scope.WithScopeImpl;
 import au.com.integradev.delphi.type.TypeUtils;
 import au.com.integradev.delphi.type.factory.ClassReferenceTypeImpl;
 import au.com.integradev.delphi.type.factory.PointerTypeImpl;
+import au.com.integradev.delphi.type.intrinsic.IntrinsicsInjector;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Iterables;
 import java.nio.file.Path;
@@ -263,6 +264,22 @@ public abstract class SymbolTableVisitor implements DelphiParserVisitor<Data> {
       public Data visit(DelphiAst node, Data data) {
         if (!node.isUnit()) {
           // Only units have interface sections.
+          return data;
+        }
+
+        return super.visit(node, data);
+      }
+
+      @Override
+      public Data visit(InterfaceSectionNode node, Data data) {
+        DelphiScope scope = Objects.requireNonNull(data.getUnitDeclaration()).getScope();
+
+        if (scope instanceof SystemScope) {
+          IntrinsicsInjector injector = new IntrinsicsInjector(data.typeFactory);
+          injector.injectTypes(scope);
+          injector.injectConstants(scope);
+          super.visit(node, data);
+          injector.injectRoutines(scope);
           return data;
         }
 

--- a/delphi-frontend/src/main/java/au/com/integradev/delphi/symbol/scope/SystemScopeImpl.java
+++ b/delphi-frontend/src/main/java/au/com/integradev/delphi/symbol/scope/SystemScopeImpl.java
@@ -18,7 +18,6 @@
  */
 package au.com.integradev.delphi.symbol.scope;
 
-import au.com.integradev.delphi.type.intrinsic.IntrinsicsInjector;
 import org.sonar.plugins.communitydelphi.api.symbol.declaration.NameDeclaration;
 import org.sonar.plugins.communitydelphi.api.symbol.declaration.TypeNameDeclaration;
 import org.sonar.plugins.communitydelphi.api.symbol.scope.SystemScope;
@@ -32,12 +31,6 @@ public class SystemScopeImpl extends FileScopeImpl implements SystemScope {
 
   public SystemScopeImpl(TypeFactory typeFactory) {
     super("System");
-    injectIntrinsics(typeFactory);
-  }
-
-  private void injectIntrinsics(TypeFactory typeFactory) {
-    IntrinsicsInjector injector = new IntrinsicsInjector(typeFactory);
-    injector.inject(this);
   }
 
   @Override

--- a/delphi-frontend/src/main/java/au/com/integradev/delphi/type/factory/TypeFactoryImpl.java
+++ b/delphi-frontend/src/main/java/au/com/integradev/delphi/type/factory/TypeFactoryImpl.java
@@ -290,6 +290,8 @@ public class TypeFactoryImpl implements TypeFactory {
     addString(IntrinsicType.UNICODESTRING, pointerSize(), IntrinsicType.WIDECHAR);
     addString(IntrinsicType.SHORTSTRING, 256, IntrinsicType.ANSICHAR);
 
+    addWeakAlias(IntrinsicType.OPENSTRING, IntrinsicType.SHORTSTRING);
+
     if (isStringUnicode()) {
       addWeakAlias(IntrinsicType.STRING, IntrinsicType.UNICODESTRING);
       addWeakAlias(IntrinsicType.CHAR, IntrinsicType.WIDECHAR);

--- a/delphi-frontend/src/main/java/au/com/integradev/delphi/type/intrinsic/IntrinsicConstant.java
+++ b/delphi-frontend/src/main/java/au/com/integradev/delphi/type/intrinsic/IntrinsicConstant.java
@@ -1,0 +1,39 @@
+/*
+ * Sonar Delphi Plugin
+ * Copyright (C) 2025 Integrated Application Development
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02
+ */
+package au.com.integradev.delphi.type.intrinsic;
+
+import org.sonar.plugins.communitydelphi.api.type.IntrinsicType;
+
+final class IntrinsicConstant {
+  private final String name;
+  private final IntrinsicType type;
+
+  public IntrinsicConstant(String name, IntrinsicType type) {
+    this.name = name;
+    this.type = type;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public IntrinsicType getType() {
+    return type;
+  }
+}

--- a/delphi-frontend/src/main/java/au/com/integradev/delphi/type/intrinsic/IntrinsicsInjector.java
+++ b/delphi-frontend/src/main/java/au/com/integradev/delphi/type/intrinsic/IntrinsicsInjector.java
@@ -352,13 +352,13 @@ public final class IntrinsicsInjector {
         .param(ANY_STRING)
         .varParam(TypeFactory.untypedType())
         .varParam(ANY_32_BIT_INTEGER);
-    routine("VarArgStart").varParam(TypeFactory.untypedType());
+    routine("VarArgStart").varParam(systemType("TVarArgList"));
     routine("VarArgGetValue")
-        .varParam(TypeFactory.untypedType())
+        .varParam(systemType("TVarArgList"))
         .param(ANY_CLASS_REFERENCE)
         .returns(IntrinsicReturnType.classReferenceValue(1));
-    routine("VarArgCopy").varParam(TypeFactory.untypedType()).varParam(TypeFactory.untypedType());
-    routine("VarArgEnd").varParam(TypeFactory.untypedType());
+    routine("VarArgCopy").varParam(systemType("TVarArgList")).varParam(systemType("TVarArgList"));
+    routine("VarArgEnd").varParam(systemType("TVarArgList"));
     routine("VarArrayRedim").varParam(ANY_VARIANT).param(type(INTEGER));
     routine("VarCast").varParam(ANY_VARIANT).param(ANY_VARIANT).param(type(INTEGER));
     routine("VarClear").varParam(ANY_VARIANT);

--- a/delphi-frontend/src/main/java/au/com/integradev/delphi/type/intrinsic/IntrinsicsInjector.java
+++ b/delphi-frontend/src/main/java/au/com/integradev/delphi/type/intrinsic/IntrinsicsInjector.java
@@ -120,6 +120,13 @@ public final class IntrinsicsInjector {
         .outParam(type(BOOLEAN))
         .required(3)
         .returns(typeFactory.untypedPointer());
+    routine("AtomicCmpExchange128")
+        .varParam(TypeFactory.untypedType())
+        .param(type(INT64))
+        .param(type(INT64))
+        .varParam(TypeFactory.untypedType())
+        .required(4)
+        .returns(type(BOOLEAN));
     routine("AtomicDecrement")
         .varParam(TypeFactory.untypedType())
         .param(TypeFactory.untypedType())

--- a/delphi-frontend/src/main/java/au/com/integradev/delphi/type/intrinsic/IntrinsicsInjector.java
+++ b/delphi-frontend/src/main/java/au/com/integradev/delphi/type/intrinsic/IntrinsicsInjector.java
@@ -262,6 +262,7 @@ public final class IntrinsicsInjector {
     routine("FreeMem").varParam(ANY_POINTER).param(type(INTEGER)).required(1);
     routine("GetDir").param(type(BYTE)).varParam(ANY_STRING);
     routine("GetMem").varParam(ANY_POINTER).param(type(INTEGER));
+    routine("GetTypeKind").param(TypeFactory.untypedType()).returns(systemType("TTypeKind"));
     routine("Halt").param(type(INTEGER)).required(0);
     routine("HasWeakRef").param(ANY_CLASS_REFERENCE).returns(type(BOOLEAN));
     routine("Hi").param(type(INTEGER)).returns(type(BYTE));

--- a/delphi-frontend/src/main/java/au/com/integradev/delphi/type/intrinsic/IntrinsicsInjector.java
+++ b/delphi-frontend/src/main/java/au/com/integradev/delphi/type/intrinsic/IntrinsicsInjector.java
@@ -54,6 +54,7 @@ import au.com.integradev.delphi.symbol.declaration.RoutineNameDeclarationImpl;
 import au.com.integradev.delphi.symbol.declaration.TypeNameDeclarationImpl;
 import au.com.integradev.delphi.symbol.declaration.VariableNameDeclarationImpl;
 import au.com.integradev.delphi.symbol.scope.DelphiScopeImpl;
+import au.com.integradev.delphi.type.UnresolvedTypeImpl;
 import au.com.integradev.delphi.type.factory.TypeFactoryImpl;
 import java.util.ArrayList;
 import java.util.List;
@@ -99,6 +100,10 @@ public final class IntrinsicsInjector {
 
   private Type type(IntrinsicType type) {
     return typeFactory.getIntrinsic(type);
+  }
+
+  private Type systemType(String image) {
+    return UnresolvedTypeImpl.referenceTo(image);
   }
 
   private Type openArraySizeType() {
@@ -387,7 +392,7 @@ public final class IntrinsicsInjector {
   }
 
   private void injectRoutine(IntrinsicRoutine.Builder builder, DelphiScopeImpl scope) {
-    IntrinsicRoutine routine = builder.build();
+    IntrinsicRoutine routine = builder.build(scope);
     SymbolicNode node = SymbolicNode.imaginary(routine.simpleName(), scope);
     RoutineNameDeclaration declaration =
         RoutineNameDeclarationImpl.create(node, routine, typeFactory);

--- a/delphi-frontend/src/main/java/au/com/integradev/delphi/type/intrinsic/IntrinsicsInjector.java
+++ b/delphi-frontend/src/main/java/au/com/integradev/delphi/type/intrinsic/IntrinsicsInjector.java
@@ -243,7 +243,7 @@ public final class IntrinsicsInjector {
         .varParam(LIKE_DYNAMIC_ARRAY)
         .param(dynamicArraySizeType());
     routine("IsConstValue").param(TypeFactory.untypedType()).returns(type(BOOLEAN));
-    routine("IsManagedType").param(ANY_CLASS_REFERENCE).returns(type(BOOLEAN));
+    routine("IsManagedType").param(TypeFactory.untypedType()).returns(type(BOOLEAN));
     routine("Length").param(type(SHORTSTRING)).returns(IntrinsicReturnType.length(typeFactory));
     routine("Length").param(type(ANSISTRING)).returns(IntrinsicReturnType.length(typeFactory));
     routine("Length").param(type(UNICODESTRING)).returns(IntrinsicReturnType.length(typeFactory));

--- a/delphi-frontend/src/main/java/org/sonar/plugins/communitydelphi/api/type/IntrinsicType.java
+++ b/delphi-frontend/src/main/java/org/sonar/plugins/communitydelphi/api/type/IntrinsicType.java
@@ -50,6 +50,7 @@ public enum IntrinsicType implements Qualifiable {
   WIDESTRING("WideString"),
   UNICODESTRING("UnicodeString"),
   SHORTSTRING("ShortString"),
+  OPENSTRING("OpenString"),
   STRING("String"),
   ANSICHAR("AnsiChar"),
   WIDECHAR("WideChar"),

--- a/delphi-frontend/src/test/java/au/com/integradev/delphi/executor/DelphiSymbolTableExecutorTest.java
+++ b/delphi-frontend/src/test/java/au/com/integradev/delphi/executor/DelphiSymbolTableExecutorTest.java
@@ -605,6 +605,12 @@ class DelphiSymbolTableExecutorTest {
   }
 
   @Test
+  void testVarArgIntrinsics() {
+    execute("intrinsics/VarArgIntrinsics.pas");
+    verifyUsages(15, 2, reference(18, 21));
+  }
+
+  @Test
   void testBinaryOperatorIntrinsics() {
     execute("operators/BinaryOperatorIntrinsics.pas");
     verifyUsages(
@@ -1639,6 +1645,8 @@ class DelphiSymbolTableExecutorTest {
               + "  TVarRec = record\n"
               + "  end;\n"
               + "  TCustomAttribute = class(TObject)\n"
+              + "  end;\n"
+              + "  TVarArgList = record\n"
               + "  end;\n"
               + "implementation\n"
               + "end.");

--- a/delphi-frontend/src/test/java/au/com/integradev/delphi/executor/DelphiSymbolTableExecutorTest.java
+++ b/delphi-frontend/src/test/java/au/com/integradev/delphi/executor/DelphiSymbolTableExecutorTest.java
@@ -611,6 +611,12 @@ class DelphiSymbolTableExecutorTest {
   }
 
   @Test
+  void testGetTypeKindIntrinsic() {
+    execute("intrinsics/GetTypeKindIntrinsic.pas");
+    verifyUsages(7, 10, reference(14, 2), reference(15, 2));
+  }
+
+  @Test
   void testBinaryOperatorIntrinsics() {
     execute("operators/BinaryOperatorIntrinsics.pas");
     verifyUsages(
@@ -1648,6 +1654,7 @@ class DelphiSymbolTableExecutorTest {
               + "  end;\n"
               + "  TVarArgList = record\n"
               + "  end;\n"
+              + "  TTypeKind = (tkUnknown);\n"
               + "implementation\n"
               + "end.");
 

--- a/delphi-frontend/src/test/resources/au/com/integradev/delphi/symbol/intrinsics/GetTypeKindIntrinsic.pas
+++ b/delphi-frontend/src/test/resources/au/com/integradev/delphi/symbol/intrinsics/GetTypeKindIntrinsic.pas
@@ -1,0 +1,18 @@
+unit GetTypeKindIntrinsic;
+
+interface
+
+implementation
+
+procedure Proc(Arg: TTypeKind); overload;
+begin
+  // Do nothing
+end;
+
+procedure Test;
+begin
+  Proc(GetTypeKind(123));
+  Proc(GetTypeKind(TObject));
+end;
+
+end.

--- a/delphi-frontend/src/test/resources/au/com/integradev/delphi/symbol/intrinsics/VarArgIntrinsics.pas
+++ b/delphi-frontend/src/test/resources/au/com/integradev/delphi/symbol/intrinsics/VarArgIntrinsics.pas
@@ -1,0 +1,27 @@
+unit VarArgIntrinsics;
+
+interface
+
+implementation
+
+procedure Proc(Arg: Integer);
+begin
+  // do nothing
+end;
+
+procedure Test; cdecl; varargs;
+var
+  VAList: TVarArgList;
+  Copy: TVarArgList;
+begin
+  VarArgStart(VAList);
+  VarArgCopy(VAList, Copy);
+
+  for var I := 0 to 3 do begin
+    Proc(VarArgGetValue(VAList, Integer));
+  end;
+
+  VarArgEnd(VAList);
+end;
+
+end.


### PR DESCRIPTION
This PR does a few things.

Improves the way we handle intrinsic routines by:
- deferring their injection into `System` until the end of the `interface` section
- resolving references to public `System` types in their parameter lists and return types

Adds support for:
- `AtomicCmpExchange128`
- `GetTypeKind`
- `OpenString` type

Improves signatures of:
  - `IsManagedType`
  - `VarArgStart`
  - `VarArgGetValue`
  - `VarArgCopy`
  - `VarArgEnd`