### PR TITLE
Fix various type resolution failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **API:** `TypeParameterNode::getTypeParameters` method.
+
+### Fixed
+
+- Name resolution failures on generic routine invocations where later type parameters are constrained by earlier type parameters.
+
 ## [1.16.0] - 2025-05-09
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Name resolution failures on generic routine invocations where later type parameters are constrained by earlier type parameters.
+- Type resolution failures on `as` casts where the type is returned from a routine invocation.
 
 ## [1.16.0] - 2025-05-09
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Name resolution failures on generic routine invocations where later type parameters are constrained by earlier type parameters.
 - Type resolution failures on `as` casts where the type is returned from a routine invocation.
+- Inaccurate type resolution when calling a constructor on a class reference type.
 
 ## [1.16.0] - 2025-05-09
 

--- a/delphi-frontend/src/main/java/au/com/integradev/delphi/antlr/ast/node/GenericDefinitionNodeImpl.java
+++ b/delphi-frontend/src/main/java/au/com/integradev/delphi/antlr/ast/node/GenericDefinitionNodeImpl.java
@@ -19,18 +19,12 @@
 package au.com.integradev.delphi.antlr.ast.node;
 
 import au.com.integradev.delphi.antlr.ast.visitors.DelphiParserVisitor;
-import au.com.integradev.delphi.type.generic.TypeParameterTypeImpl;
-import com.google.common.collect.ImmutableList;
 import java.util.List;
 import java.util.stream.Collectors;
 import org.antlr.runtime.Token;
-import org.sonar.plugins.communitydelphi.api.ast.ConstraintNode;
 import org.sonar.plugins.communitydelphi.api.ast.DelphiNode;
 import org.sonar.plugins.communitydelphi.api.ast.GenericDefinitionNode;
-import org.sonar.plugins.communitydelphi.api.ast.NameDeclarationNode;
 import org.sonar.plugins.communitydelphi.api.ast.TypeParameterNode;
-import org.sonar.plugins.communitydelphi.api.type.Constraint;
-import org.sonar.plugins.communitydelphi.api.type.Type.TypeParameterType;
 
 public final class GenericDefinitionNodeImpl extends DelphiNodeImpl
     implements GenericDefinitionNode {
@@ -53,22 +47,10 @@ public final class GenericDefinitionNodeImpl extends DelphiNodeImpl
   @Override
   public List<TypeParameter> getTypeParameters() {
     if (typeParameters == null) {
-      ImmutableList.Builder<TypeParameter> builder = ImmutableList.builder();
-
-      for (TypeParameterNode parameterNode : getTypeParameterNodes()) {
-        List<Constraint> constraints =
-            parameterNode.getConstraintNodes().stream()
-                .map(ConstraintNode::getConstraint)
-                .collect(Collectors.toUnmodifiableList());
-
-        for (NameDeclarationNode name : parameterNode.getTypeParameterNameNodes()) {
-          TypeParameterType type = TypeParameterTypeImpl.create(name.getImage(), constraints);
-          TypeParameter typeParameter = new TypeParameterImpl(name, type);
-          builder.add(typeParameter);
-        }
-      }
-
-      typeParameters = builder.build();
+      typeParameters =
+          getTypeParameterNodes().stream()
+              .flatMap(node -> node.getTypeParameters().stream())
+              .collect(Collectors.toList());
     }
 
     return typeParameters;
@@ -91,25 +73,5 @@ public final class GenericDefinitionNodeImpl extends DelphiNodeImpl
               + ">";
     }
     return image;
-  }
-
-  private static final class TypeParameterImpl implements TypeParameter {
-    private final NameDeclarationNode location;
-    private final TypeParameterType type;
-
-    private TypeParameterImpl(NameDeclarationNode location, TypeParameterType type) {
-      this.location = location;
-      this.type = type;
-    }
-
-    @Override
-    public NameDeclarationNode getLocation() {
-      return location;
-    }
-
-    @Override
-    public TypeParameterType getType() {
-      return type;
-    }
   }
 }

--- a/delphi-frontend/src/main/java/au/com/integradev/delphi/antlr/ast/visitors/SymbolTableVisitor.java
+++ b/delphi-frontend/src/main/java/au/com/integradev/delphi/antlr/ast/visitors/SymbolTableVisitor.java
@@ -88,7 +88,6 @@ import org.sonar.plugins.communitydelphi.api.ast.ForStatementNode;
 import org.sonar.plugins.communitydelphi.api.ast.ForToStatementNode;
 import org.sonar.plugins.communitydelphi.api.ast.FormalParameterNode.FormalParameterData;
 import org.sonar.plugins.communitydelphi.api.ast.GenericDefinitionNode;
-import org.sonar.plugins.communitydelphi.api.ast.GenericDefinitionNode.TypeParameter;
 import org.sonar.plugins.communitydelphi.api.ast.GotoStatementNode;
 import org.sonar.plugins.communitydelphi.api.ast.IfStatementNode;
 import org.sonar.plugins.communitydelphi.api.ast.ImplementationSectionNode;
@@ -402,12 +401,14 @@ public abstract class SymbolTableVisitor implements DelphiParserVisitor<Data> {
             .map(TypeConstraintNodeImpl.class::cast)
             .map(TypeConstraintNodeImpl::getTypeNode)
             .forEach(data.nameResolutionHelper::resolve);
-      }
 
-      for (TypeParameter typeParameter : definition.getTypeParameters()) {
-        NameDeclarationNode location = typeParameter.getLocation();
-        var declaration = new TypeParameterNameDeclarationImpl(location, typeParameter.getType());
-        data.addDeclaration(declaration, location);
+        parameterNode
+            .getTypeParameters()
+            .forEach(
+                param ->
+                    data.addDeclaration(
+                        new TypeParameterNameDeclarationImpl(param.getLocation(), param.getType()),
+                        param.getLocation()));
       }
     }
   }

--- a/delphi-frontend/src/main/java/au/com/integradev/delphi/symbol/resolve/ExpressionTypeResolver.java
+++ b/delphi-frontend/src/main/java/au/com/integradev/delphi/symbol/resolve/ExpressionTypeResolver.java
@@ -121,9 +121,14 @@ public final class ExpressionTypeResolver {
   }
 
   private static Type classReferenceValueType(Type type) {
+    if (type.isProcedural()) {
+      type = ((ProceduralType) type).returnType();
+    }
+
     if (type.isClassReference()) {
       return ((ClassReferenceType) type).classType();
     }
+
     return unknownType();
   }
 

--- a/delphi-frontend/src/main/java/org/sonar/plugins/communitydelphi/api/ast/TypeParameterNode.java
+++ b/delphi-frontend/src/main/java/org/sonar/plugins/communitydelphi/api/ast/TypeParameterNode.java
@@ -19,6 +19,7 @@
 package org.sonar.plugins.communitydelphi.api.ast;
 
 import java.util.List;
+import org.sonar.plugins.communitydelphi.api.ast.GenericDefinitionNode.TypeParameter;
 
 public interface TypeParameterNode extends DelphiNode {
   List<NameDeclarationNode> getTypeParameterNameNodes();
@@ -30,4 +31,6 @@ public interface TypeParameterNode extends DelphiNode {
   List<TypeReferenceNode> getTypeConstraintNodes();
 
   List<ConstraintNode> getConstraintNodes();
+
+  List<TypeParameter> getTypeParameters();
 }

--- a/delphi-frontend/src/test/java/au/com/integradev/delphi/executor/DelphiSymbolTableExecutorTest.java
+++ b/delphi-frontend/src/test/java/au/com/integradev/delphi/executor/DelphiSymbolTableExecutorTest.java
@@ -458,7 +458,7 @@ class DelphiSymbolTableExecutorTest {
   @Test
   void testClassReferenceConstructorTypeResolution() {
     execute("classReferences/ConstructorTypeResolution.pas");
-    verifyUsages(15, 10, reference(22, 2));
+    verifyUsages(15, 10, reference(22, 2), reference(23, 2));
     verifyUsages(8, 16, reference(22, 11));
   }
 

--- a/delphi-frontend/src/test/java/au/com/integradev/delphi/executor/DelphiSymbolTableExecutorTest.java
+++ b/delphi-frontend/src/test/java/au/com/integradev/delphi/executor/DelphiSymbolTableExecutorTest.java
@@ -517,7 +517,7 @@ class DelphiSymbolTableExecutorTest {
   @Test
   void testCastTypeResolution() {
     execute("typeResolution/Casts.pas");
-    verifyUsages(8, 14, reference(15, 12), reference(16, 16));
+    verifyUsages(8, 14, reference(22, 12), reference(23, 16), reference(24, 20));
   }
 
   @Test

--- a/delphi-frontend/src/test/java/au/com/integradev/delphi/executor/DelphiSymbolTableExecutorTest.java
+++ b/delphi-frontend/src/test/java/au/com/integradev/delphi/executor/DelphiSymbolTableExecutorTest.java
@@ -1100,7 +1100,8 @@ class DelphiSymbolTableExecutorTest {
   @Test
   void testGenericConstraints() {
     execute("generics/Constraint.pas");
-    verifyUsages(11, 14, reference(20, 25), reference(53, 8));
+    verifyUsages(11, 14, reference(20, 25), reference(58, 8));
+    verifyUsages(31, 20, reference(68, 8));
   }
 
   @Test

--- a/delphi-frontend/src/test/resources/au/com/integradev/delphi/symbol/classReferences/ConstructorTypeResolution.pas
+++ b/delphi-frontend/src/test/resources/au/com/integradev/delphi/symbol/classReferences/ConstructorTypeResolution.pas
@@ -20,6 +20,7 @@ end;
 procedure Test(Bar: Boolean; Baz: TMetaFoo);
 begin
   Proc(Baz.Create(Bar));
+  Proc(TMetaFoo.Create(Bar));
 end;
 
 end.

--- a/delphi-frontend/src/test/resources/au/com/integradev/delphi/symbol/generics/Constraint.pas
+++ b/delphi-frontend/src/test/resources/au/com/integradev/delphi/symbol/generics/Constraint.pas
@@ -26,6 +26,11 @@ interface
      procedure Test;
    end;
 
+   TMock = class(TObject)
+   public
+     class function Mock<I: IInterface; T: I>(out Raw: T): I;
+   end;
+
 implementation
 
 function TTest.SerializableClone: ISerializable;
@@ -60,4 +65,5 @@ var
 initialization
   Foo := TFoo<TTest>.Create(Test);
   Foo.Test;
+  TMock.Mock<ISerializable, TTest>(Test);
 end.

--- a/delphi-frontend/src/test/resources/au/com/integradev/delphi/symbol/typeResolution/Casts.pas
+++ b/delphi-frontend/src/test/resources/au/com/integradev/delphi/symbol/typeResolution/Casts.pas
@@ -8,12 +8,20 @@ type
     procedure Bar;
   end;
 
+  TFooClass = class of TFoo;
+
 implementation
+
+function GetClass: TFooClass;
+begin
+  Result := TFoo;
+end;
 
 procedure Test(Arg: TObject);
 begin
   TFoo(Arg).Bar;
   (Arg as TFoo).Bar;
+  (Arg as GetClass).Bar;
 end;
 
 end.


### PR DESCRIPTION
This PR fixes:

- Name resolution failures around generic routine invocations, mostly because we were not specializing type constraints
- Type resolution failures on `as` casts where the type expression is a function (e.g. `GetFooClass`)
- Type resolution failures on constructors for class reference types (e.g. `TFooClass.Create`, which creates a `TFoo`)