### PR TITLE
Fix grammar ambiguity between attributes and interface GUIDs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,12 +10,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - **API:** `TypeParameterNode::getTypeParameters` method.
+- **API:** `InterfaceTypeNode::getGuidExpression` method.
+- **API:** `AttributeNode::getExpression` method.
+
+### Deprecated
+
+- **API:** `InterfaceGuidNode` node type.
+- **API:** `InterfaceTypeNode::getGuid` method, use `getGuidExpression` instead.
+- **API:** `DelphiTokenType.GUID`, as the associated `InterfaceGuidNode` is no longer parsed.
 
 ### Fixed
 
 - Name resolution failures on generic routine invocations where later type parameters are constrained by earlier type parameters.
 - Type resolution failures on `as` casts where the type is returned from a routine invocation.
 - Inaccurate type resolution when calling a constructor on a class reference type.
+- Grammar ambiguity causing attributes to be misinterpreted as interface GUIDs.
 
 ## [1.16.0] - 2025-05-09
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **API:** `InterfaceTypeNode::getGuidExpression` method.
 - **API:** `AttributeNode::getExpression` method.
 
+### Changed
+
+- Issue locations no longer span the entire routine declaration in `RoutineName`.
+
 ### Deprecated
 
 - **API:** `InterfaceGuidNode` node type.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Name resolution failures on generic routine invocations where later type parameters are constrained by earlier type parameters.
+- Type resolution failures on property attribute lists.
+- Type resolution failures on implementation-local routine attribute lists.
 - Type resolution failures on `as` casts where the type is returned from a routine invocation.
 - Inaccurate type resolution when calling a constructor on a class reference type.
 - Grammar ambiguity causing attributes to be misinterpreted as interface GUIDs.

--- a/delphi-checks/src/main/java/au/com/integradev/delphi/checks/ForbiddenRoutineCheck.java
+++ b/delphi-checks/src/main/java/au/com/integradev/delphi/checks/ForbiddenRoutineCheck.java
@@ -20,6 +20,7 @@ package au.com.integradev.delphi.checks;
 
 import com.google.common.base.Splitter;
 import com.google.common.collect.ImmutableSortedSet;
+import java.util.Objects;
 import java.util.Set;
 import org.sonar.check.Rule;
 import org.sonar.check.RuleProperty;
@@ -76,7 +77,8 @@ public class ForbiddenRoutineCheck extends DelphiCheck {
       NameDeclaration declaration = occurrence.getNameDeclaration();
       if (declaration instanceof RoutineNameDeclaration
           && routinesSet.contains(((RoutineNameDeclaration) declaration).fullyQualifiedName())) {
-        reportIssue(context, attribute.getNameReference().getIdentifier(), message);
+        NameReferenceNode reference = Objects.requireNonNull(attribute.getNameReference());
+        reportIssue(context, reference.getIdentifier(), message);
       }
     }
     return super.visit(attribute, context);

--- a/delphi-checks/src/main/java/au/com/integradev/delphi/checks/InterfaceGuidCheck.java
+++ b/delphi-checks/src/main/java/au/com/integradev/delphi/checks/InterfaceGuidCheck.java
@@ -34,7 +34,7 @@ public class InterfaceGuidCheck extends DelphiCheck {
   public DelphiCheckContext visit(TypeDeclarationNode typeDeclaration, DelphiCheckContext context) {
     if (typeDeclaration.isInterface()) {
       InterfaceTypeNode interfaceType = (InterfaceTypeNode) typeDeclaration.getTypeNode();
-      if (!interfaceType.isForwardDeclaration() && interfaceType.getGuid() == null) {
+      if (!interfaceType.isForwardDeclaration() && interfaceType.getGuidExpression() == null) {
         reportIssue(context, typeDeclaration.getTypeNameNode(), MESSAGE);
       }
     }

--- a/delphi-checks/src/main/java/au/com/integradev/delphi/checks/MixedNamesCheck.java
+++ b/delphi-checks/src/main/java/au/com/integradev/delphi/checks/MixedNamesCheck.java
@@ -118,7 +118,12 @@ public class MixedNamesCheck extends DelphiCheck {
 
   @Override
   public DelphiCheckContext visit(AttributeNode attributeNode, DelphiCheckContext context) {
-    List<NameReferenceNode> nameReferences = attributeNode.getNameReference().flatten();
+    NameReferenceNode reference = attributeNode.getNameReference();
+    if (reference == null) {
+      return super.visit(attributeNode, context);
+    }
+
+    List<NameReferenceNode> nameReferences = reference.flatten();
 
     for (int i = 0; i + 1 < nameReferences.size(); i++) {
       context = super.visit(nameReferences.get(i), context);

--- a/delphi-checks/src/main/java/au/com/integradev/delphi/checks/RoutineNameCheck.java
+++ b/delphi-checks/src/main/java/au/com/integradev/delphi/checks/RoutineNameCheck.java
@@ -38,7 +38,7 @@ public class RoutineNameCheck extends DelphiCheck {
   @Override
   public DelphiCheckContext visit(RoutineDeclarationNode routine, DelphiCheckContext context) {
     if (isViolation(routine) && !isExcluded(routine)) {
-      reportIssue(context, routine, MESSAGE);
+      reportIssue(context, routine.getRoutineNameNode(), MESSAGE);
     }
     return super.visit(routine, context);
   }

--- a/delphi-frontend/src/main/antlr3/au/com/integradev/delphi/antlr/Delphi.g
+++ b/delphi-frontend/src/main/antlr3/au/com/integradev/delphi/antlr/Delphi.g
@@ -11,6 +11,7 @@ tokens {
   // Deprecated tokens
   //----------------------------------------------------------------------------
   AMPERSAND__deprecated;
+  TkGuid__deprecated;
 
   //----------------------------------------------------------------------------
   // Imaginary tokens
@@ -25,7 +26,6 @@ tokens {
   TkRecordVariantItem;
   TkRecordVariantTag;
   TkRecordExpressionItem;
-  TkGuid;
   TkClassParents;
   TkLocalDeclarations;
   TkCaseItem;
@@ -708,9 +708,7 @@ fieldDecl                    : attributeList? nameDeclarationList ':' varType po
                              ;
 classHelperType              : CLASS<ClassHelperTypeNodeImpl>^ HELPER classParent? FOR typeReference visibilitySection* END
                              ;
-interfaceType                : (INTERFACE<InterfaceTypeNodeImpl>^ | DISPINTERFACE<InterfaceTypeNodeImpl>^) classParent? (interfaceGuid? interfaceItems? END)?
-                             ;
-interfaceGuid                : lbrack expression rbrack -> ^(TkGuid<InterfaceGuidNodeImpl> expression)
+interfaceType                : (INTERFACE<InterfaceTypeNodeImpl>^ | DISPINTERFACE<InterfaceTypeNodeImpl>^) classParent? ((interfaceItems | attributeList?)  END)?
                              ;
 interfaceItems               : interfaceItem+ -> ^(TkVisibilitySection<VisibilitySectionNodeImpl> interfaceItem+)
                              ;
@@ -913,8 +911,8 @@ attributeList                : attributeGroup+
 attributeGroup               : lbrack (attribute ','?)+ rbrack
                              -> ^(TkAttributeGroup<AttributeGroupNodeImpl> attribute+)
                              ;
-attribute                    : (ASSEMBLY ':')? nameReference argumentList? (':' nameReference argumentList?)*
-                             -> ^(TkAttribute<AttributeNodeImpl> ASSEMBLY? nameReference argumentList? (':' nameReference argumentList?)*)
+attribute                    : (ASSEMBLY ':')? expression (':' expression)*
+                             -> ^(TkAttribute<AttributeNodeImpl> ASSEMBLY? expression (':' expression)*)
                              ;
 
 //----------------------------------------------------------------------------

--- a/delphi-frontend/src/main/java/au/com/integradev/delphi/antlr/ast/node/AttributeGroupNodeImpl.java
+++ b/delphi-frontend/src/main/java/au/com/integradev/delphi/antlr/ast/node/AttributeGroupNodeImpl.java
@@ -47,7 +47,7 @@ public final class AttributeGroupNodeImpl extends DelphiNodeImpl implements Attr
   @Override
   public String getImage() {
     return getAttributes().stream()
-        .map(attribute -> attribute.getNameReference().fullyQualifiedName())
+        .map(AttributeNode::getImage)
         .collect(Collectors.joining(", ", "[", "]"));
   }
 }

--- a/delphi-frontend/src/main/java/au/com/integradev/delphi/antlr/ast/node/AttributeListNodeImpl.java
+++ b/delphi-frontend/src/main/java/au/com/integradev/delphi/antlr/ast/node/AttributeListNodeImpl.java
@@ -25,10 +25,8 @@ import org.antlr.runtime.Token;
 import org.sonar.plugins.communitydelphi.api.ast.AttributeGroupNode;
 import org.sonar.plugins.communitydelphi.api.ast.AttributeListNode;
 import org.sonar.plugins.communitydelphi.api.ast.AttributeNode;
-import org.sonar.plugins.communitydelphi.api.symbol.declaration.NameDeclaration;
-import org.sonar.plugins.communitydelphi.api.symbol.declaration.TypeNameDeclaration;
+import org.sonar.plugins.communitydelphi.api.ast.ExpressionNode;
 import org.sonar.plugins.communitydelphi.api.type.Type;
-import org.sonar.plugins.communitydelphi.api.type.TypeFactory;
 
 public final class AttributeListNodeImpl extends DelphiNodeImpl implements AttributeListNode {
   public AttributeListNodeImpl(Token token) {
@@ -57,20 +55,9 @@ public final class AttributeListNodeImpl extends DelphiNodeImpl implements Attri
   @Override
   public List<Type> getAttributeTypes() {
     return getAttributes().stream()
-        .map(AttributeNode::getTypeNameOccurrence)
-        .map(
-            occurrence -> {
-              if (occurrence == null) {
-                return TypeFactory.unknownType();
-              }
-
-              NameDeclaration declaration = occurrence.getNameDeclaration();
-              if (!(declaration instanceof TypeNameDeclaration)) {
-                return TypeFactory.unknownType();
-              }
-
-              return ((TypeNameDeclaration) declaration).getType();
-            })
+        .map(AttributeNode::getExpression)
+        .map(ExpressionNode::getType)
+        .filter(type -> type.isUnknown() || type.isDescendantOf("System.TCustomAttribute"))
         .collect(Collectors.toList());
   }
 }

--- a/delphi-frontend/src/main/java/au/com/integradev/delphi/antlr/ast/node/InterfaceGuidNodeImpl.java
+++ b/delphi-frontend/src/main/java/au/com/integradev/delphi/antlr/ast/node/InterfaceGuidNodeImpl.java
@@ -22,6 +22,7 @@ import au.com.integradev.delphi.antlr.ast.visitors.DelphiParserVisitor;
 import org.antlr.runtime.Token;
 import org.sonar.plugins.communitydelphi.api.ast.InterfaceGuidNode;
 
+@SuppressWarnings("removal")
 public final class InterfaceGuidNodeImpl extends DelphiNodeImpl implements InterfaceGuidNode {
   public InterfaceGuidNodeImpl(Token token) {
     super(token);

--- a/delphi-frontend/src/main/java/au/com/integradev/delphi/antlr/ast/visitors/DelphiParserVisitor.java
+++ b/delphi-frontend/src/main/java/au/com/integradev/delphi/antlr/ast/visitors/DelphiParserVisitor.java
@@ -319,6 +319,7 @@ public interface DelphiParserVisitor<T> {
     return visit((DelphiNode) node, data);
   }
 
+  @SuppressWarnings("removal")
   default T visit(InterfaceGuidNode node, T data) {
     return visit((DelphiNode) node, data);
   }

--- a/delphi-frontend/src/main/java/au/com/integradev/delphi/antlr/ast/visitors/SymbolTableVisitor.java
+++ b/delphi-frontend/src/main/java/au/com/integradev/delphi/antlr/ast/visitors/SymbolTableVisitor.java
@@ -63,6 +63,7 @@ import java.util.Objects;
 import javax.annotation.Nullable;
 import org.sonar.plugins.communitydelphi.api.ast.AnonymousMethodNode;
 import org.sonar.plugins.communitydelphi.api.ast.ArrayConstructorNode;
+import org.sonar.plugins.communitydelphi.api.ast.AttributeListNode;
 import org.sonar.plugins.communitydelphi.api.ast.AttributeNode;
 import org.sonar.plugins.communitydelphi.api.ast.CaseItemStatementNode;
 import org.sonar.plugins.communitydelphi.api.ast.CaseStatementNode;
@@ -111,6 +112,7 @@ import org.sonar.plugins.communitydelphi.api.ast.RecordVariantTagNode;
 import org.sonar.plugins.communitydelphi.api.ast.RepeatStatementNode;
 import org.sonar.plugins.communitydelphi.api.ast.RoutineBodyNode;
 import org.sonar.plugins.communitydelphi.api.ast.RoutineDeclarationNode;
+import org.sonar.plugins.communitydelphi.api.ast.RoutineHeadingNode;
 import org.sonar.plugins.communitydelphi.api.ast.RoutineImplementationNode;
 import org.sonar.plugins.communitydelphi.api.ast.RoutineNameNode;
 import org.sonar.plugins.communitydelphi.api.ast.RoutineNode;
@@ -823,6 +825,23 @@ public abstract class SymbolTableVisitor implements DelphiParserVisitor<Data> {
                 arrayConstructor.getElements().forEach(element -> element.accept(this, data)));
     data.nameResolutionHelper.resolve(node);
     return data;
+  }
+
+  @Override
+  public Data visit(AttributeListNode node, Data data) {
+    DelphiNode parent = node.getParent();
+
+    if (parent instanceof PropertyNode) {
+      // Already resolved by the PropertyNode visit.
+      return data;
+    }
+
+    if (parent instanceof RoutineHeadingNode) {
+      // Already resolved by the RoutineNode visit.
+      return data;
+    }
+
+    return DelphiParserVisitor.super.visit(node, data);
   }
 
   @Override

--- a/delphi-frontend/src/main/java/au/com/integradev/delphi/symbol/resolve/ExpressionTypeResolver.java
+++ b/delphi-frontend/src/main/java/au/com/integradev/delphi/symbol/resolve/ExpressionTypeResolver.java
@@ -21,6 +21,7 @@ package au.com.integradev.delphi.symbol.resolve;
 import static org.sonar.plugins.communitydelphi.api.type.TypeFactory.unknownType;
 
 import au.com.integradev.delphi.operator.OperatorInvocableCollector;
+import au.com.integradev.delphi.symbol.occurrence.AttributeNameOccurrenceImpl;
 import au.com.integradev.delphi.type.TypeUtils;
 import au.com.integradev.delphi.type.intrinsic.IntrinsicReturnType;
 import com.google.common.collect.Iterables;
@@ -316,13 +317,15 @@ public final class ExpressionTypeResolver {
     if (declaration instanceof Typed) {
       Type type = ((Typed) declaration).getType();
 
-      if (declaration instanceof TypeNameDeclaration
-          || declaration instanceof TypeParameterNameDeclaration) {
-        type = typeFactory.classOf(null, type);
-      }
+      if (!(occurrence instanceof AttributeNameOccurrenceImpl)) {
+        if (declaration instanceof TypeNameDeclaration
+            || declaration instanceof TypeParameterNameDeclaration) {
+          type = typeFactory.classOf(null, type);
+        }
 
-      if (type.isProcedural() && occurrence.isExplicitInvocation()) {
-        type = ((ProceduralType) type).returnType();
+        if (type.isProcedural() && occurrence.isExplicitInvocation()) {
+          type = ((ProceduralType) type).returnType();
+        }
       }
 
       return type;

--- a/delphi-frontend/src/main/java/au/com/integradev/delphi/symbol/resolve/NameResolutionHelper.java
+++ b/delphi-frontend/src/main/java/au/com/integradev/delphi/symbol/resolve/NameResolutionHelper.java
@@ -170,7 +170,12 @@ public class NameResolutionHelper {
   public void resolve(AttributeNode attribute) {
     NameResolver resolver = createNameResolver();
     resolver.readAttribute(attribute);
-    resolver.addToSymbolTable();
+
+    if (resolver.getApproximateType().isDescendantOf("System.TCustomAttribute")) {
+      resolver.addToSymbolTable();
+    } else {
+      resolve(attribute.getExpression());
+    }
   }
 
   public void resolve(PrimaryExpressionNode expression) {

--- a/delphi-frontend/src/main/java/au/com/integradev/delphi/symbol/resolve/NameResolutionHelper.java
+++ b/delphi-frontend/src/main/java/au/com/integradev/delphi/symbol/resolve/NameResolutionHelper.java
@@ -167,6 +167,12 @@ public class NameResolutionHelper {
     resolver.addToSymbolTable();
   }
 
+  private void resolve(@Nullable AttributeListNode attributeList) {
+    if (attributeList != null) {
+      attributeList.getAttributes().forEach(this::resolve);
+    }
+  }
+
   public void resolve(AttributeNode attribute) {
     NameResolver resolver = createNameResolver();
     resolver.readAttribute(attribute);
@@ -255,6 +261,7 @@ public class NameResolutionHelper {
   }
 
   public void resolve(PropertyNode property) {
+    resolve(property.getAttributeList());
     resolve(property.getParameterListNode());
 
     TypeNode type = property.getTypeNode();
@@ -427,6 +434,7 @@ public class NameResolutionHelper {
   }
 
   private void resolveRoutine(RoutineNode routine) {
+    resolve(routine.getRoutineHeading().getAttributeList());
     SearchMode previousSearchMode = searchMode;
     try {
       searchMode = SearchMode.ROUTINE_HEADING;

--- a/delphi-frontend/src/main/java/au/com/integradev/delphi/symbol/resolve/NameResolver.java
+++ b/delphi-frontend/src/main/java/au/com/integradev/delphi/symbol/resolve/NameResolver.java
@@ -564,10 +564,15 @@ public class NameResolver {
   }
 
   void readAttribute(AttributeNode node) {
-    readNameReference(node.getNameReference(), true);
+    NameReferenceNode nameReference = node.getNameReference();
+    if (nameReference == null) {
+      return;
+    }
+
+    readNameReference(nameReference, true);
     addResolvedDeclaration();
 
-    List<NameReferenceNode> references = node.getNameReference().flatten();
+    List<NameReferenceNode> references = nameReference.flatten();
     NameReferenceNode lastReference = references.get(references.size() - 1);
 
     var attributeNameOccurrence = (AttributeNameOccurrenceImpl) lastReference.getNameOccurrence();

--- a/delphi-frontend/src/main/java/org/sonar/plugins/communitydelphi/api/ast/AttributeNode.java
+++ b/delphi-frontend/src/main/java/org/sonar/plugins/communitydelphi/api/ast/AttributeNode.java
@@ -32,14 +32,17 @@ public interface AttributeNode extends DelphiNode {
    */
   boolean isAssembly();
 
+  ExpressionNode getExpression();
+
+  @Nullable
   NameReferenceNode getNameReference();
+
+  @Nullable
+  ArgumentListNode getArgumentList();
 
   @Nullable
   NameOccurrence getTypeNameOccurrence();
 
   @Nullable
   NameOccurrence getConstructorNameOccurrence();
-
-  @Nullable
-  ArgumentListNode getArgumentList();
 }

--- a/delphi-frontend/src/main/java/org/sonar/plugins/communitydelphi/api/ast/InterfaceGuidNode.java
+++ b/delphi-frontend/src/main/java/org/sonar/plugins/communitydelphi/api/ast/InterfaceGuidNode.java
@@ -18,4 +18,5 @@
  */
 package org.sonar.plugins.communitydelphi.api.ast;
 
+@Deprecated(forRemoval = true)
 public interface InterfaceGuidNode extends DelphiNode {}

--- a/delphi-frontend/src/main/java/org/sonar/plugins/communitydelphi/api/ast/InterfaceTypeNode.java
+++ b/delphi-frontend/src/main/java/org/sonar/plugins/communitydelphi/api/ast/InterfaceTypeNode.java
@@ -18,8 +18,18 @@
  */
 package org.sonar.plugins.communitydelphi.api.ast;
 
+import javax.annotation.Nullable;
+
 public interface InterfaceTypeNode extends StructTypeNode {
   boolean isForwardDeclaration();
 
+  /**
+   * @deprecated Use {@link InterfaceTypeNode#getGuidExpression} instead.
+   */
+  @SuppressWarnings("removal")
+  @Deprecated(forRemoval = true)
   InterfaceGuidNode getGuid();
+
+  @Nullable
+  ExpressionNode getGuidExpression();
 }

--- a/delphi-frontend/src/test/java/au/com/integradev/delphi/executor/DelphiSymbolTableExecutorTest.java
+++ b/delphi-frontend/src/test/java/au/com/integradev/delphi/executor/DelphiSymbolTableExecutorTest.java
@@ -417,6 +417,13 @@ class DelphiSymbolTableExecutorTest {
   }
 
   @Test
+  void testGuid() {
+    execute("Guid.pas");
+    verifyUsages(7, 2, reference(11, 5));
+    verifyUsages(15, 2, reference(20, 16));
+  }
+
+  @Test
   void testBestEffortArguments() {
     execute("BestEffortArguments.pas");
     verifyUsages(9, 2, reference(11, 6), reference(11, 11));

--- a/delphi-frontend/src/test/resources/au/com/integradev/delphi/symbol/Guid.pas
+++ b/delphi-frontend/src/test/resources/au/com/integradev/delphi/symbol/Guid.pas
@@ -1,0 +1,27 @@
+unit Guid;
+
+interface
+
+
+const
+  Foo = '{4E89BDD0-B67C-4B4D-86E6-2C0D1DC7B237';
+
+type
+  TBar = interface
+    [Foo]
+  end;
+
+type
+  FooAttribute = class(TCustomAttribute)
+    // ...
+  end;
+
+  TBaz = interface
+    [assembly : Foo, '{4E89BDD0-B67C-4B4D-86E6-2C0D1DC7B237']
+    procedure Flarp;
+  end;
+
+
+implementation
+
+end.


### PR DESCRIPTION
This PR fixes a significant grammar ambiguity between attributes and interface GUIDs.

Consider the following:
```pas
const
  FooAttribute = class(TCustomAttribute)
  end;

  TBar = interface
    [Foo]
    procedure Baz;
  end;
```

At the moment, the grammar interprets `[Foo]` as a GUID containing constant expression `Foo`.
It should actually be interpreted as a custom attribute on the `Baz` procedure.

In the process of resolving this ambiguity, I discovered some awful details.
```pas
const
  FooAttribute = class(TCustomAttribute)
  end;

  TBar = interface
    [Foo, '{4E89BDD0-B67C-4B4D-86E6-2C0D1DC7B237']
    procedure Baz;
  end;
```

This applies `FooAttribute` to `Baz` and applies the GUID to `TBar`.
Based on this, it's clear that the custom attribute and GUID syntax are really one and the same, and the ambiguity was a result of us pretending they were different nodes in the first place.

There's some gnarly technical details here about who should actually owns the attribute node in a case like this.

Here's how it shook out:
- Any `AttributeListNode` as the first child of an `InterfaceTypeNode` is owned by that parent type node.
- The first declaration (routine/property) within the `InterfaceTypeNode` must look upward to find that attribute list in `RoutineHeadingNode::getAttributeList` and `PropertyNode::getAttributeList`.
- There is no further disambiguation of ownership, even if we can statically determine that the final attribute of the first attribute group of the attribute list is a GUID.

This would have been easier to handle with #261.