### PR TITLE
Add changelog entry for `IntrinsicType.OPENSTRING` enum value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **API:** `TypeParameterNode::getTypeParameters` method.
 - **API:** `InterfaceTypeNode::getGuidExpression` method.
 - **API:** `AttributeNode::getExpression` method.
+- **API:** `IntrinsicType.OPENSTRING` enum value.
 
 ### Changed
 


### PR DESCRIPTION
I'll also update the release notes for 1.17.0.