### PR TITLE
Fix ambiguous type comparisons from variants to real types 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Ambiguous type comparisons from variants to real types.
+
 ## [1.17.1] - 2025-06-10
 
 ### Fixed

--- a/delphi-frontend/src/main/java/au/com/integradev/delphi/symbol/resolve/InvocationResolver.java
+++ b/delphi-frontend/src/main/java/au/com/integradev/delphi/symbol/resolve/InvocationResolver.java
@@ -563,7 +563,6 @@ public class InvocationResolver {
   private static boolean isCurrencyCompConflict(Type currencyComp, Type real) {
     currencyComp = TypeUtils.findBaseType(currencyComp);
     return (currencyComp.is(IntrinsicType.CURRENCY) || currencyComp.is(IntrinsicType.COMP))
-        && real.isReal()
         && currencyComp.size() >= real.size();
   }
 

--- a/delphi-frontend/src/test/java/au/com/integradev/delphi/symbol/resolve/InvocationResolverTest.java
+++ b/delphi-frontend/src/test/java/au/com/integradev/delphi/symbol/resolve/InvocationResolverTest.java
@@ -365,9 +365,7 @@ class InvocationResolverTest {
     assertResolved(type(VARIANT), TypeFactory.untypedType(), type(UNICODESTRING));
     assertResolved(type(VARIANT), TypeFactory.untypedType(), type(BOOLEAN));
 
-    assertResolved(type(VARIANT), type(EXTENDED), type(CURRENCY));
     assertResolved(type(VARIANT), type(CURRENCY), type(UINT64));
-    assertResolved(type(VARIANT), type(EXTENDED), type(COMP));
     assertResolved(type(VARIANT), type(COMP), type(UINT64));
 
     assertAmbiguous(type(VARIANT), type(CURRENCY), type(DOUBLE));
@@ -416,6 +414,19 @@ class InvocationResolverTest {
 
     assertIncompatible(type(VARIANT), type(WIDECHAR));
     assertIncompatible(type(VARIANT), type(ANSICHAR));
+  }
+
+  @Test
+  void testVariantToExtendedCurrencyShouldResolveOnDcc32() {
+    assertResolved(type(VARIANT), type(EXTENDED), type(CURRENCY));
+    assertResolved(type(VARIANT), type(EXTENDED), type(COMP));
+  }
+
+  @Test
+  void testVariantToExtendedCurrencyShouldBeAmbiguousOnDcc64() {
+    factory = new TypeFactoryImpl(Toolchain.DCC64, DelphiProperties.COMPILER_VERSION_DEFAULT);
+    assertAmbiguous(type(VARIANT), type(EXTENDED), type(CURRENCY));
+    assertAmbiguous(type(VARIANT), type(EXTENDED), type(COMP));
   }
 
   @Test


### PR DESCRIPTION
`Variant` -> `Double` and `Variant` -> `Extended` were being treated as equally good conversions on toolchains where `Double` and `Extended` are the same size, such as `DCC64`.