### PR TITLE
Migrate from OSSRH to the Central Portal

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,16 +20,16 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: '17'
-          server-id: ossrh
-          server-username: MAVEN_USERNAME
-          server-password: MAVEN_CENTRAL_TOKEN
+          server-id: central
+          server-username: MAVEN_CENTRAL_PORTAL_USERNAME
+          server-password: MAVEN_CENTRAL_PORTAL_PASSWORD
           gpg-private-key: ${{ secrets.MAVEN_GPG_PRIVATE_KEY }}
           gpg-passphrase: MAVEN_GPG_PASSPHRASE
       - name: Publish to Maven Central
         run: mvn deploy -DskipTests -Prelease --batch-mode --no-transfer-progress
         env:
-          MAVEN_USERNAME: ${{ secrets.OSSRH_USERNAME }}
-          MAVEN_CENTRAL_TOKEN: ${{ secrets.OSSRH_TOKEN }}
+          MAVEN_CENTRAL_PORTAL_USERNAME: ${{ secrets.MAVEN_CENTRAL_PORTAL_USERNAME }}
+          MAVEN_CENTRAL_PORTAL_PASSWORD: ${{ secrets.MAVEN_CENTRAL_PORTAL_PASSWORD }}
           MAVEN_GPG_PASSPHRASE: ${{ secrets.MAVEN_GPG_PASSPHRASE }}
       - name: Get version from tag
         id: get-version

--- a/pom.xml
+++ b/pom.xml
@@ -148,7 +148,7 @@
     <source-plugin.version>3.3.0</source-plugin.version>
     <javadoc-plugin.version>3.6.3</javadoc-plugin.version>
     <gpg-plugin.version>3.1.0</gpg-plugin.version>
-    <nexus-staging-plugin.version>1.6.13</nexus-staging-plugin.version>
+    <central-publishing-plugin.version>0.8.0</central-publishing-plugin.version>
   </properties>
 
   <dependencyManagement>
@@ -534,14 +534,14 @@
             </executions>
           </plugin>
           <plugin>
-            <groupId>org.sonatype.plugins</groupId>
-            <artifactId>nexus-staging-maven-plugin</artifactId>
-            <version>${nexus-staging-plugin.version}</version>
+            <groupId>org.sonatype.central</groupId>
+            <artifactId>central-publishing-maven-plugin</artifactId>
+            <version>${central-publishing-plugin.version}</version>
             <extensions>true</extensions>
             <configuration>
-              <serverId>ossrh</serverId>
-              <nexusUrl>https://s01.oss.sonatype.org/</nexusUrl>
-              <autoReleaseAfterClose>true</autoReleaseAfterClose>
+              <publishingServerId>central</publishingServerId>
+              <autoPublish>true</autoPublish>
+              <waitUntil>published</waitUntil>
             </configuration>
           </plugin>
         </plugins>


### PR DESCRIPTION
This PR unblocks the July release by migrating from OSSRH (EOL) to the Central Portal.
Repository secrets have already been updated.

Successful run here (including staging/validation, but of course not publishing):
https://github.com/cirras/sonar-delphi/actions/runs/16017755532/job/45187583849