### PR TITLE
Add full support for `HIGHCHARUNICODE`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Support for implicit `Self` in `Initialize` and `Finalize` operators, introduced in Delphi 13.
 - Support for `DCCARM64EC` toolchain, introduced in Delphi 13.1.
 - `NoreturnContract` analysis rule, which flags `noreturn` routines that return normally.
+- Full support for the `HIGHCHARUNICODE` compiler directive.
+- Support for the `DCC_CodePage` property in dproj files.
+- `sonar.delphi.codePage` property to specify the code page that will be used to interpret ANSI data.
 
 ### Fixed
 

--- a/delphi-frontend/src/main/java/au/com/integradev/delphi/DelphiProperties.java
+++ b/delphi-frontend/src/main/java/au/com/integradev/delphi/DelphiProperties.java
@@ -34,6 +34,7 @@ public final class DelphiProperties {
   public static final String COMPILER_TOOLCHAIN_KEY = "sonar.delphi.toolchain";
   public static final String COMPILER_VERSION_KEY = "sonar.delphi.compilerVersion";
   public static final String SEARCH_PATH_KEY = "sonar.delphi.searchPath";
+  public static final String CODE_PAGE_KEY = "sonar.delphi.codePage";
   public static final String CONDITIONAL_DEFINES_KEY = "sonar.delphi.conditionalDefines";
   public static final String CONDITIONAL_UNDEFINES_KEY = "sonar.delphi.conditionalUndefines";
   public static final String UNIT_SCOPE_NAMES_KEY = "sonar.delphi.unitScopeNames";
@@ -123,6 +124,15 @@ public final class DelphiProperties {
                 "List of directories to search for include files and unit imports."
                     + " Each path may be absolute or relative to the project base directory.")
             .multiValues(true)
+            .onQualifiers(Qualifiers.PROJECT)
+            .build(),
+        PropertyDefinition.builder(DelphiProperties.CODE_PAGE_KEY)
+            .category(DELPHI_CATEGORY)
+            .subCategory(PROJECT_OPTIONS_SUBCATEGORY)
+            .name("Code page")
+            .description(
+                " Code page to use when interpreting ANSI data. Use 0 for the system code page."
+                    + " Defaults to DCC_CodePage from project files.")
             .onQualifiers(Qualifiers.PROJECT)
             .build(),
         PropertyDefinition.builder(DelphiProperties.CONDITIONAL_DEFINES_KEY)

--- a/delphi-frontend/src/main/java/au/com/integradev/delphi/antlr/ast/node/TextLiteralNodeImpl.java
+++ b/delphi-frontend/src/main/java/au/com/integradev/delphi/antlr/ast/node/TextLiteralNodeImpl.java
@@ -20,6 +20,9 @@ package au.com.integradev.delphi.antlr.ast.node;
 
 import au.com.integradev.delphi.antlr.ast.visitors.DelphiParserVisitor;
 import au.com.integradev.delphi.preprocessor.TextBlockLineEndingMode;
+import au.com.integradev.delphi.utils.CharsetUtils;
+import java.nio.ByteBuffer;
+import java.nio.charset.Charset;
 import java.util.ArrayDeque;
 import java.util.Deque;
 import java.util.stream.Collectors;
@@ -28,6 +31,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.Strings;
 import org.sonar.plugins.communitydelphi.api.ast.DelphiNode;
 import org.sonar.plugins.communitydelphi.api.ast.TextLiteralNode;
+import org.sonar.plugins.communitydelphi.api.directive.SwitchDirective.SwitchKind;
 import org.sonar.plugins.communitydelphi.api.token.DelphiTokenType;
 import org.sonar.plugins.communitydelphi.api.type.IntrinsicType;
 import org.sonar.plugins.communitydelphi.api.type.Type;
@@ -51,9 +55,15 @@ public final class TextLiteralNodeImpl extends DelphiNodeImpl implements TextLit
 
   @Override
   public Type getType() {
-    IntrinsicType intrinsic =
-        (getValue().length() == 1) ? IntrinsicType.CHAR : IntrinsicType.STRING;
+    boolean isSingleCharacter = (getValue().length() == 1);
 
+    if (hasAnsiCharacterEscape()) {
+      return isSingleCharacter
+          ? getTypeFactory().getIntrinsic(IntrinsicType.ANSICHAR)
+          : getTypeFactory().getIntrinsic(IntrinsicType.ANSISTRING);
+    }
+
+    IntrinsicType intrinsic = isSingleCharacter ? IntrinsicType.CHAR : IntrinsicType.STRING;
     return getTypeFactory().getIntrinsic(intrinsic);
   }
 
@@ -167,7 +177,42 @@ public final class TextLiteralNodeImpl extends DelphiNodeImpl implements TextLit
     return imageBuilder.toString();
   }
 
-  private static char characterEscapeToChar(String image) {
+  private boolean isHighCharUnicode() {
+    return getAst()
+        .getDelphiFile()
+        .getCompilerSwitchRegistry()
+        .isActiveSwitch(SwitchKind.HIGHCHARUNICODE, getTokenIndex());
+  }
+
+  private boolean hasAnsiCharacterEscape() {
+    if (isHighCharUnicode()) {
+      return false;
+    }
+
+    return getChildren().stream()
+        .filter(child -> child.getTokenType() == DelphiTokenType.CHARACTER_ESCAPE_CODE)
+        .map(DelphiNode::getImage)
+        .mapToInt(TextLiteralNodeImpl::parseCharacterEscape)
+        .anyMatch(TextLiteralNodeImpl::isAnsiCodePoint);
+  }
+
+  private char characterEscapeToChar(String image) {
+    int codePoint = parseCharacterEscape(image);
+
+    if (!isHighCharUnicode() && isAnsiCodePoint(codePoint)) {
+      var buffer = ByteBuffer.allocate(1).put((byte) codePoint).flip();
+      return getAnsiCharset().decode(buffer).get();
+    }
+
+    return (char) codePoint;
+  }
+
+  private Charset getAnsiCharset() {
+    Charset ansiCharset = getAst().getDelphiFile().getAnsiCharset();
+    return ansiCharset != null ? ansiCharset : CharsetUtils.nativeCharset();
+  }
+
+  private static int parseCharacterEscape(String image) {
     image = image.substring(1);
     int radix = 10;
 
@@ -181,12 +226,15 @@ public final class TextLiteralNodeImpl extends DelphiNodeImpl implements TextLit
         image = image.substring(1);
         break;
       default:
-        // do nothing
+        // Do nothing
     }
 
     image = StringUtils.remove(image, '_');
+    return Integer.parseInt(image, radix);
+  }
 
-    return (char) Integer.parseInt(image, radix);
+  private static boolean isAnsiCodePoint(int codePoint) {
+    return codePoint >= 128 && codePoint <= 255;
   }
 
   @Override

--- a/delphi-frontend/src/main/java/au/com/integradev/delphi/file/DefaultDelphiFile.java
+++ b/delphi-frontend/src/main/java/au/com/integradev/delphi/file/DefaultDelphiFile.java
@@ -21,6 +21,7 @@ package au.com.integradev.delphi.file;
 import au.com.integradev.delphi.preprocessor.CompilerSwitchRegistry;
 import au.com.integradev.delphi.preprocessor.TextBlockLineEndingModeRegistry;
 import java.io.File;
+import java.nio.charset.Charset;
 import java.util.List;
 import org.sonar.plugins.communitydelphi.api.ast.DelphiAst;
 import org.sonar.plugins.communitydelphi.api.token.DelphiToken;
@@ -36,6 +37,7 @@ class DefaultDelphiFile implements DelphiFile {
   private TextBlockLineEndingModeRegistry textBlockLineEndingModeRegistry;
   private TypeFactory typeFactory;
   private String encoding;
+  private Charset ansiCharset;
 
   DefaultDelphiFile() {
     // package-private constructor
@@ -54,6 +56,11 @@ class DefaultDelphiFile implements DelphiFile {
   @Override
   public String getSourceCodeFileEncoding() {
     return encoding;
+  }
+
+  @Override
+  public Charset getAnsiCharset() {
+    return ansiCharset;
   }
 
   @Override
@@ -96,6 +103,10 @@ class DefaultDelphiFile implements DelphiFile {
 
   void setSourceCodeEncoding(String encoding) {
     this.encoding = encoding;
+  }
+
+  void setAnsiCharset(Charset ansiCharset) {
+    this.ansiCharset = ansiCharset;
   }
 
   void setAst(DelphiAst ast) {

--- a/delphi-frontend/src/main/java/au/com/integradev/delphi/file/DefaultDelphiFileConfig.java
+++ b/delphi-frontend/src/main/java/au/com/integradev/delphi/file/DefaultDelphiFileConfig.java
@@ -20,12 +20,14 @@ package au.com.integradev.delphi.file;
 
 import au.com.integradev.delphi.preprocessor.DelphiPreprocessorFactory;
 import au.com.integradev.delphi.preprocessor.search.SearchPath;
+import java.nio.charset.Charset;
 import java.util.Set;
 import javax.annotation.Nullable;
 import org.sonar.plugins.communitydelphi.api.type.TypeFactory;
 
 public class DefaultDelphiFileConfig implements DelphiFileConfig {
   private final String encoding;
+  private final Charset ansiCharset;
   private final DelphiPreprocessorFactory preprocessorFactory;
   private final TypeFactory typeFactory;
   private final SearchPath searchPath;
@@ -34,12 +36,14 @@ public class DefaultDelphiFileConfig implements DelphiFileConfig {
 
   DefaultDelphiFileConfig(
       String encoding,
+      Charset ansiCharset,
       DelphiPreprocessorFactory preprocessorFactory,
       TypeFactory typeFactory,
       SearchPath searchPath,
       Set<String> definitions,
       boolean skipImplementation) {
     this.encoding = encoding;
+    this.ansiCharset = ansiCharset;
     this.preprocessorFactory = preprocessorFactory;
     this.typeFactory = typeFactory;
     this.searchPath = searchPath;
@@ -51,6 +55,11 @@ public class DefaultDelphiFileConfig implements DelphiFileConfig {
   @Override
   public String getEncoding() {
     return encoding;
+  }
+
+  @Override
+  public Charset getAnsiCharset() {
+    return ansiCharset;
   }
 
   @Override

--- a/delphi-frontend/src/main/java/au/com/integradev/delphi/file/DelphiFile.java
+++ b/delphi-frontend/src/main/java/au/com/integradev/delphi/file/DelphiFile.java
@@ -35,6 +35,7 @@ import au.com.integradev.delphi.utils.DelphiUtils;
 import com.google.common.base.Splitter;
 import java.io.File;
 import java.io.IOException;
+import java.nio.charset.Charset;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -62,6 +63,8 @@ public interface DelphiFile {
 
   List<DelphiToken> getComments();
 
+  Charset getAnsiCharset();
+
   CompilerSwitchRegistry getCompilerSwitchRegistry();
 
   TextBlockLineEndingModeRegistry getTextBlockLineEndingModeRegistry();
@@ -85,6 +88,7 @@ public interface DelphiFile {
         config =
             DelphiFile.createConfig(
                 inputFile.charset().name(),
+                config.getAnsiCharset(),
                 config.getPreprocessorFactory(),
                 config.getTypeFactory(),
                 config.getSearchPath(),
@@ -109,15 +113,18 @@ public interface DelphiFile {
 
   static DelphiFileConfig createConfig(
       String encoding,
+      Charset ansiCharset,
       DelphiPreprocessorFactory preprocessorFactory,
       TypeFactory typeFactory,
       SearchPath searchPath,
       Set<String> definitions) {
-    return createConfig(encoding, preprocessorFactory, typeFactory, searchPath, definitions, false);
+    return createConfig(
+        encoding, ansiCharset, preprocessorFactory, typeFactory, searchPath, definitions, false);
   }
 
   static DelphiFileConfig createConfig(
       @Nullable String encoding,
+      Charset ansiCharset,
       DelphiPreprocessorFactory preprocessorFactory,
       TypeFactory typeFactory,
       SearchPath searchPath,
@@ -125,6 +132,7 @@ public interface DelphiFile {
       boolean shouldSkipImplementation) {
     return new DefaultDelphiFileConfig(
         encoding,
+        ansiCharset,
         preprocessorFactory,
         typeFactory,
         searchPath,
@@ -146,6 +154,7 @@ public interface DelphiFile {
       DelphiPreprocessor preprocessor = preprocess(fileStream, config);
       delphiFile.setSourceCodeFile(sourceFile);
       delphiFile.setSourceCodeEncoding(fileStream.getEncoding());
+      delphiFile.setAnsiCharset(config.getAnsiCharset());
       delphiFile.setTypeFactory(config.getTypeFactory());
       delphiFile.setAst(createAST(delphiFile, preprocessor.getTokenStream(), config));
       delphiFile.setCompilerSwitchRegistry(preprocessor.getCompilerSwitchRegistry());

--- a/delphi-frontend/src/main/java/au/com/integradev/delphi/file/DelphiFileConfig.java
+++ b/delphi-frontend/src/main/java/au/com/integradev/delphi/file/DelphiFileConfig.java
@@ -20,6 +20,7 @@ package au.com.integradev.delphi.file;
 
 import au.com.integradev.delphi.preprocessor.DelphiPreprocessorFactory;
 import au.com.integradev.delphi.preprocessor.search.SearchPath;
+import java.nio.charset.Charset;
 import java.util.Set;
 import javax.annotation.Nullable;
 import org.sonar.plugins.communitydelphi.api.type.TypeFactory;
@@ -32,6 +33,13 @@ public interface DelphiFileConfig {
    */
   @Nullable
   String getEncoding();
+
+  /**
+   * Returns the charset that will be used for interpreting ANSI data in the source file
+   *
+   * @return ANSI charset
+   */
+  Charset getAnsiCharset();
 
   /**
    * Returns the preprocessor factory, which can be used to create a preprocessor for this platform

--- a/delphi-frontend/src/main/java/au/com/integradev/delphi/msbuild/DelphiProject.java
+++ b/delphi-frontend/src/main/java/au/com/integradev/delphi/msbuild/DelphiProject.java
@@ -26,6 +26,7 @@ import java.nio.file.Path;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import javax.annotation.Nullable;
 
 public interface DelphiProject {
   Set<String> getConditionalDefines();
@@ -43,4 +44,7 @@ public interface DelphiProject {
   List<Path> getBrowsingPathDirectories();
 
   Map<String, String> getUnitAliases();
+
+  @Nullable
+  Integer getCodePage();
 }

--- a/delphi-frontend/src/main/java/au/com/integradev/delphi/msbuild/DelphiProjectFactory.java
+++ b/delphi-frontend/src/main/java/au/com/integradev/delphi/msbuild/DelphiProjectFactory.java
@@ -58,6 +58,7 @@ final class DelphiProjectFactory {
     project.setLibraryPath(createLibraryPathDirectories(state, projectDirectory));
     project.setBrowsingPath(createBrowsingPathDirectories(state, projectDirectory));
     project.setUnitAliases(createUnitAliases(state));
+    project.setCodePage(createCodePage(state));
     project.setSourceFiles(sourceFiles);
 
     return project;
@@ -149,6 +150,20 @@ final class DelphiProjectFactory {
     return Collections.unmodifiableMap(result);
   }
 
+  private static Integer createCodePage(MSBuildState state) {
+    String codePage = state.getProperty("DCC_CodePage");
+    if (codePage == null) {
+      return null;
+    }
+
+    try {
+      return Integer.parseInt(codePage);
+    } catch (NumberFormatException e) {
+      LOG.warn("Invalid DCC_CodePage value: {}", codePage);
+      return null;
+    }
+  }
+
   private static List<String> propertyList(String value) {
     if (value == null) {
       return Collections.emptyList();
@@ -165,6 +180,7 @@ final class DelphiProjectFactory {
     private List<Path> libraryPathDirectories = Collections.emptyList();
     private List<Path> browsingPathDirectories = Collections.emptyList();
     private Map<String, String> unitAliases = Collections.emptyMap();
+    private Integer codePage;
 
     private void setDefinitions(Set<String> definitions) {
       this.definitions = ImmutableSortedSet.copyOf(String.CASE_INSENSITIVE_ORDER, definitions);
@@ -197,6 +213,10 @@ final class DelphiProjectFactory {
 
     private void setUnitAliases(Map<String, String> unitAliases) {
       this.unitAliases = ImmutableSortedMap.copyOf(unitAliases, String.CASE_INSENSITIVE_ORDER);
+    }
+
+    private void setCodePage(Integer codePage) {
+      this.codePage = codePage;
     }
 
     @Override
@@ -237,6 +257,12 @@ final class DelphiProjectFactory {
     @Override
     public Map<String, String> getUnitAliases() {
       return unitAliases;
+    }
+
+    @Nullable
+    @Override
+    public Integer getCodePage() {
+      return codePage;
     }
   }
 }

--- a/delphi-frontend/src/main/java/au/com/integradev/delphi/msbuild/DelphiProjectHelper.java
+++ b/delphi-frontend/src/main/java/au/com/integradev/delphi/msbuild/DelphiProjectHelper.java
@@ -32,6 +32,8 @@ import au.com.integradev.delphi.compiler.Toolchain;
 import au.com.integradev.delphi.core.Delphi;
 import au.com.integradev.delphi.enviroment.EnvironmentProjVariableProvider;
 import au.com.integradev.delphi.enviroment.EnvironmentVariableProvider;
+import au.com.integradev.delphi.utils.CharsetUtils;
+import au.com.integradev.delphi.utils.CharsetUtils.UnsupportedCodePageException;
 import au.com.integradev.delphi.utils.DelphiUtils;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.Iterables;
@@ -57,6 +59,7 @@ import org.sonar.api.batch.fs.FileSystem;
 import org.sonar.api.batch.fs.InputFile;
 import org.sonar.api.config.Configuration;
 import org.sonar.api.scanner.ScannerSide;
+import org.sonar.plugins.communitydelphi.api.type.CodePages;
 import org.sonarsource.api.sonarlint.SonarLintSide;
 
 @ScannerSide
@@ -78,6 +81,7 @@ public class DelphiProjectHelper {
   private final Set<String> conditionalDefines;
   private final Set<String> unitScopeNames;
   private final Map<String, String> unitAliases;
+  private Charset ansiCharset;
   private boolean indexedProjects;
 
   /**
@@ -104,6 +108,7 @@ public class DelphiProjectHelper {
     this.conditionalDefines = getPredefinedConditionalDefines();
     this.unitScopeNames = getSetFromSettings(DelphiProperties.UNIT_SCOPE_NAMES_KEY);
     this.unitAliases = getUnitAliasesFromSettings();
+    this.ansiCharset = null;
     this.effectiveEnvironmentVariableProvider =
         () ->
             new EnvironmentProjVariableProvider(environmentProjPath(), environmentVariableProvider);
@@ -183,6 +188,79 @@ public class DelphiProjectHelper {
     return PredefinedConditionals.getConditionalDefines(toolchain, compilerVersion);
   }
 
+  private Integer getCodePageFromSettings() {
+    String codePage = settings.get(DelphiProperties.CODE_PAGE_KEY).orElse(null);
+    if (StringUtils.isBlank(codePage)) {
+      return null;
+    }
+
+    try {
+      return Integer.parseInt(codePage.trim());
+    } catch (NumberFormatException e) {
+      LOG.warn("Ignoring invalid {} value: {}", DelphiProperties.CODE_PAGE_KEY, codePage);
+      return null;
+    }
+  }
+
+  private Charset resolveAnsiCharset() {
+    Integer configuredCodePage = getCodePageFromSettings();
+    if (configuredCodePage != null) {
+      return charsetForCodePage(configuredCodePage);
+    }
+
+    List<Integer> codePages =
+        projects.stream()
+            .map(DelphiProject::getCodePage)
+            .map(codePage -> codePage == null ? CodePages.CP_ACP : codePage)
+            .distinct()
+            .sorted()
+            .collect(Collectors.toUnmodifiableList());
+
+    List<Integer> explicitCodePages =
+        codePages.stream()
+            .filter(codePage -> !codePage.equals(CodePages.CP_ACP))
+            .collect(Collectors.toUnmodifiableList());
+
+    boolean useAcp =
+        codePages.isEmpty()
+            || codePages.stream().anyMatch(codePage -> codePage.equals(CodePages.CP_ACP));
+
+    boolean conflict = false;
+    Charset result = CharsetUtils.nativeCharset();
+
+    if (explicitCodePages.size() > 1) {
+      conflict = true;
+    } else if (explicitCodePages.size() == 1) {
+      Charset charset = charsetForCodePage(explicitCodePages.get(0));
+      if (useAcp) {
+        conflict = !charset.equals(result);
+      } else {
+        result = charset;
+      }
+    }
+
+    if (conflict) {
+      LOG.warn(
+          "Conflicting DCC_CodePage values found in dproj files: {}. Falling back to the system"
+              + " encoding. Set {} to choose the code page used for analysis.",
+          codePages,
+          DelphiProperties.CODE_PAGE_KEY);
+    }
+
+    return result;
+  }
+
+  private Charset charsetForCodePage(int codePage) {
+    try {
+      return CharsetUtils.charsetForCodePage(codePage);
+    } catch (UnsupportedCodePageException e) {
+      LOG.warn(
+          "Ignoring unsupported code page value: {}. Falling back to the system encoding.",
+          codePage);
+      return CharsetUtils.nativeCharset();
+    }
+  }
+
   private void indexProjects() {
     if (indexedProjects) {
       return;
@@ -221,6 +299,7 @@ public class DelphiProjectHelper {
 
     conditionalDefines.addAll(getSetFromSettings(DelphiProperties.CONDITIONAL_DEFINES_KEY));
     conditionalDefines.removeAll(getSetFromSettings(DelphiProperties.CONDITIONAL_UNDEFINES_KEY));
+    ansiCharset = resolveAnsiCharset();
 
     indexedProjects = true;
   }
@@ -375,6 +454,16 @@ public class DelphiProjectHelper {
   public Map<String, String> getUnitAliases() {
     indexProjects();
     return unitAliases;
+  }
+
+  /**
+   * Gets the charset for the ANSI code page specified in settings and project files
+   *
+   * @return ANSI charset
+   */
+  public Charset getAnsiCharset() {
+    indexProjects();
+    return ansiCharset;
   }
 
   public List<Path> getReferencedFiles() {

--- a/delphi-frontend/src/main/java/au/com/integradev/delphi/symbol/SymbolTableBuilder.java
+++ b/delphi-frontend/src/main/java/au/com/integradev/delphi/symbol/SymbolTableBuilder.java
@@ -30,7 +30,9 @@ import au.com.integradev.delphi.preprocessor.DelphiPreprocessorFactory;
 import au.com.integradev.delphi.preprocessor.search.SearchPath;
 import au.com.integradev.delphi.symbol.declaration.UnitImportNameDeclarationImpl;
 import au.com.integradev.delphi.symbol.scope.FileScopeImpl;
+import au.com.integradev.delphi.utils.CharsetUtils;
 import java.io.IOException;
+import java.nio.charset.Charset;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Collections;
@@ -73,6 +75,7 @@ public class SymbolTableBuilder {
   private final HashMap<String, UnitData> allUnitsByName = new HashMap<>();
   private final Set<Path> unitPaths = new HashSet<>();
   private String encoding;
+  private Charset ansiCharset = CharsetUtils.nativeCharset();
   private DelphiPreprocessorFactory preprocessorFactory;
   private TypeFactory typeFactory;
   private Path standardLibraryPath;
@@ -108,6 +111,11 @@ public class SymbolTableBuilder {
 
   public SymbolTableBuilder encoding(String encoding) {
     this.encoding = encoding;
+    return this;
+  }
+
+  public SymbolTableBuilder ansiCharset(Charset ansiCharset) {
+    this.ansiCharset = ansiCharset;
     return this;
   }
 
@@ -262,6 +270,7 @@ public class SymbolTableBuilder {
   private DelphiFileConfig createFileConfig(UnitData unit, boolean shouldSkipImplementation) {
     return DelphiFile.createConfig(
         sourceFileUnits.contains(unit) ? encoding : null,
+        ansiCharset,
         preprocessorFactory,
         typeFactory,
         searchPath,

--- a/delphi-frontend/src/main/java/au/com/integradev/delphi/utils/CharsetUtils.java
+++ b/delphi-frontend/src/main/java/au/com/integradev/delphi/utils/CharsetUtils.java
@@ -1,0 +1,204 @@
+/*
+ * Sonar Delphi Plugin
+ * Copyright (C) 2026 Integrated Application Development
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02
+ */
+package au.com.integradev.delphi.utils;
+
+import com.google.common.collect.ImmutableMap;
+import java.nio.charset.Charset;
+import java.util.Map;
+import org.sonar.plugins.communitydelphi.api.type.CodePages;
+
+public final class CharsetUtils {
+  private static final String NATIVE_ENCODING_PROPERTY = "native.encoding";
+  private static final Map<Integer, String> CODE_PAGE_CHARSET_NAMES =
+      ImmutableMap.<Integer, String>builder()
+          .put(37, "IBM037")
+          .put(437, "IBM437")
+          .put(500, "IBM500")
+          .put(708, "ASMO-708")
+          .put(720, "x-IBM720")
+          .put(737, "x-IBM737")
+          .put(775, "IBM775")
+          .put(850, "IBM850")
+          .put(852, "IBM852")
+          .put(855, "IBM855")
+          .put(857, "IBM857")
+          .put(858, "IBM00858")
+          .put(860, "IBM860")
+          .put(861, "IBM861")
+          .put(862, "IBM862")
+          .put(863, "IBM863")
+          .put(864, "IBM864")
+          .put(865, "IBM865")
+          .put(866, "IBM866")
+          .put(869, "IBM869")
+          .put(870, "IBM870")
+          .put(874, "x-windows-874")
+          .put(875, "x-IBM875")
+          .put(932, "windows-31j")
+          .put(936, "GBK")
+          .put(949, "x-windows-949")
+          .put(950, "Big5")
+          .put(1026, "IBM1026")
+          .put(1047, "IBM1047")
+          .put(1140, "IBM01140")
+          .put(1141, "IBM01141")
+          .put(1142, "IBM01142")
+          .put(1143, "IBM01143")
+          .put(1144, "IBM01144")
+          .put(1145, "IBM01145")
+          .put(1146, "IBM01146")
+          .put(1147, "IBM01147")
+          .put(1148, "IBM01148")
+          .put(1149, "IBM01149")
+          .put(1200, "UTF-16LE")
+          .put(1201, "UTF-16BE")
+          .put(1250, "windows-1250")
+          .put(1251, "windows-1251")
+          .put(1252, "windows-1252")
+          .put(1253, "windows-1253")
+          .put(1254, "windows-1254")
+          .put(1255, "windows-1255")
+          .put(1256, "windows-1256")
+          .put(1257, "windows-1257")
+          .put(1258, "windows-1258")
+          .put(1361, "x-Johab")
+          .put(10000, "x-MacRoman")
+          .put(10001, "x-MacJapanese") // Unsupported on standard JVMs
+          .put(10002, "x-MacChineseTrad") // Unsupported on standard JVMs
+          .put(10003, "x-MacKorean") // Unsupported on standard JVMs
+          .put(10004, "x-MacArabic")
+          .put(10005, "x-MacHebrew")
+          .put(10006, "x-MacGreek")
+          .put(10007, "x-MacCyrillic")
+          .put(10008, "x-MacChineseSimp") // Unsupported on standard JVMs
+          .put(10010, "x-MacRomania")
+          .put(10017, "x-MacUkraine")
+          .put(10021, "x-MacThai")
+          .put(10029, "x-MacCentralEurope")
+          .put(10079, "x-MacIceland")
+          .put(10081, "x-MacTurkish")
+          .put(10082, "x-MacCroatian")
+          .put(12000, "UTF-32LE")
+          .put(12001, "UTF-32BE")
+          .put(20000, "x-EUC-TW")
+          .put(20001, "x-cp20001") // Unsupported on standard JVMs (Traditional Chinese TCA Taiwan)
+          .put(20002, "x-cp20002") // Unsupported on standard JVMs (Traditional Chinese Eten)
+          .put(20003, "x-cp20003") // Unsupported on standard JVMs (IBM EBCDIC Korea Extended)
+          .put(20004, "x-cp20004") // Unsupported on standard JVMs (IBM EBCDIC Japan)
+          .put(20005, "x-cp20005") // Unsupported on standard JVMs (IBM EBCDIC Japan variant)
+          .put(20105, "US-ASCII") // Equivalent mapping (x-IA5)
+          .put(20106, "x-IA5-German") // Unsupported on standard JVMs
+          .put(20107, "x-IA5-Swedish") // Unsupported on standard JVMs
+          .put(20108, "x-IA5-Norwegian") // Unsupported on standard JVMs
+          .put(20127, "US-ASCII")
+          .put(20261, "x-cp20261") // Unsupported on standard JVMs (ITU T.61)
+          .put(20269, "x-cp20269") // Unsupported on standard JVMs (ITU T.51)
+          .put(20273, "IBM273")
+          .put(20277, "IBM277")
+          .put(20278, "IBM278")
+          .put(20280, "IBM280")
+          .put(20284, "IBM284")
+          .put(20285, "IBM285")
+          .put(20290, "IBM290")
+          .put(20297, "IBM297")
+          .put(20420, "IBM420")
+          .put(20423, "IBM423") // Supported on IBM JVMs
+          .put(20424, "IBM424")
+          .put(20833, "x-EBCDIC-KoreanExtended") // Unsupported on standard JVMs
+          .put(20838, "IBM-Thai")
+          .put(20866, "KOI8-R")
+          .put(20871, "IBM871")
+          .put(20880, "IBM880") // Supported on IBM JVMs
+          .put(20905, "IBM905") // Supported on IBM JVMs
+          .put(20924, "IBM00924") // Supported on IBM JVMs
+          .put(20932, "EUC-JP")
+          .put(20936, "GB2312")
+          .put(20949, "EUC-KR")
+          .put(21025, "x-IBM1025")
+          .put(21866, "KOI8-U")
+          .put(28591, "ISO-8859-1")
+          .put(28592, "ISO-8859-2")
+          .put(28593, "ISO-8859-3")
+          .put(28594, "ISO-8859-4")
+          .put(28595, "ISO-8859-5")
+          .put(28596, "ISO-8859-6")
+          .put(28597, "ISO-8859-7")
+          .put(28598, "ISO-8859-8")
+          .put(28599, "ISO-8859-9")
+          .put(28603, "ISO-8859-13")
+          .put(28605, "ISO-8859-15")
+          .put(29001, "x-Europa") // Unsupported on standard JVMs
+          .put(38598, "ISO-8859-8")
+          .put(50220, "ISO-2022-JP")
+          .put(50221, "x-windows-50221")
+          .put(50222, "x-windows-50221")
+          .put(50225, "ISO-2022-KR")
+          .put(50227, "x-ISO-2022-CN-GB")
+          .put(51932, "EUC-JP")
+          .put(51936, "EUC-CN")
+          .put(51949, "EUC-KR")
+          .put(52936, "hz-gb-2312") // Unsupported on standard JVMs
+          .put(54936, "GB18030")
+          .put(57002, "x-ISCII91") // We map all ISCII codepages to the generic x-ISCII91 charset
+          .put(57003, "x-ISCII91")
+          .put(57004, "x-ISCII91")
+          .put(57005, "x-ISCII91")
+          .put(57006, "x-ISCII91")
+          .put(57007, "x-ISCII91")
+          .put(57008, "x-ISCII91")
+          .put(57009, "x-ISCII91")
+          .put(57010, "x-ISCII91")
+          .put(57011, "x-ISCII91")
+          .put(65000, "UTF-7") // Unsupported on all JVMs
+          .put(65001, "UTF-8")
+          .buildOrThrow();
+
+  private CharsetUtils() {
+    // Utility class
+  }
+
+  public static final class UnsupportedCodePageException extends IllegalArgumentException {
+    UnsupportedCodePageException(int codePage) {
+      super("Unsupported code page: " + codePage);
+    }
+  }
+
+  public static Charset nativeCharset() {
+    String charsetName = System.getProperty(NATIVE_ENCODING_PROPERTY);
+
+    if (charsetName != null && !charsetName.isBlank() && Charset.isSupported(charsetName)) {
+      return Charset.forName(charsetName);
+    }
+
+    return Charset.defaultCharset();
+  }
+
+  public static Charset charsetForCodePage(int codePage) {
+    if (codePage == CodePages.CP_ACP) {
+      return nativeCharset();
+    }
+
+    String charsetName = CODE_PAGE_CHARSET_NAMES.get(codePage);
+    if (charsetName == null || !Charset.isSupported(charsetName)) {
+      throw new UnsupportedCodePageException(codePage);
+    }
+
+    return Charset.forName(charsetName);
+  }
+}

--- a/delphi-frontend/src/test/java/au/com/integradev/delphi/DelphiPropertiesTest.java
+++ b/delphi-frontend/src/test/java/au/com/integradev/delphi/DelphiPropertiesTest.java
@@ -25,6 +25,6 @@ import org.junit.jupiter.api.Test;
 class DelphiPropertiesTest {
   @Test
   void testGetProperties() {
-    assertThat(DelphiProperties.getProperties()).hasSize(14);
+    assertThat(DelphiProperties.getProperties()).hasSize(15);
   }
 }

--- a/delphi-frontend/src/test/java/au/com/integradev/delphi/antlr/GrammarTest.java
+++ b/delphi-frontend/src/test/java/au/com/integradev/delphi/antlr/GrammarTest.java
@@ -276,6 +276,7 @@ class GrammarTest {
     fileConfig =
         DelphiFile.createConfig(
             StandardCharsets.UTF_8.name(),
+            StandardCharsets.UTF_8,
             new DelphiPreprocessorFactory(
                 DelphiProperties.COMPILER_VERSION_DEFAULT, Platform.WINDOWS),
             TypeFactoryUtils.defaultFactory(),

--- a/delphi-frontend/src/test/java/au/com/integradev/delphi/antlr/ast/node/TextLiteralNodeImplTest.java
+++ b/delphi-frontend/src/test/java/au/com/integradev/delphi/antlr/ast/node/TextLiteralNodeImplTest.java
@@ -20,19 +20,35 @@ package au.com.integradev.delphi.antlr.ast.node;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import au.com.integradev.delphi.antlr.DelphiLexer;
 import au.com.integradev.delphi.antlr.ast.DelphiAstImpl;
 import au.com.integradev.delphi.file.DelphiFile;
+import au.com.integradev.delphi.preprocessor.CompilerSwitchRegistry;
 import au.com.integradev.delphi.preprocessor.TextBlockLineEndingMode;
 import au.com.integradev.delphi.preprocessor.TextBlockLineEndingModeRegistry;
+import au.com.integradev.delphi.utils.types.TypeFactoryUtils;
+import java.nio.charset.Charset;
 import org.antlr.runtime.CommonToken;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.sonar.plugins.communitydelphi.api.ast.DelphiNode;
+import org.sonar.plugins.communitydelphi.api.directive.SwitchDirective.SwitchKind;
+import org.sonar.plugins.communitydelphi.api.type.IntrinsicType;
 
 class TextLiteralNodeImplTest {
+  private boolean highCharUnicode;
+
+  @BeforeEach
+  void setup() {
+    highCharUnicode = false;
+  }
+
   @Test
   void testMultilineImage() {
     String image =
@@ -50,7 +66,7 @@ class TextLiteralNodeImplTest {
 
     TextLiteralNodeImpl node = new TextLiteralNodeImpl(DelphiLexer.TkTextLiteral);
     node.setParent(DelphiAstImpl.create(delphiFile, mock()));
-    node.addChild(createNode(DelphiLexer.TkMultilineString, image));
+    node.addChild(commonNode(DelphiLexer.TkMultilineString, image));
 
     assertThat(node.getImage()).isEqualTo(image);
     assertThat(node.getValue())
@@ -59,43 +75,111 @@ class TextLiteralNodeImplTest {
     assertThat(node.isMultiline()).isTrue();
   }
 
-  @Test
-  void testGetImageWithCharacterEscapes() {
-    TextLiteralNodeImpl node = new TextLiteralNodeImpl(DelphiLexer.TkTextLiteral);
-    node.addChild(createNode(DelphiLexer.TkQuotedString, "'F'"));
-    node.addChild(createNode(DelphiLexer.TkCharacterEscapeCode, "#111"));
-    node.addChild(createNode(DelphiLexer.TkCharacterEscapeCode, "#111"));
-    node.addChild(createNode(DelphiLexer.TkQuotedString, "'B'"));
-    node.addChild(createNode(DelphiLexer.TkCharacterEscapeCode, "#$61"));
-    node.addChild(createNode(DelphiLexer.TkCharacterEscapeCode, "#$72"));
-    node.addChild(createNode(DelphiLexer.TkQuotedString, "'B'"));
-    node.addChild(createNode(DelphiLexer.TkCharacterEscapeCode, "#%01100001"));
-    node.addChild(createNode(DelphiLexer.TkCharacterEscapeCode, "#%01111010"));
+  @ParameterizedTest(name = "HIGHCHARUNICODE = {0}")
+  @ValueSource(booleans = {true, false})
+  void testGetImageWithCharacterEscapes(boolean highCharUnicode) {
+    this.highCharUnicode = highCharUnicode;
 
-    assertThat(node.getImage()).isEqualTo("'F'#111#111'B'#$61#$72'B'#%01100001#%01111010");
-    assertThat(node.getValue()).isEqualTo(node.getImageWithoutQuotes()).isEqualTo("FooBarBaz");
+    TextLiteralNodeImpl node = textNode();
+
+    node.addChild(commonNode(DelphiLexer.TkQuotedString, "'F'"));
+    node.addChild(commonNode(DelphiLexer.TkCharacterEscapeCode, "#111"));
+    node.addChild(commonNode(DelphiLexer.TkCharacterEscapeCode, "#111"));
+    node.addChild(commonNode(DelphiLexer.TkQuotedString, "'B'"));
+    node.addChild(commonNode(DelphiLexer.TkCharacterEscapeCode, "#$61"));
+    node.addChild(commonNode(DelphiLexer.TkCharacterEscapeCode, "#$72"));
+    node.addChild(commonNode(DelphiLexer.TkQuotedString, "'B'"));
+    node.addChild(commonNode(DelphiLexer.TkCharacterEscapeCode, "#$80"));
+    node.addChild(commonNode(DelphiLexer.TkCharacterEscapeCode, "#$98"));
+    node.addChild(commonNode(DelphiLexer.TkCharacterEscapeCode, "#$A3"));
+    node.addChild(commonNode(DelphiLexer.TkCharacterEscapeCode, "#$20AC"));
+    node.addChild(commonNode(DelphiLexer.TkQuotedString, "'az'"));
+
     assertThat(node.isMultiline()).isFalse();
+    assertThat(node.getImage()).isEqualTo("'F'#111#111'B'#$61#$72'B'#$80#$98#$A3#$20AC'az'");
+    if (highCharUnicode) {
+      assertThat(node.getValue())
+          .isEqualTo(node.getImageWithoutQuotes())
+          .isEqualTo("FooBarB\u0080\u0098£€az");
+      assertThat(node.getType().is(IntrinsicType.UNICODESTRING)).isTrue();
+    } else {
+      assertThat(node.getValue())
+          .isEqualTo(node.getImageWithoutQuotes())
+          .isEqualTo("FooBarB€˜£€az");
+      assertThat(node.getType().is(IntrinsicType.ANSISTRING)).isTrue();
+    }
+  }
+
+  @Test
+  void testGetImageWithBinaryCharacterEscapes() {
+    TextLiteralNodeImpl node = textNode();
+
+    node.addChild(commonNode(DelphiLexer.TkQuotedString, "'F'"));
+    node.addChild(commonNode(DelphiLexer.TkCharacterEscapeCode, "#%1101111"));
+    node.addChild(commonNode(DelphiLexer.TkCharacterEscapeCode, "#%1101111"));
+
+    assertThat(node.getImage()).isEqualTo("'F'#%1101111#%1101111");
+    assertThat(node.getValue()).isEqualTo("Foo");
+    assertThat(node.getType().is(IntrinsicType.UNICODESTRING)).isTrue();
+  }
+
+  @ParameterizedTest(name = "HIGHCHARUNICODE = {0}")
+  @ValueSource(booleans = {true, false})
+  void testSingleCharacterEscapeType(boolean highCharUnicode) {
+    this.highCharUnicode = highCharUnicode;
+
+    TextLiteralNodeImpl lowChar = textNode();
+    lowChar.addChild(commonNode(DelphiLexer.TkCharacterEscapeCode, "#127"));
+
+    TextLiteralNodeImpl highChar = textNode();
+    highChar.addChild(commonNode(DelphiLexer.TkCharacterEscapeCode, "#128"));
+
+    assertThat(lowChar.getType().is(IntrinsicType.WIDECHAR)).isTrue();
+
+    if (highCharUnicode) {
+      assertThat(highChar.getType().is(IntrinsicType.WIDECHAR)).isTrue();
+    } else {
+      assertThat(highChar.getType().is(IntrinsicType.ANSICHAR)).isTrue();
+    }
   }
 
   @Test
   void testGetImageWithCaretNotation() {
-    TextLiteralNodeImpl node = new TextLiteralNodeImpl(DelphiLexer.TkTextLiteral);
-    node.addChild(createNode(DelphiLexer.TkQuotedString, "'F'"));
-    node.addChild(createNode(DelphiLexer.TkEscapedCharacter, "/"));
-    node.addChild(createNode(DelphiLexer.TkEscapedCharacter, "/"));
-    node.addChild(createNode(DelphiLexer.TkQuotedString, "'B'"));
-    node.addChild(createNode(DelphiLexer.TkEscapedCharacter, "!"));
-    node.addChild(createNode(DelphiLexer.TkEscapedCharacter, "2"));
-    node.addChild(createNode(DelphiLexer.TkQuotedString, "'B'"));
-    node.addChild(createNode(DelphiLexer.TkEscapedCharacter, "!"));
-    node.addChild(createNode(DelphiLexer.TkEscapedCharacter, ":"));
+    TextLiteralNodeImpl node = textNode();
+    node.addChild(commonNode(DelphiLexer.TkQuotedString, "'F'"));
+    node.addChild(commonNode(DelphiLexer.TkEscapedCharacter, "/"));
+    node.addChild(commonNode(DelphiLexer.TkEscapedCharacter, "/"));
+    node.addChild(commonNode(DelphiLexer.TkQuotedString, "'B'"));
+    node.addChild(commonNode(DelphiLexer.TkEscapedCharacter, "!"));
+    node.addChild(commonNode(DelphiLexer.TkEscapedCharacter, "2"));
+    node.addChild(commonNode(DelphiLexer.TkQuotedString, "'B'"));
+    node.addChild(commonNode(DelphiLexer.TkEscapedCharacter, "!"));
+    node.addChild(commonNode(DelphiLexer.TkEscapedCharacter, ":"));
 
     assertThat(node.getImage()).isEqualTo("'F'^/^/'B'^!^2'B'^!^:");
     assertThat(node.getValue()).isEqualTo(node.getImageWithoutQuotes()).isEqualTo("FooBarBaz");
     assertThat(node.isMultiline()).isFalse();
   }
 
-  private static DelphiNode createNode(int tokenType, String image) {
+  private static DelphiNode commonNode(int tokenType, String image) {
     return new CommonDelphiNodeImpl(new CommonToken(tokenType, image));
+  }
+
+  private TextLiteralNodeImpl textNode() {
+    var registry = mock(CompilerSwitchRegistry.class);
+    when(registry.isActiveSwitch(eq(SwitchKind.HIGHCHARUNICODE), anyInt()))
+        .thenAnswer(invocation -> highCharUnicode);
+
+    var file = mock(DelphiFile.class);
+    when(file.getCompilerSwitchRegistry()).thenReturn(registry);
+    when(file.getTypeFactory()).thenReturn(TypeFactoryUtils.defaultFactory());
+    when(file.getAnsiCharset()).thenReturn(Charset.forName("windows-1252"));
+
+    var ast = mock(DelphiAstImpl.class);
+    when(ast.getDelphiFile()).thenReturn(file);
+
+    TextLiteralNodeImpl node = new TextLiteralNodeImpl(DelphiLexer.TkTextLiteral);
+    node.setParent(ast);
+    return node;
   }
 }

--- a/delphi-frontend/src/test/java/au/com/integradev/delphi/executor/DelphiSymbolTableExecutorTest.java
+++ b/delphi-frontend/src/test/java/au/com/integradev/delphi/executor/DelphiSymbolTableExecutorTest.java
@@ -581,9 +581,10 @@ class DelphiSymbolTableExecutorTest {
   @Test
   void testCharsTypeInference() {
     execute("typeInference/Chars.pas");
-    verifyUsages(15, 10, reference(47, 2), reference(49, 2), reference(50, 2));
-    verifyUsages(20, 10, reference(48, 2));
-    verifyUsages(30, 10, reference(52, 2), reference(53, 2));
+    verifyUsages(15, 10, reference(47, 2), reference(49, 2));
+    verifyUsages(20, 10, reference(48, 2), reference(50, 2));
+    verifyUsages(25, 10, reference(53, 2));
+    verifyUsages(30, 10, reference(51, 2), reference(52, 2));
   }
 
   @Test

--- a/delphi-frontend/src/test/java/au/com/integradev/delphi/file/DelphiFileTest.java
+++ b/delphi-frontend/src/test/java/au/com/integradev/delphi/file/DelphiFileTest.java
@@ -67,6 +67,7 @@ class DelphiFileTest {
     DelphiFileConfig config =
         DelphiFile.createConfig(
             StandardCharsets.UTF_8.name(),
+            StandardCharsets.UTF_8,
             new DelphiPreprocessorFactory(
                 DelphiProperties.COMPILER_VERSION_DEFAULT, Platform.WINDOWS),
             TypeFactoryUtils.defaultFactory(),
@@ -84,6 +85,7 @@ class DelphiFileTest {
     DelphiFileConfig config =
         DelphiFile.createConfig(
             StandardCharsets.UTF_8.name(),
+            StandardCharsets.UTF_8,
             new DelphiPreprocessorFactory(
                 DelphiProperties.COMPILER_VERSION_DEFAULT, Platform.WINDOWS),
             TypeFactoryUtils.defaultFactory(),
@@ -101,6 +103,7 @@ class DelphiFileTest {
     DelphiFileConfig config =
         DelphiFile.createConfig(
             StandardCharsets.UTF_8.name(),
+            StandardCharsets.UTF_8,
             new DelphiPreprocessorFactory(
                 DelphiProperties.COMPILER_VERSION_DEFAULT, Platform.WINDOWS),
             TypeFactoryUtils.defaultFactory(),
@@ -120,6 +123,7 @@ class DelphiFileTest {
     DelphiFileConfig config =
         DelphiFile.createConfig(
             StandardCharsets.UTF_8.name(),
+            StandardCharsets.UTF_8,
             new DelphiPreprocessorFactory(
                 DelphiProperties.COMPILER_VERSION_DEFAULT, Platform.WINDOWS),
             TypeFactoryUtils.defaultFactory(),

--- a/delphi-frontend/src/test/java/au/com/integradev/delphi/msbuild/DelphiProjectFactoryTest.java
+++ b/delphi-frontend/src/test/java/au/com/integradev/delphi/msbuild/DelphiProjectFactoryTest.java
@@ -63,6 +63,9 @@ class DelphiProjectFactoryTest {
   private static final String BROWSING_PATH_PROJECT =
       "/au/com/integradev/delphi/msbuild/BrowsingPath.dproj";
 
+  private static final String CODE_PAGE_PROJECT =
+      "/au/com/integradev/delphi/projects/CodePageProject/Utf8.dproj";
+
   private EnvironmentVariableProvider environmentVariableProvider;
 
   private DelphiProject createProject(String resource) {
@@ -190,5 +193,12 @@ class DelphiProjectFactoryTest {
 
     assertThat(project.getBrowsingPathDirectories())
         .containsExactly(DelphiUtils.getResource("/au/com/integradev/delphi").toPath());
+  }
+
+  @Test
+  void testCodePageProject() {
+    DelphiProject project = createProject(CODE_PAGE_PROJECT);
+
+    assertThat(project.getCodePage()).isEqualTo(65001);
   }
 }

--- a/delphi-frontend/src/test/java/au/com/integradev/delphi/msbuild/DelphiProjectHelperTest.java
+++ b/delphi-frontend/src/test/java/au/com/integradev/delphi/msbuild/DelphiProjectHelperTest.java
@@ -36,12 +36,15 @@ import au.com.integradev.delphi.enviroment.EnvironmentVariableProvider;
 import au.com.integradev.delphi.utils.DelphiUtils;
 import java.io.File;
 import java.io.IOException;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Collections;
 import java.util.Map;
 import java.util.Optional;
 import org.assertj.core.util.Arrays;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -58,9 +61,11 @@ class DelphiProjectHelperTest {
   private EnvironmentVariableProvider environmentVariableProvider;
   private String installationPath;
   private String standardLibraryPath;
+  private String originalNativeEncoding;
 
   @BeforeEach
   void setup() throws IOException {
+    originalNativeEncoding = System.getProperty("native.encoding");
     settings = mock(Configuration.class);
     fs = new DefaultFileSystem(BASE_DIR);
     environmentVariableProvider = mock(EnvironmentVariableProvider.class);
@@ -83,6 +88,15 @@ class DelphiProjectHelperTest {
     when(settings.getStringArray(DelphiProperties.CONDITIONAL_DEFINES_KEY)).thenReturn(defines);
   }
 
+  @AfterEach
+  void restoreNativeEncoding() {
+    if (originalNativeEncoding == null) {
+      System.clearProperty("native.encoding");
+    } else {
+      System.setProperty("native.encoding", originalNativeEncoding);
+    }
+  }
+
   @Test
   void testInvalidIncludesShouldBeSkipped() {
     String[] includes = {"EmptyProject/empty", "BadSyntaxProject", "BadPath/Spooky"};
@@ -96,14 +110,7 @@ class DelphiProjectHelperTest {
 
   @Test
   void testDprojProject() {
-    InputFile inputFile =
-        TestInputFileBuilder.create(
-                Delphi.KEY,
-                BASE_DIR,
-                DelphiUtils.getResource(
-                    PROJECTS_PATH + "SimpleProject/dproj/SimpleDelphiProject.dproj"))
-            .build();
-    fs.add(inputFile);
+    addInputFile(PROJECTS_PATH + "SimpleProject/dproj/SimpleDelphiProject.dproj");
 
     DelphiProjectHelper delphiProjectHelper =
         new DelphiProjectHelper(settings, fs, environmentVariableProvider);
@@ -136,13 +143,7 @@ class DelphiProjectHelperTest {
 
   @Test
   void testWorkgroupProject() {
-    InputFile inputFile =
-        TestInputFileBuilder.create(
-                Delphi.KEY,
-                BASE_DIR,
-                DelphiUtils.getResource(PROJECTS_PATH + "SimpleProject/workgroup/All.groupproj"))
-            .build();
-    fs.add(inputFile);
+    addInputFile(PROJECTS_PATH + "SimpleProject/workgroup/All.groupproj");
 
     DelphiProjectHelper delphiProjectHelper =
         new DelphiProjectHelper(settings, fs, environmentVariableProvider);
@@ -318,6 +319,110 @@ class DelphiProjectHelperTest {
   }
 
   @Test
+  void testProjectCodePageProvidesAnsiCharset() {
+    addInputFile(PROJECTS_PATH + "CodePageProject/Utf8.dproj");
+
+    DelphiProjectHelper delphiProjectHelper =
+        new DelphiProjectHelper(settings, fs, environmentVariableProvider);
+
+    assertThat(delphiProjectHelper.getAnsiCharset()).isEqualTo(StandardCharsets.UTF_8);
+  }
+
+  @Test
+  void testConfiguredCodePageOverridesProjectCodePage() {
+    addInputFile(PROJECTS_PATH + "CodePageProject/Utf8.dproj");
+    when(settings.get(DelphiProperties.CODE_PAGE_KEY)).thenReturn(Optional.of("1252"));
+
+    DelphiProjectHelper delphiProjectHelper =
+        new DelphiProjectHelper(settings, fs, environmentVariableProvider);
+
+    assertThat(delphiProjectHelper.getAnsiCharset().name()).isEqualTo("windows-1252");
+  }
+
+  @Test
+  void testConfiguredAcpCodePageUsesNativeCharset() {
+    setNativeEncoding(StandardCharsets.ISO_8859_1.name());
+    when(settings.get(DelphiProperties.CODE_PAGE_KEY)).thenReturn(Optional.of("0"));
+
+    DelphiProjectHelper delphiProjectHelper =
+        new DelphiProjectHelper(settings, fs, environmentVariableProvider);
+
+    assertThat(delphiProjectHelper.getAnsiCharset()).isEqualTo(StandardCharsets.ISO_8859_1);
+  }
+
+  @Test
+  void testInvalidConfiguredCodePageFallsBackToProjectCodePage() {
+    addInputFile(PROJECTS_PATH + "CodePageProject/Utf8.dproj");
+    when(settings.get(DelphiProperties.CODE_PAGE_KEY)).thenReturn(Optional.of("not-a-number"));
+
+    DelphiProjectHelper delphiProjectHelper =
+        new DelphiProjectHelper(settings, fs, environmentVariableProvider);
+
+    assertThat(delphiProjectHelper.getAnsiCharset()).isEqualTo(StandardCharsets.UTF_8);
+  }
+
+  @Test
+  void testUnsupportedConfiguredCodePageFallsBackToNativeCharset() {
+    setNativeEncoding(StandardCharsets.ISO_8859_1.name());
+
+    when(settings.get(DelphiProperties.CODE_PAGE_KEY)).thenReturn(Optional.of("99999"));
+
+    DelphiProjectHelper delphiProjectHelper =
+        new DelphiProjectHelper(settings, fs, environmentVariableProvider);
+
+    assertThat(delphiProjectHelper.getAnsiCharset()).isEqualTo(StandardCharsets.ISO_8859_1);
+  }
+
+  @Test
+  void testNoConfiguredOrProjectCodePagesFallBackToNativeCharset() {
+    setNativeEncoding(StandardCharsets.ISO_8859_1.name());
+
+    DelphiProjectHelper delphiProjectHelper =
+        new DelphiProjectHelper(settings, fs, environmentVariableProvider);
+
+    assertThat(delphiProjectHelper.getAnsiCharset()).isEqualTo(StandardCharsets.ISO_8859_1);
+  }
+
+  @Test
+  void testConflictingProjectCodePagesFallBackToNativeCharset() {
+    setNativeEncoding(StandardCharsets.ISO_8859_1.name());
+
+    addInputFile(PROJECTS_PATH + "CodePageProject/Utf8.dproj");
+    addInputFile(PROJECTS_PATH + "CodePageProject/Windows1252.dproj");
+
+    DelphiProjectHelper delphiProjectHelper =
+        new DelphiProjectHelper(settings, fs, environmentVariableProvider);
+
+    assertThat(delphiProjectHelper.getAnsiCharset()).isEqualTo(StandardCharsets.ISO_8859_1);
+  }
+
+  @Test
+  void testMissingProjectCodePageFallsBackToNativeCharset() {
+    setNativeEncoding("windows-1252");
+
+    addInputFile(PROJECTS_PATH + "CodePageProject/Utf8.dproj");
+    addInputFile(PROJECTS_PATH + "SimpleProject/dproj/SimpleDelphiProject.dproj");
+
+    DelphiProjectHelper delphiProjectHelper =
+        new DelphiProjectHelper(settings, fs, environmentVariableProvider);
+
+    assertThat(delphiProjectHelper.getAnsiCharset()).isEqualTo(Charset.forName("windows-1252"));
+  }
+
+  @Test
+  void testAcpProjectCodePageUsesNativeCharsetWithoutConflictWhenItMatchesExplicitCodePage() {
+    setNativeEncoding("windows-1252");
+
+    addInputFile(PROJECTS_PATH + "CodePageProject/Acp.dproj");
+    addInputFile(PROJECTS_PATH + "CodePageProject/Windows1252.dproj");
+
+    DelphiProjectHelper delphiProjectHelper =
+        new DelphiProjectHelper(settings, fs, environmentVariableProvider);
+
+    assertThat(delphiProjectHelper.getAnsiCharset()).isEqualTo(Charset.forName("windows-1252"));
+  }
+
+  @Test
   void testNoFilesExist(@TempDir Path tempDir) {
     fs = new DefaultFileSystem(tempDir);
 
@@ -350,5 +455,16 @@ class DelphiProjectHelperTest {
 
     assertThat(delphiProjectHelper.inputFiles()).isEmpty();
     assertThat(delphiProjectHelper.shouldExecuteOnProject()).isFalse();
+  }
+
+  private void addInputFile(String resourcePath) {
+    InputFile inputFile =
+        TestInputFileBuilder.create(Delphi.KEY, BASE_DIR, DelphiUtils.getResource(resourcePath))
+            .build();
+    fs.add(inputFile);
+  }
+
+  private static void setNativeEncoding(String encoding) {
+    System.setProperty("native.encoding", encoding);
   }
 }

--- a/delphi-frontend/src/test/java/au/com/integradev/delphi/preprocessor/DelphiPreprocessorTest.java
+++ b/delphi-frontend/src/test/java/au/com/integradev/delphi/preprocessor/DelphiPreprocessorTest.java
@@ -148,6 +148,7 @@ class DelphiPreprocessorTest {
     DelphiFileConfig config =
         DelphiFile.createConfig(
             UTF_8.name(),
+            UTF_8,
             new DelphiPreprocessorFactory(
                 DelphiProperties.COMPILER_VERSION_DEFAULT, Platform.WINDOWS),
             TypeFactoryUtils.defaultFactory(),
@@ -168,6 +169,7 @@ class DelphiPreprocessorTest {
         filename,
         DelphiFile.createConfig(
             UTF_8.name(),
+            UTF_8,
             new DelphiPreprocessorFactory(
                 DelphiProperties.COMPILER_VERSION_DEFAULT, Platform.WINDOWS),
             typeFactory,

--- a/delphi-frontend/src/test/java/au/com/integradev/delphi/utils/CharsetUtilsTest.java
+++ b/delphi-frontend/src/test/java/au/com/integradev/delphi/utils/CharsetUtilsTest.java
@@ -1,0 +1,110 @@
+/*
+ * Sonar Delphi Plugin
+ * Copyright (C) 2011 Sabre Airline Solutions and Fabricio Colombo
+ * Author(s):
+ * Przemyslaw Kociolek (przemyslaw.kociolek@sabre.com)
+ * Michal Wojcik (michal.wojcik@sabre.com)
+ * Fabricio Colombo (fabricio.colombo.mva@gmail.com)
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02
+ */
+package au.com.integradev.delphi.utils;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.sonar.plugins.communitydelphi.api.type.CodePages;
+
+class CharsetUtilsTest {
+  @Test
+  void testAcpCodePage() {
+    String originalNativeEncoding = System.getProperty("native.encoding");
+    try {
+      System.setProperty("native.encoding", StandardCharsets.ISO_8859_1.name());
+      assertThat(CharsetUtils.charsetForCodePage(CodePages.CP_ACP))
+          .isEqualTo(StandardCharsets.ISO_8859_1);
+    } finally {
+      if (originalNativeEncoding != null) {
+        System.setProperty("native.encoding", originalNativeEncoding);
+      } else {
+        System.clearProperty("native.encoding");
+      }
+    }
+  }
+
+  @ParameterizedTest
+  @CsvSource({
+    "37,IBM037",
+    "437,IBM437",
+    "708,ASMO-708",
+    "874,x-windows-874",
+    "862,IBM862",
+    "866,IBM866",
+    "932,windows-31j",
+    "936,GBK",
+    "949,x-windows-949",
+    "950,Big5",
+    "1047,IBM1047",
+    "1140,IBM01140",
+    "1200,UTF-16LE",
+    "1201,UTF-16BE",
+    "10000,x-MacRoman",
+    "10004,x-MacArabic",
+    "10029,x-MacCentralEurope",
+    "12000,UTF-32LE",
+    "12001,UTF-32BE",
+    "20127,US-ASCII",
+    "20273,IBM273",
+    "20420,IBM420",
+    "20866,KOI8-R",
+    "20838,IBM-Thai",
+    "21866,KOI8-U",
+    "21025,cp1025",
+    "28591,ISO-8859-1",
+    "50225,ISO-2022-KR",
+    "51932,EUC-JP",
+    "51936,GB2312",
+    "51949,EUC-KR",
+    "54936,GB18030",
+    "1252,windows-1252",
+    "1361,x-Johab"
+  })
+  void testCodePagesResolveExpectedCharsets(int codePage, String expectedCharsetName) {
+    assertThat(CharsetUtils.charsetForCodePage(codePage))
+        .isEqualTo(Charset.forName(expectedCharsetName));
+  }
+
+  @ParameterizedTest
+  @ValueSource(ints = {720, 10001, 29001, 65000})
+  void testMappedButUnsupportedCodePageThrows(int codePage) {
+    assertThatThrownBy(() -> CharsetUtils.charsetForCodePage(codePage))
+        .isInstanceOf(CharsetUtils.UnsupportedCodePageException.class)
+        .hasMessage("Unsupported code page: " + codePage);
+  }
+
+  @ParameterizedTest
+  @ValueSource(ints = {709, 710, 21027, 50229, 51950})
+  void testCodePageOutsideTableThrows(int codePage) {
+    assertThatThrownBy(() -> CharsetUtils.charsetForCodePage(codePage))
+        .isInstanceOf(CharsetUtils.UnsupportedCodePageException.class)
+        .hasMessage("Unsupported code page: " + codePage);
+  }
+}

--- a/delphi-frontend/src/test/resources/au/com/integradev/delphi/projects/CodePageProject/Acp.dproj
+++ b/delphi-frontend/src/test/resources/au/com/integradev/delphi/projects/CodePageProject/Acp.dproj
@@ -1,0 +1,6 @@
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+    <PropertyGroup>
+        <DCC_CodePage>0</DCC_CodePage>
+    </PropertyGroup>
+</Project>
+

--- a/delphi-frontend/src/test/resources/au/com/integradev/delphi/projects/CodePageProject/Utf8.dproj
+++ b/delphi-frontend/src/test/resources/au/com/integradev/delphi/projects/CodePageProject/Utf8.dproj
@@ -1,0 +1,5 @@
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+    <PropertyGroup>
+        <DCC_CodePage>65001</DCC_CodePage>
+    </PropertyGroup>
+</Project>

--- a/delphi-frontend/src/test/resources/au/com/integradev/delphi/projects/CodePageProject/Windows1252.dproj
+++ b/delphi-frontend/src/test/resources/au/com/integradev/delphi/projects/CodePageProject/Windows1252.dproj
@@ -1,0 +1,5 @@
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+    <PropertyGroup>
+        <DCC_CodePage>1252</DCC_CodePage>
+    </PropertyGroup>
+</Project>

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -37,6 +37,7 @@ force their analysis (not recommended).
 | Key                                 | Value                                                                                                                                  | Default Value |
 |-------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------|---------------|
 | `sonar.delphi.searchPath`           | List of directories to search for include files and unit imports. Each path may be absolute or relative to the project base directory. | -             |
+| `sonar.delphi.codePage`             | Code page to use when interpreting ANSI data.                                                                                          | -             |
 | `sonar.delphi.conditionalDefines`   | List of conditional defines to consider defined while parsing the project.                                                             | -             |
 | `sonar.delphi.conditionalUndefines` | List of conditional defines to consider undefined while parsing the project.                                                           | -             |
 | `sonar.delphi.unitScopeNames`       | List of unit scope names, used for import resolution.                                                                                  | -             |

--- a/sonar-delphi-plugin/src/main/java/au/com/integradev/delphi/DelphiSensor.java
+++ b/sonar-delphi-plugin/src/main/java/au/com/integradev/delphi/DelphiSensor.java
@@ -116,6 +116,7 @@ public class DelphiSensor implements Sensor {
             .sourceFiles(sourceFiles)
             .referencedFiles(referencedFiles)
             .encoding(delphiProjectHelper.encoding())
+            .ansiCharset(delphiProjectHelper.getAnsiCharset())
             .searchPath(searchPath)
             .conditionalDefines(delphiProjectHelper.getConditionalDefines())
             .unitScopeNames(delphiProjectHelper.getUnitScopeNames())
@@ -133,6 +134,7 @@ public class DelphiSensor implements Sensor {
     DelphiFileConfig config =
         DelphiFile.createConfig(
             delphiProjectHelper.encoding(),
+            delphiProjectHelper.getAnsiCharset(),
             preprocessorFactory,
             typeFactory,
             searchPath,

--- a/sonar-delphi-plugin/src/test/java/au/com/integradev/delphi/DelphiPluginTest.java
+++ b/sonar-delphi-plugin/src/test/java/au/com/integradev/delphi/DelphiPluginTest.java
@@ -57,6 +57,6 @@ class DelphiPluginTest {
     Plugin.Context context = new Plugin.Context(runtime);
     plugin.define(context);
 
-    assertThat((List<?>) context.getExtensions()).hasSize(35);
+    assertThat((List<?>) context.getExtensions()).hasSize(36);
   }
 }


### PR DESCRIPTION
Fixes #368 by improving `TextLiteralNode::characterEscapeToChar`. Note that the interpretation of "ANSI encoding" is the system native encoding, so it is assumed that the system the Sonar scan runs on has the same native encoding as the system compiling the code.