### PR TITLE
Ignore all blocks with comments in EmptyBlock

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- `EmptyBlock` now ignores all empty blocks containing an explanatory comment.
+
 ## [1.17.2] - 2025-07-03
 
 ### Fixed

--- a/delphi-checks/src/main/resources/org/sonar/l10n/delphi/rules/community-delphi/EmptyBlock.html
+++ b/delphi-checks/src/main/resources/org/sonar/l10n/delphi/rules/community-delphi/EmptyBlock.html
@@ -5,7 +5,7 @@
 </p>
 <h3>Exceptions</h3>
 <ul>
+  <li>Empty blocks with an explanatory comment</li>
   <li>Empty routine bodies (covered by the <code>EmptyRoutine</code> rule)</li>
   <li>Empty except blocks (covered by the <code>SwallowedException</code> rule)</li>
-  <li>Case blocks that are empty apart from a comment</li>
 </ul>


### PR DESCRIPTION
Fixes #221. 

I considered updating EmptyRoutine and SwallowedException to also ignore all blocks with comments, but I didn't in the end because I decided they had higher-level reasoning than just syntax-level "this block is unnecessary", and so we probably want to forbid those bad patterns regardless of whether there's a comment or not. Happy to hear other views.