### PR TITLE
Improve type comparisons between classes and interfaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Inaccurate type comparisons between class and interface types, where class-to-class upcasts were
+  not always preferred over class-to-interface upcasts.
+
 ## [1.18.0] - 2025-08-05
 
 ### Added

--- a/delphi-frontend/src/main/java/au/com/integradev/delphi/symbol/resolve/TypeComparer.java
+++ b/delphi-frontend/src/main/java/au/com/integradev/delphi/symbol/resolve/TypeComparer.java
@@ -48,6 +48,7 @@ import org.sonar.plugins.communitydelphi.api.type.Type.IntegerType;
 import org.sonar.plugins.communitydelphi.api.type.Type.PointerType;
 import org.sonar.plugins.communitydelphi.api.type.Type.ProceduralType;
 import org.sonar.plugins.communitydelphi.api.type.Type.StringType;
+import org.sonar.plugins.communitydelphi.api.type.Type.StructType;
 import org.sonar.plugins.communitydelphi.api.type.Type.SubrangeType;
 
 final class TypeComparer {
@@ -780,7 +781,11 @@ final class TypeComparer {
 
   private static EqualityType compareObject(Type from, Type to) {
     if (from.isStruct() && from.isDescendantOf(to)) {
-      return CONVERT_LEVEL_1;
+      if (((StructType) from).kind() == ((StructType) to).kind()) {
+        return CONVERT_LEVEL_1;
+      } else {
+        return CONVERT_LEVEL_2;
+      }
     } else if (from.isPointer() && !to.isRecord()) {
       PointerType fromPointer = (PointerType) from;
       if (fromPointer.isUntypedPointer()) {

--- a/delphi-frontend/src/test/java/au/com/integradev/delphi/symbol/resolve/InvocationResolverTest.java
+++ b/delphi-frontend/src/test/java/au/com/integradev/delphi/symbol/resolve/InvocationResolverTest.java
@@ -440,6 +440,21 @@ class InvocationResolverTest {
   }
 
   @Test
+  void testClassToInterfaceTypes() {
+    Type grandparent = TypeMocker.struct("Grandparent", CLASS);
+    Type parent = TypeMocker.struct("Parent", CLASS, grandparent);
+    Type child = TypeMocker.struct("Child", CLASS, parent);
+    Type intf = TypeMocker.struct("Intf", INTERFACE);
+
+    when(child.ancestorList()).thenReturn(Set.of(parent, intf));
+    when(child.isDescendantOf(grandparent)).thenReturn(true);
+    when(child.isDescendantOf(parent)).thenReturn(true);
+    when(child.isDescendantOf(intf)).thenReturn(true);
+
+    assertResolved(child, grandparent, intf);
+  }
+
+  @Test
   void testVarParameters() {
     Type openArray =
         ((TypeFactoryImpl) factory).array(null, type(INTEGER), Set.of(ArrayOption.OPEN));


### PR DESCRIPTION
This PR fixes a type comparison inaccuracy where class-to-class upcasts weren't always preferred over class-to-interface upcasts.

The downstream effects were incorrect overload resolution, and false positives in rules like `ObjectPassedAsInterface` where the rule would think an object was being passed to an interface parameter on the incorrectly-selected overload.