### PR TITLE
Fail the release workflow if the plugin jar is not found

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,3 +46,4 @@ jobs:
           name: ${{ steps.changelog.outputs.version }}
           body: ${{ steps.changelog.outputs.release-notes }}
           files: sonar-delphi-plugin/target/sonar-delphi-plugin-${{ steps.changelog.outputs.version }}.jar
+          fail_on_unmatched_files: true


### PR DESCRIPTION
Now that immutable releases are available on GitHub, I'm enabling them for this repository.

I've made this tweak to the release workflow to ensure the release workflow can't generates a release without the plugin jar attached. Such a release wouldn't be manually fixable, now that the releases and their artifacts are immutable.