### PR TITLE
Handle name references properly within `exports` sections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Parsing errors on qualified name references within `exports` sections.
+
 ## [1.18.1] - 2025-08-07
 
 ### Added

--- a/delphi-frontend/src/main/antlr3/au/com/integradev/delphi/antlr/Delphi.g
+++ b/delphi-frontend/src/main/antlr3/au/com/integradev/delphi/antlr/Delphi.g
@@ -558,7 +558,7 @@ arrayVarValueSpec            : ABSOLUTE expression
 varValueSpec                 : ABSOLUTE expression
                              | '=' constExpression
                              ;
-exportsSection               : EXPORTS ident exportItem (',' ident exportItem)* ';'
+exportsSection               : EXPORTS nameReference exportItem (',' nameReference exportItem)* ';'
                              ;
 exportItem                   : ('(' formalParameterList ')')? (INDEX expression)? (NAME expression)? (RESIDENT)?
                              ;

--- a/delphi-frontend/src/test/java/au/com/integradev/delphi/antlr/GrammarTest.java
+++ b/delphi-frontend/src/test/java/au/com/integradev/delphi/antlr/GrammarTest.java
@@ -360,4 +360,9 @@ class GrammarTest {
   void testGreaterThanEqualAmbiguity() {
     assertParsed("GreaterThanEqualAmbiguity.pas");
   }
+
+  @Test
+  void testQualifiedExports() {
+    assertParsed("QualifiedExports.dpk");
+  }
 }

--- a/delphi-frontend/src/test/resources/au/com/integradev/delphi/grammar/QualifiedExports.dpk
+++ b/delphi-frontend/src/test/resources/au/com/integradev/delphi/grammar/QualifiedExports.dpk
@@ -1,0 +1,13 @@
+library QualifiedExports;
+
+procedure Foo; stdcall;
+begin
+  // ...
+end;
+
+exports
+  QualifiedExports.Foo;
+
+begin
+  // ...
+end.


### PR DESCRIPTION
This PR fixes parsing errors around qualified name references in `exports` sections.

Fixes #418.