### PR TITLE
Fix stack overflow on alias types that reference their containing type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Stack overflow on alias types that reference their containing type.
+
 ## [1.18.2] - 2025-10-01
 
 ### Fixed

--- a/delphi-frontend/src/main/java/au/com/integradev/delphi/symbol/SymbolTableBuilder.java
+++ b/delphi-frontend/src/main/java/au/com/integradev/delphi/symbol/SymbolTableBuilder.java
@@ -389,6 +389,7 @@ public class SymbolTableBuilder {
     return scope.getTypeDeclarations().stream()
         .map(TypeNameDeclaration::getType)
         .filter(Predicate.not(Type::isClassReference))
+        .filter(Predicate.not(Type::isAlias))
         .filter(ScopedType.class::isInstance)
         .map(ScopedType.class::cast)
         .map(ScopedType::typeScope)


### PR DESCRIPTION
This PR fixes a bug during symbol table construction.
A type alias declaration nested within the type it aliases would trigger infinite recursion / stack overflow.

Fixes #420.