### PR TITLE
Add support for 'NameOf' intrinsic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Support for `noreturn` routines, introduced in Delphi 13.
+- Support for `NameOf` intrinsic, introduced in Delphi 13.
 - `NoreturnContract` analysis rule, which flags `noreturn` routines that return normally.
 
 ## [1.18.3] - 2025-11-11

--- a/delphi-frontend/src/main/java/au/com/integradev/delphi/type/intrinsic/IntrinsicsInjector.java
+++ b/delphi-frontend/src/main/java/au/com/integradev/delphi/type/intrinsic/IntrinsicsInjector.java
@@ -296,6 +296,7 @@ public final class IntrinsicsInjector {
         .outParam(type(INT64))
         .required(3)
         .returns(type(INT64));
+    routine("NameOf").param(TypeFactory.untypedType()).returns(type(UNICODESTRING));
     routine("New").varParam(ANY_POINTER);
     routine("Odd").param(type(INTEGER)).returns(type(BOOLEAN));
     routine("Ord").param(ANY_ORDINAL).returns(type(BYTE));


### PR DESCRIPTION
Delphi 13 introduces the NameOf compiler intrinsic that accepts an identifier and returns its string representation at compile time, similar to C#'s nameof operator.

Closes #415