### PR TITLE
Add support for implicit Self in Initialize and Finalize operators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Support for `noreturn` routines, introduced in Delphi 13.
 - Support for `NameOf` intrinsic, introduced in Delphi 13.
+- Support for implicit `Self` in `Initialize` and `Finalize` operators, introduced in Delphi 13.
 - `NoreturnContract` analysis rule, which flags `noreturn` routines that return normally.
 
 ## [1.18.3] - 2025-11-11

--- a/delphi-frontend/src/main/java/au/com/integradev/delphi/antlr/ast/visitors/SymbolTableVisitor.java
+++ b/delphi-frontend/src/main/java/au/com/integradev/delphi/antlr/ast/visitors/SymbolTableVisitor.java
@@ -508,21 +508,35 @@ public abstract class SymbolTableVisitor implements DelphiParserVisitor<Data> {
 
   private static Type findSelfType(
       RoutineNode node, @Nullable RoutineNameDeclaration declaration, Data data) {
-    Type selfType = null;
-    TypeNameDeclaration routineType = node.getTypeDeclaration();
-    if (routineType != null) {
-      selfType = routineType.getType();
-      if (selfType.isHelper()) {
-        selfType = ((HelperType) selfType).extendedType();
-      }
-      if (node.isClassMethod()) {
-        selfType = data.typeFactory.classOf(null, selfType);
+    TypeNameDeclaration selfTypeDeclaration = node.getTypeDeclaration();
+    if (selfTypeDeclaration == null) {
+      return null;
+    }
+
+    Type selfType = selfTypeDeclaration.getType();
+    if (selfType.isHelper()) {
+      selfType = ((HelperType) selfType).extendedType();
+    }
+
+    if (node.isClassMethod()) {
+      if (node.isOperator()) {
+        if (!isOperatorWithSelf(node.simpleName())) {
+          selfType = null;
+        }
+      } else {
         if (declaration != null && declaration.hasDirective(RoutineDirective.STATIC)) {
           selfType = null;
+        } else {
+          selfType = data.typeFactory.classOf(null, selfType);
         }
       }
     }
+
     return selfType;
+  }
+
+  private static boolean isOperatorWithSelf(String name) {
+    return name.equalsIgnoreCase("Initialize") || name.equalsIgnoreCase("Finalize");
   }
 
   @Override

--- a/delphi-frontend/src/test/java/au/com/integradev/delphi/executor/DelphiSymbolTableExecutorTest.java
+++ b/delphi-frontend/src/test/java/au/com/integradev/delphi/executor/DelphiSymbolTableExecutorTest.java
@@ -313,6 +313,15 @@ class DelphiSymbolTableExecutorTest {
   }
 
   @Test
+  void testRecordInitializeFinalizeSelfTypes() {
+    execute("RecordInitializeFinalizeSelfTypes.pas");
+    verifyUsages(18, 10, reference(30, 2), reference(35, 2));
+    verifyUsages(28, 35, reference(30, 7));
+    verifyUsages(33, 35, reference(35, 7));
+    verifyUsages(23, 10, reference(40, 2), reference(45, 2));
+  }
+
+  @Test
   void testSelfInNestedProcedures() {
     execute("SelfInNestedProcedures.pas");
     verifyUsages(17, 11, reference(37, 2));

--- a/delphi-frontend/src/test/resources/au/com/integradev/delphi/symbol/RecordInitializeFinalizeSelfTypes.pas
+++ b/delphi-frontend/src/test/resources/au/com/integradev/delphi/symbol/RecordInitializeFinalizeSelfTypes.pas
@@ -1,0 +1,48 @@
+unit RecordInitializeFinalizeSelfTypes;
+
+interface
+
+type
+  TFoo = record
+    class operator Initialize(out Self: TFoo);
+    class operator Finalize(var Self: TFoo);
+  end;
+
+  TBar = record
+    class operator Initialize;
+    class operator Finalize;
+  end;
+
+implementation
+
+procedure Test(Foo: TFoo); overload;
+begin
+  // Do nothing
+end;
+
+procedure Test(Bar: TBar); overload;
+begin
+  // Do nothing
+end;
+
+class operator TFoo.Initialize(out Self: TFoo);
+begin
+  Test(Self);
+end;
+
+class operator TFoo.Finalize(var Self: TFoo);
+begin
+  Test(Self);
+end;
+
+class operator TBar.Initialize;
+begin
+  Test(Self);
+end;
+
+class operator TBar.Finalize;
+begin
+  Test(Self);
+end;
+
+end.


### PR DESCRIPTION
Delphi 13 automatically declares Self in Initialize and Finalize operators for custom managed records. Previously developers had to manually declare it as a parameter.

Updates findSelfType() in SymbolTableVisitor to skip classOf() wrapping for these specific record operators, so Self resolves to the record type directly.

Closes #416