### PR TITLE
Add support for ARM64EC toolchain

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Support for `noreturn` routines, introduced in Delphi 13.
 - Support for `NameOf` intrinsic, introduced in Delphi 13.
 - Support for implicit `Self` in `Initialize` and `Finalize` operators, introduced in Delphi 13.
+- Support for `DCCARM64EC` toolchain, introduced in Delphi 13.1.
 - `NoreturnContract` analysis rule, which flags `noreturn` routines that return normally.
 
 ## [1.18.3] - 2025-11-11

--- a/delphi-frontend/src/main/java/au/com/integradev/delphi/compiler/Bitness.java
+++ b/delphi-frontend/src/main/java/au/com/integradev/delphi/compiler/Bitness.java
@@ -1,6 +1,6 @@
 /*
  * Sonar Delphi Plugin
- * Copyright (C) 2019 Integrated Application Development
+ * Copyright (C) 2026 Integrated Application Development
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -18,15 +18,7 @@
  */
 package au.com.integradev.delphi.compiler;
 
-public enum Architecture {
-  X86(Bitness.BIT_32),
-  X64(Bitness.BIT_64),
-  ARM32(Bitness.BIT_32),
-  ARM64(Bitness.BIT_64);
-
-  public final Bitness bitness;
-
-  Architecture(Bitness bitness) {
-    this.bitness = bitness;
-  }
+public enum Bitness {
+  BIT_32,
+  BIT_64;
 }

--- a/delphi-frontend/src/main/java/au/com/integradev/delphi/compiler/PredefinedConditionals.java
+++ b/delphi-frontend/src/main/java/au/com/integradev/delphi/compiler/PredefinedConditionals.java
@@ -111,6 +111,16 @@ public final class PredefinedConditionals {
     return result;
   }
 
+  private Set<String> getToolchainConditionalDefines() {
+    Set<String> result = new HashSet<>();
+
+    if (toolchain == Toolchain.DCCARM64EC) {
+      result.add("ARM64EC");
+    }
+
+    return result;
+  }
+
   private Set<String> getCPUConditionalDefines() {
     Set<String> result = new HashSet<>();
     if (checkToolchain(Toolchain.DCC32, Toolchain.DCCOSX, Toolchain.DCCOSX64, Toolchain.DCCIOS32)) {
@@ -131,7 +141,8 @@ public final class PredefinedConditionals {
         Toolchain.DCCIOSARM64,
         Toolchain.DCCIOSSIMARM64,
         Toolchain.DCCAARM,
-        Toolchain.DCCAARM64)) {
+        Toolchain.DCCAARM64,
+        Toolchain.DCCARM64EC)) {
       result.add("CPUARM");
       result.add(selectByBitness("CPUARM32", "CPUARM64"));
     }
@@ -172,6 +183,7 @@ public final class PredefinedConditionals {
             Toolchain.DCCIOSSIMARM64,
             Toolchain.DCCAARM,
             Toolchain.DCCAARM64,
+            Toolchain.DCCARM64EC,
             Toolchain.DCCLINUX64);
 
     if (basedOnLLVM) {
@@ -238,6 +250,7 @@ public final class PredefinedConditionals {
     Set<String> result = new HashSet<>();
     result.addAll(getCompilerConditionalDefines());
     result.addAll(getPlatformConditionalDefines());
+    result.addAll(getToolchainConditionalDefines());
     result.addAll(getCPUConditionalDefines());
     result.addAll(getAvailabilityConditionalDefines());
     return result;

--- a/delphi-frontend/src/main/java/au/com/integradev/delphi/compiler/PredefinedConditionals.java
+++ b/delphi-frontend/src/main/java/au/com/integradev/delphi/compiler/PredefinedConditionals.java
@@ -44,14 +44,11 @@ public final class PredefinedConditionals {
     return Set.of(options).contains(toolchain);
   }
 
-  private <T> T selectByArchitecture(T x86, T x64) {
-    switch (toolchain.architecture) {
-      case X86:
-        return x86;
-      case X64:
-        return x64;
-      default:
-        throw new AssertionError("Unhandled Architecture");
+  private <T> T selectByBitness(T bit32, T bit64) {
+    if (toolchain.bitness() == Bitness.BIT_32) {
+      return bit32;
+    } else {
+      return bit64;
     }
   }
 
@@ -72,25 +69,25 @@ public final class PredefinedConditionals {
     switch (toolchain.platform) {
       case WINDOWS:
         result.add("MSWINDOWS");
-        result.add(selectByArchitecture("WIN32", "WIN64"));
+        result.add(selectByBitness("WIN32", "WIN64"));
         break;
       case LINUX:
         result.add("LINUX");
-        result.add(selectByArchitecture("LINUX32", "LINUX64"));
+        result.add(selectByBitness("LINUX32", "LINUX64"));
         break;
       case MACOS:
         result.add("OSX");
-        if (toolchain.architecture == Architecture.X64) {
+        if (toolchain.bitness() == Bitness.BIT_64) {
           result.add("OSX64");
         }
         break;
       case IOS:
         result.add("IOS");
-        result.add(selectByArchitecture("IOS32", "IOS64"));
+        result.add(selectByBitness("IOS32", "IOS64"));
         break;
       case ANDROID:
         result.add("ANDROID");
-        result.add(selectByArchitecture("ANDROID32", "ANDROID64"));
+        result.add(selectByBitness("ANDROID32", "ANDROID64"));
         break;
       default:
         // Do nothing
@@ -100,12 +97,12 @@ public final class PredefinedConditionals {
       // Indicates the target platform is an Apple Darwin OS (macOS or iOS).
       // Note: This symbol existed before Apple changed the name of OS X to macOS.
       result.add("MACOS");
-      result.add(selectByArchitecture("MACOS32", "MACOS64"));
+      result.add(selectByBitness("MACOS32", "MACOS64"));
     }
 
     if (toolchain.platform != Platform.WINDOWS) {
       result.add("POSIX");
-      result.add(selectByArchitecture("POSIX32", "POSIX64"));
+      result.add(selectByBitness("POSIX32", "POSIX64"));
     }
 
     result.add("CONSOLE");
@@ -136,10 +133,10 @@ public final class PredefinedConditionals {
         Toolchain.DCCAARM,
         Toolchain.DCCAARM64)) {
       result.add("CPUARM");
-      result.add(selectByArchitecture("CPUARM32", "CPUARM64"));
+      result.add(selectByBitness("CPUARM32", "CPUARM64"));
     }
 
-    result.add(selectByArchitecture("CPU32BITS", "CPU64BITS"));
+    result.add(selectByBitness("CPU32BITS", "CPU64BITS"));
 
     return result;
   }

--- a/delphi-frontend/src/main/java/au/com/integradev/delphi/compiler/Toolchain.java
+++ b/delphi-frontend/src/main/java/au/com/integradev/delphi/compiler/Toolchain.java
@@ -21,6 +21,7 @@ package au.com.integradev.delphi.compiler;
 public enum Toolchain {
   DCC32(Architecture.X86, Platform.WINDOWS),
   DCC64(Architecture.X64, Platform.WINDOWS),
+  DCCARM64EC(Architecture.ARM64, Platform.WINDOWS),
   DCCOSX(Architecture.X86, Platform.MACOS),
   DCCOSX64(Architecture.X64, Platform.MACOS),
   DCCOSXARM64(Architecture.ARM64, Platform.MACOS),

--- a/delphi-frontend/src/main/java/au/com/integradev/delphi/compiler/Toolchain.java
+++ b/delphi-frontend/src/main/java/au/com/integradev/delphi/compiler/Toolchain.java
@@ -23,13 +23,13 @@ public enum Toolchain {
   DCC64(Architecture.X64, Platform.WINDOWS),
   DCCOSX(Architecture.X86, Platform.MACOS),
   DCCOSX64(Architecture.X64, Platform.MACOS),
-  DCCOSXARM64(Architecture.X64, Platform.MACOS),
-  DCCIOSARM(Architecture.X86, Platform.IOS),
-  DCCIOSARM64(Architecture.X64, Platform.IOS),
+  DCCOSXARM64(Architecture.ARM64, Platform.MACOS),
+  DCCIOSARM(Architecture.ARM32, Platform.IOS),
+  DCCIOSARM64(Architecture.ARM64, Platform.IOS),
   DCCIOS32(Architecture.X86, Platform.IOS),
-  DCCIOSSIMARM64(Architecture.X64, Platform.IOS),
-  DCCAARM(Architecture.X86, Platform.ANDROID),
-  DCCAARM64(Architecture.X64, Platform.ANDROID),
+  DCCIOSSIMARM64(Architecture.ARM64, Platform.IOS),
+  DCCAARM(Architecture.ARM32, Platform.ANDROID),
+  DCCAARM64(Architecture.ARM64, Platform.ANDROID),
   DCCLINUX64(Architecture.X64, Platform.LINUX);
 
   public final Architecture architecture;
@@ -38,5 +38,9 @@ public enum Toolchain {
   Toolchain(Architecture architecture, Platform platform) {
     this.architecture = architecture;
     this.platform = platform;
+  }
+
+  public final Bitness bitness() {
+    return architecture.bitness;
   }
 }

--- a/delphi-frontend/src/main/java/au/com/integradev/delphi/type/factory/TypeFactoryImpl.java
+++ b/delphi-frontend/src/main/java/au/com/integradev/delphi/type/factory/TypeFactoryImpl.java
@@ -21,7 +21,7 @@ package au.com.integradev.delphi.type.factory;
 import static org.sonar.plugins.communitydelphi.api.type.StructKind.CLASS_HELPER;
 import static org.sonar.plugins.communitydelphi.api.type.StructKind.RECORD_HELPER;
 
-import au.com.integradev.delphi.compiler.Architecture;
+import au.com.integradev.delphi.compiler.Bitness;
 import au.com.integradev.delphi.compiler.CompilerVersion;
 import au.com.integradev.delphi.compiler.Platform;
 import au.com.integradev.delphi.compiler.Toolchain;
@@ -114,7 +114,7 @@ public class TypeFactoryImpl implements TypeFactory {
             BigInteger.ZERO,
             ((IntegerType) getIntrinsic(IntrinsicType.INTEGER)).max());
 
-    if (toolchain.architecture == Architecture.X86) {
+    if (toolchain.bitness() == Bitness.BIT_32) {
       this.openArraySizeType = (IntegerType) getIntrinsic(IntrinsicType.INTEGER);
       this.dynamicArraySizeType = (IntegerType) getIntrinsic(IntrinsicType.INTEGER);
     } else {
@@ -135,7 +135,7 @@ public class TypeFactoryImpl implements TypeFactory {
   private boolean isLong64Bit() {
     // See: https://bit.ly/long-on-different-platforms
     return compilerVersion.compareTo(VERSION_XE8) >= 0
-        && toolchain.architecture == Architecture.X64
+        && toolchain.bitness() == Bitness.BIT_64
         && toolchain.platform != Platform.WINDOWS;
   }
 
@@ -149,9 +149,9 @@ public class TypeFactoryImpl implements TypeFactory {
     return compilerVersion.compareTo(VERSION_2009) >= 0;
   }
 
-  private int sizeByArchitecture(int x86, int x64) {
-    if (toolchain.architecture == Architecture.X86) {
-      return x86;
+  private int sizeByBitness(int x32, int x64) {
+    if (toolchain.bitness() == Bitness.BIT_32) {
+      return x32;
     } else {
       return x64;
     }
@@ -176,11 +176,11 @@ public class TypeFactoryImpl implements TypeFactory {
       // See: https://stackoverflow.com/questions/7630781/delphi-2007-and-xe2-using-nativeint
       return 8;
     }
-    return sizeByArchitecture(4, 8);
+    return sizeByBitness(4, 8);
   }
 
   private int pointerSize() {
-    return sizeByArchitecture(4, 8);
+    return sizeByBitness(4, 8);
   }
 
   private int proceduralSize(ProceduralKind kind) {
@@ -267,7 +267,7 @@ public class TypeFactoryImpl implements TypeFactory {
     }
 
     if (isNativeIntWeakAlias()) {
-      if (toolchain.architecture == Architecture.X64) {
+      if (toolchain.bitness() == Bitness.BIT_64) {
         addWeakAlias(IntrinsicType.NATIVEINT, IntrinsicType.INT64);
         addWeakAlias(IntrinsicType.NATIVEUINT, IntrinsicType.UINT64);
       } else {
@@ -311,13 +311,13 @@ public class TypeFactoryImpl implements TypeFactory {
       addWeakAlias(IntrinsicType.PCHAR, IntrinsicType.PANSICHAR);
     }
 
-    int variantSize = sizeByArchitecture(16, 24);
+    int variantSize = sizeByBitness(16, 24);
     addVariant(IntrinsicType.VARIANT, variantSize, false);
     addVariant(IntrinsicType.OLEVARIANT, variantSize, true);
 
     intrinsicTypes.put(
         IntrinsicType.TEXT,
-        new FileTypeImpl(TypeFactory.untypedType(), sizeByArchitecture(730, 754)) {
+        new FileTypeImpl(TypeFactory.untypedType(), sizeByBitness(730, 754)) {
           @Override
           public String getImage() {
             return IntrinsicType.TEXT.fullyQualifiedName();
@@ -487,7 +487,7 @@ public class TypeFactoryImpl implements TypeFactory {
 
   @Override
   public FileType fileOf(Type type) {
-    return new FileTypeImpl(type, sizeByArchitecture(592, 616));
+    return new FileTypeImpl(type, sizeByBitness(592, 616));
   }
 
   @Override

--- a/delphi-frontend/src/test/java/au/com/integradev/delphi/compiler/PredefinedConditionalsTest.java
+++ b/delphi-frontend/src/test/java/au/com/integradev/delphi/compiler/PredefinedConditionalsTest.java
@@ -340,6 +340,28 @@ class PredefinedConditionalsTest {
             "WEAKINTFREF");
   }
 
+  void testDCCARM64EC() {
+    assertThat(PredefinedConditionals.getConditionalDefines(Toolchain.DCCARM64EC, VERSION_ATHENS))
+        .containsExactlyInAnyOrder(
+            "DCC",
+            "VER360",
+            "CONSOLE",
+            "NATIVECODE",
+            "MSWINDOWS",
+            "WIN64",
+            "ARM64EC",
+            "CPU64BITS",
+            "CPUARM",
+            "CPUARM64",
+            "EXTERNALLINKER",
+            "LLVM",
+            "UNICODE",
+            "CONDITIONALEXPRESSIONS",
+            "WEAKREF",
+            "WEAKINTFREF",
+            "WEAK_NATIVEINT");
+  }
+
   @Test
   void testDelphi2007ShouldBeBinaryCompatibleWithDelphi2006() {
     assertThat(PredefinedConditionals.getConditionalDefines(Toolchain.DCC32, VERSION_2007))
@@ -384,6 +406,7 @@ class PredefinedConditionalsTest {
         "DCCIOSSIMARM64",
         "DCCAARM",
         "DCCAARM64",
+        "DCCARM64EC",
         "DCCLINUX64"
       })
   void testLLVMToolchainsAfterDelphiAlexandriaShouldDefineLLVM(Toolchain toolchain) {


### PR DESCRIPTION
Delphi 13.1 introduces the ARM64EC toolchain, a Windows ARM64 emulation-compatible architecture based on LLVM.

- Adds ARM64EC to Architecture enum with is64Bit() helper
- Adds DCCAARM64EC toolchain entry
- Updates predefined conditionals (CPUARM64EC, LLVM, etc.)
- Fixes TypeFactoryImpl to use is64Bit() for NativeInt sizing

Closes #434