### PR TITLE
Report metrics/duplications/coverage correctly on `MAIN` vs `TEST` input files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Metrics are no longer reported on test sources.
 - Duplications are no longer reported on test sources.
 - Coverage data is no longer reported on test sources.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Support for `DCCARM64EC` toolchain, introduced in Delphi 13.1.
 - `NoreturnContract` analysis rule, which flags `noreturn` routines that return normally.
 
+### Changed
+
+- Coverage data is no longer reported on test sources.
+
 ### Fixed
 
 - Quick fixes removing too much surrounding code in `RedundantInherited`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Duplications are no longer reported on test sources.
 - Coverage data is no longer reported on test sources.
 
 ### Fixed

--- a/delphi-frontend/src/main/java/au/com/integradev/delphi/coverage/DelphiCodeCoverageParser.java
+++ b/delphi-frontend/src/main/java/au/com/integradev/delphi/coverage/DelphiCodeCoverageParser.java
@@ -109,6 +109,10 @@ public class DelphiCodeCoverageParser implements DelphiCoverageParser {
       return;
     }
 
+    if (sourceFile.type() == InputFile.Type.TEST) {
+      return;
+    }
+
     LOG.debug("Parsing line hit information for file: {}", fileName);
 
     NewCoverage newCoverage = sensorContext.newCoverage();

--- a/delphi-frontend/src/main/java/au/com/integradev/delphi/executor/DelphiCpdExecutor.java
+++ b/delphi-frontend/src/main/java/au/com/integradev/delphi/executor/DelphiCpdExecutor.java
@@ -19,6 +19,7 @@
 package au.com.integradev.delphi.executor;
 
 import au.com.integradev.delphi.file.DelphiFile.DelphiInputFile;
+import org.sonar.api.batch.fs.InputFile;
 import org.sonar.api.batch.sensor.SensorContext;
 import org.sonar.api.batch.sensor.cpd.NewCpdTokens;
 import org.sonar.plugins.communitydelphi.api.token.DelphiToken;
@@ -29,6 +30,13 @@ public class DelphiCpdExecutor extends DelphiTokenExecutor {
   static final String NUMERIC_LITERAL = "NUMERIC_LITERAL";
 
   private NewCpdTokens cpdTokens;
+
+  @Override
+  public void execute(Context context, DelphiInputFile delphiFile) {
+    if (delphiFile.getInputFile().type() == InputFile.Type.MAIN) {
+      super.execute(context, delphiFile);
+    }
+  }
 
   @Override
   public void onFile(SensorContext context, DelphiInputFile delphiFile) {

--- a/delphi-frontend/src/main/java/au/com/integradev/delphi/executor/DelphiMetricsExecutor.java
+++ b/delphi-frontend/src/main/java/au/com/integradev/delphi/executor/DelphiMetricsExecutor.java
@@ -23,6 +23,7 @@ import au.com.integradev.delphi.antlr.ast.visitors.MetricsVisitor.Data;
 import au.com.integradev.delphi.file.DelphiFile.DelphiInputFile;
 import java.io.Serializable;
 import java.util.Set;
+import org.sonar.api.batch.fs.InputFile;
 import org.sonar.api.batch.sensor.SensorContext;
 import org.sonar.api.measures.CoreMetrics;
 import org.sonar.api.measures.FileLinesContext;
@@ -41,6 +42,10 @@ public class DelphiMetricsExecutor implements Executor {
 
   @Override
   public void execute(Context context, DelphiInputFile file) {
+    if (file.getInputFile().type() != InputFile.Type.MAIN) {
+      return;
+    }
+
     this.context = context.sensorContext();
     this.file = file;
 

--- a/delphi-frontend/src/main/java/au/com/integradev/delphi/msbuild/DelphiProjectHelper.java
+++ b/delphi-frontend/src/main/java/au/com/integradev/delphi/msbuild/DelphiProjectHelper.java
@@ -387,10 +387,6 @@ public class DelphiProjectHelper {
     return fs.inputFiles(p.and(p.hasLanguage(Delphi.KEY)));
   }
 
-  public boolean shouldExecuteOnProject() {
-    return fs.hasFiles(fs.predicates().hasLanguage(Delphi.KEY));
-  }
-
   public InputFile getFile(String path) {
     return fs.inputFile(fs.predicates().hasURI(Paths.get(path).toUri()));
   }

--- a/delphi-frontend/src/test/java/au/com/integradev/delphi/coverage/delphicodecoveragetool/DelphiCoverageToolParserTest.java
+++ b/delphi-frontend/src/test/java/au/com/integradev/delphi/coverage/delphicodecoveragetool/DelphiCoverageToolParserTest.java
@@ -37,10 +37,10 @@ import au.com.integradev.delphi.msbuild.DelphiProjectHelper;
 import au.com.integradev.delphi.utils.DelphiUtils;
 import java.io.File;
 import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.util.Collections;
 import java.util.UUID;
 import org.apache.commons.io.FileUtils;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.sonar.api.batch.fs.InputFile;
 import org.sonar.api.batch.fs.internal.TestInputFileBuilder;
@@ -65,29 +65,29 @@ class DelphiCoverageToolParserTest {
   private static final String MAIN_WINDOW_FILE_KEY = ":" + MAIN_WINDOW_FILENAME;
 
   private SensorContextTester context;
-  private EnvironmentVariableProvider environmentVariableProvider;
   private File baseDir;
   private DelphiProjectHelper delphiProjectHelper;
   private DelphiCodeCoverageParser parser;
 
   private static final String ROOT_NAME = "/au/com/integradev/delphi/projects/SimpleProject";
 
-  private void addFile(String fileName) throws IOException {
+  private void addFile(String fileName, InputFile.Type type) throws IOException {
     File file = DelphiUtils.getResource(fileName);
     final InputFile inputFile =
         TestInputFileBuilder.create("", baseDir, file)
             .setLanguage(Delphi.KEY)
+            .setType(type)
             .setContents(FileUtils.readFileToString(file, delphiProjectHelper.encoding()))
             .build();
     context.fileSystem().add(inputFile);
   }
 
-  @BeforeEach
-  void setup() throws IOException {
+  private void setup(InputFile.Type inputFileType) {
     baseDir = DelphiUtils.getResource(ROOT_NAME);
     context = SensorContextTester.create(baseDir);
 
-    environmentVariableProvider = mock(EnvironmentVariableProvider.class);
+    EnvironmentVariableProvider environmentVariableProvider =
+        mock(EnvironmentVariableProvider.class);
     when(environmentVariableProvider.getenv()).thenReturn(Collections.emptyMap());
     when(environmentVariableProvider.getenv(anyString())).thenReturn(null);
 
@@ -95,14 +95,20 @@ class DelphiCoverageToolParserTest {
         new DelphiProjectHelper(
             context.config(), context.fileSystem(), environmentVariableProvider);
 
-    addFile(ROOT_NAME + "/" + GLOBALS_FILENAME);
-    addFile(ROOT_NAME + "/" + MAIN_WINDOW_FILENAME);
+    try {
+      addFile(ROOT_NAME + "/" + GLOBALS_FILENAME, inputFileType);
+      addFile(ROOT_NAME + "/" + MAIN_WINDOW_FILENAME, inputFileType);
+    } catch (IOException e) {
+      throw new UncheckedIOException(e);
+    }
 
     parser = new DelphiCodeCoverageParser(delphiProjectHelper);
   }
 
   @Test
   void testWhenValidReportLineHitsAreExtracted() {
+    setup(InputFile.Type.MAIN);
+
     parser.parse(context, DelphiUtils.getResource(NORMAL_COVERAGE));
 
     assertThat(context.lineHits(GLOBALS_FILE_KEY, 16)).isEqualTo((Integer) 1);
@@ -119,6 +125,8 @@ class DelphiCoverageToolParserTest {
 
   @Test
   void testLineHitsFromDifferentReportsAreMerged() {
+    setup(InputFile.Type.MAIN);
+
     parser.parse(context, DelphiUtils.getResource(NORMAL_COVERAGE));
     parser.parse(context, DelphiUtils.getResource(NORMAL_COVERAGE_PART_2));
 
@@ -129,6 +137,8 @@ class DelphiCoverageToolParserTest {
 
   @Test
   void testMismatchedCasingAllowed() {
+    setup(InputFile.Type.MAIN);
+
     parser.parse(context, DelphiUtils.getResource(MISMATCHED_CASING_COVERAGE));
 
     assertThat(context.lineHits(GLOBALS_FILE_KEY, 16)).isEqualTo(1);
@@ -143,6 +153,20 @@ class DelphiCoverageToolParserTest {
     assertThat(context.lineHits(MAIN_WINDOW_FILE_KEY, 40)).isEqualTo(1);
   }
 
+  @Test
+  void testCoverageIsNotReportedForTestInputFiles() {
+    setup(InputFile.Type.TEST);
+
+    parser.parse(context, DelphiUtils.getResource(NORMAL_COVERAGE));
+
+    assertThat(context.lineHits(GLOBALS_FILE_KEY, 16)).isNull();
+    assertThat(context.lineHits(GLOBALS_FILE_KEY, 17)).isNull();
+    assertThat(context.lineHits(GLOBALS_FILE_KEY, 23)).isNull();
+
+    assertThat(context.lineHits(MAIN_WINDOW_FILE_KEY, 31)).isNull();
+    assertThat(context.lineHits(MAIN_WINDOW_FILE_KEY, 36)).isNull();
+  }
+
   void testReportFileIsIgnored(File file) {
     SensorContext mockContext = mock(SensorContext.class);
     assertThatCode(() -> parser.parse(mockContext, file)).doesNotThrowAnyException();
@@ -151,11 +175,15 @@ class DelphiCoverageToolParserTest {
 
   @Test
   void testInvalidXmlReportIsIgnored() {
+    setup(InputFile.Type.MAIN);
+
     testReportFileIsIgnored(DelphiUtils.getResource(INVALID_STRUCTURE));
   }
 
   @Test
   void testBadExistentFileIsIgnored() {
+    setup(InputFile.Type.MAIN);
+
     File file = mock(File.class);
     when(file.exists()).thenReturn(true);
     testReportFileIsIgnored(file);
@@ -163,16 +191,22 @@ class DelphiCoverageToolParserTest {
 
   @Test
   void testNonExistentReportIsIgnored() {
+    setup(InputFile.Type.MAIN);
+
     testReportFileIsIgnored(new File(UUID.randomUUID().toString()));
   }
 
   @Test
   void testReportWithNoLineHitsIsIgnored() {
+    setup(InputFile.Type.MAIN);
+
     testReportFileIsIgnored(DelphiUtils.getResource(NO_LINE_HITS));
   }
 
   @Test
   void testWhenPartiallyValidReportOnlyValidLineHitsAreRecorded() {
+    setup(InputFile.Type.MAIN);
+
     parser.parse(context, DelphiUtils.getResource(INVALID_LINE_HITS));
 
     assertThat(context.lineHits(GLOBALS_FILE_KEY, 16)).isEqualTo((Integer) 1);

--- a/delphi-frontend/src/test/java/au/com/integradev/delphi/executor/DelphiMetricsExecutorTest.java
+++ b/delphi-frontend/src/test/java/au/com/integradev/delphi/executor/DelphiMetricsExecutorTest.java
@@ -21,7 +21,9 @@ package au.com.integradev.delphi.executor;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -141,7 +143,24 @@ class DelphiMetricsExecutorTest {
     checkCodeLines(Set.of(1, 3, 5, 6, 7, 8, 9, 10, 12, 14, 15, 20, 21, 22, 23, 24, 25, 27), 27);
   }
 
+  @Test
+  void testTestFileShouldNotReportMetrics() {
+    execute(GLOBALS_TEST, InputFile.Type.TEST);
+    checkMetricNotReported(CoreMetrics.CLASSES);
+    checkMetricNotReported(CoreMetrics.FUNCTIONS);
+    checkMetricNotReported(CoreMetrics.COMPLEXITY);
+    checkMetricNotReported(CoreMetrics.COMMENT_LINES);
+    checkMetricNotReported(CoreMetrics.STATEMENTS);
+    checkMetricNotReported(CoreMetrics.NCLOC);
+    checkMetricNotReported(CoreMetrics.COGNITIVE_COMPLEXITY);
+    verify(fileLinesContext, never()).setIntValue(any(), anyInt(), anyInt());
+  }
+
   private void execute(String resourcePath) {
+    execute(resourcePath, InputFile.Type.MAIN);
+  }
+
+  private void execute(String resourcePath, InputFile.Type inputFileType) {
     try {
       File resource = DelphiUtils.getResource(resourcePath);
       DelphiInputFile file =
@@ -149,7 +168,7 @@ class DelphiMetricsExecutorTest {
               TestInputFileBuilder.create("moduleKey", ROOT_DIR, resource)
                   .setContents(FileUtils.readFileToString(resource, UTF_8.name()))
                   .setLanguage(Delphi.KEY)
-                  .setType(InputFile.Type.MAIN)
+                  .setType(inputFileType)
                   .build(),
               mockConfig());
       componentKey = file.getInputFile().key();
@@ -163,6 +182,10 @@ class DelphiMetricsExecutorTest {
     assertThat(sensorContext.measure(componentKey, metric).value())
         .as(metric.getDescription())
         .isEqualTo(value);
+  }
+
+  private <T extends Serializable> void checkMetricNotReported(Metric<T> metric) {
+    assertThat(sensorContext.measure(componentKey, metric)).as(metric.getDescription()).isNull();
   }
 
   void checkCodeLines(Set<Integer> codeLines, int totalLines) {

--- a/delphi-frontend/src/test/java/au/com/integradev/delphi/msbuild/DelphiProjectHelperTest.java
+++ b/delphi-frontend/src/test/java/au/com/integradev/delphi/msbuild/DelphiProjectHelperTest.java
@@ -325,7 +325,6 @@ class DelphiProjectHelperTest {
         new DelphiProjectHelper(settings, fs, environmentVariableProvider);
 
     assertThat(delphiProjectHelper.inputFiles()).isEmpty();
-    assertThat(delphiProjectHelper.shouldExecuteOnProject()).isFalse();
   }
 
   @Test
@@ -337,7 +336,6 @@ class DelphiProjectHelperTest {
         new DelphiProjectHelper(settings, fs, environmentVariableProvider);
 
     assertThat(delphiProjectHelper.inputFiles()).isEmpty();
-    assertThat(delphiProjectHelper.shouldExecuteOnProject()).isFalse();
   }
 
   @Test
@@ -349,6 +347,5 @@ class DelphiProjectHelperTest {
         new DelphiProjectHelper(settings, fs, environmentVariableProvider);
 
     assertThat(delphiProjectHelper.inputFiles()).isEmpty();
-    assertThat(delphiProjectHelper.shouldExecuteOnProject()).isFalse();
   }
 }

--- a/sonar-delphi-plugin/src/main/java/au/com/integradev/delphi/DelphiCoverageSensor.java
+++ b/sonar-delphi-plugin/src/main/java/au/com/integradev/delphi/DelphiCoverageSensor.java
@@ -21,7 +21,6 @@ package au.com.integradev.delphi;
 import au.com.integradev.delphi.core.Delphi;
 import au.com.integradev.delphi.coverage.DelphiCoverageParser;
 import au.com.integradev.delphi.coverage.DelphiCoverageParserFactory;
-import au.com.integradev.delphi.msbuild.DelphiProjectHelper;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.InvalidPathException;
@@ -31,6 +30,7 @@ import java.util.stream.Stream;
 import javax.annotation.Nonnull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.sonar.api.batch.fs.InputFile;
 import org.sonar.api.batch.sensor.Sensor;
 import org.sonar.api.batch.sensor.SensorContext;
 import org.sonar.api.batch.sensor.SensorDescriptor;
@@ -38,33 +38,30 @@ import org.sonar.api.batch.sensor.SensorDescriptor;
 public class DelphiCoverageSensor implements Sensor {
   private static final Logger LOG = LoggerFactory.getLogger(DelphiCoverageSensor.class);
 
-  private final DelphiProjectHelper delphiProjectHelper;
   private final DelphiCoverageParserFactory coverageParserFactory;
 
   /**
    * Dependency-injection constructor
    *
-   * @param delphiProjectHelper Helper class for navigating delphi projects
    * @param coverageParserFactory Provides a coverage parsers
    */
-  public DelphiCoverageSensor(
-      DelphiProjectHelper delphiProjectHelper, DelphiCoverageParserFactory coverageParserFactory) {
-    this.delphiProjectHelper = delphiProjectHelper;
+  public DelphiCoverageSensor(DelphiCoverageParserFactory coverageParserFactory) {
     this.coverageParserFactory = coverageParserFactory;
   }
 
   /** Populate {@link SensorDescriptor} of this sensor. */
   @Override
   public void describe(SensorDescriptor descriptor) {
-    descriptor.onlyOnLanguage(Delphi.KEY).name("DelphiCoverageSensor");
+    descriptor
+        .onlyOnLanguage(Delphi.KEY)
+        .onlyOnFileType(InputFile.Type.MAIN)
+        .name("DelphiCoverageSensor");
   }
 
   /** The actual sensor code. */
   @Override
   public void execute(@Nonnull SensorContext context) {
-    if (shouldExecuteOnProject()) {
-      addCoverage(context);
-    }
+    addCoverage(context);
   }
 
   private void addCoverage(SensorContext context) {
@@ -93,10 +90,6 @@ public class DelphiCoverageSensor implements Sensor {
     } catch (IOException | InvalidPathException e) {
       LOG.error("Error while parsing coverage reports:", e);
     }
-  }
-
-  private boolean shouldExecuteOnProject() {
-    return delphiProjectHelper.shouldExecuteOnProject();
   }
 
   @Override

--- a/sonar-delphi-plugin/src/main/java/au/com/integradev/delphi/DelphiSensor.java
+++ b/sonar-delphi-plugin/src/main/java/au/com/integradev/delphi/DelphiSensor.java
@@ -86,11 +86,9 @@ public class DelphiSensor implements Sensor {
   /** The actual sensor code. */
   @Override
   public void execute(@Nonnull SensorContext context) {
-    if (shouldExecuteOnProject()) {
-      executor.setup();
-      executeOnFiles(context);
-      executor.complete();
-    }
+    executor.setup();
+    executeOnFiles(context);
+    executor.complete();
   }
 
   private void executeOnFiles(SensorContext sensorContext) {
@@ -210,10 +208,6 @@ public class DelphiSensor implements Sensor {
     searchPathDirectories.addAll(delphiProjectHelper.getLibraryPathDirectories());
     searchPathDirectories.addAll(delphiProjectHelper.getBrowsingPathDirectories());
     return SearchPath.create(searchPathDirectories);
-  }
-
-  private boolean shouldExecuteOnProject() {
-    return delphiProjectHelper.shouldExecuteOnProject();
   }
 
   @Override

--- a/sonar-delphi-plugin/src/test/java/au/com/integradev/delphi/DelphiCoverageSensorTest.java
+++ b/sonar-delphi-plugin/src/test/java/au/com/integradev/delphi/DelphiCoverageSensorTest.java
@@ -20,7 +20,6 @@ package au.com.integradev.delphi;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -37,8 +36,9 @@ import java.io.File;
 import java.util.UUID;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.sonar.api.batch.fs.InputFile;
 import org.sonar.api.batch.fs.internal.DefaultFileSystem;
-import org.sonar.api.batch.sensor.SensorDescriptor;
+import org.sonar.api.batch.sensor.internal.DefaultSensorDescriptor;
 import org.sonar.api.batch.sensor.internal.SensorContextTester;
 
 class DelphiCoverageSensorTest {
@@ -68,13 +68,13 @@ class DelphiCoverageSensorTest {
 
   @Test
   void testDescribe() {
-    final SensorDescriptor mockDescriptor = mock(SensorDescriptor.class);
-    when(mockDescriptor.onlyOnLanguage(anyString())).thenReturn(mockDescriptor);
+    final DefaultSensorDescriptor descriptor = new DefaultSensorDescriptor();
 
-    sensor.describe(mockDescriptor);
+    sensor.describe(descriptor);
 
-    verify(mockDescriptor).onlyOnLanguage(Delphi.KEY);
-    verify(mockDescriptor).name("DelphiCoverageSensor");
+    assertThat(descriptor.name()).isEqualTo("DelphiCoverageSensor");
+    assertThat(descriptor.languages()).containsExactly(Delphi.KEY);
+    assertThat(descriptor.type()).isEqualTo(InputFile.Type.MAIN);
   }
 
   @Test

--- a/sonar-delphi-plugin/src/test/java/au/com/integradev/delphi/DelphiCoverageSensorTest.java
+++ b/sonar-delphi-plugin/src/test/java/au/com/integradev/delphi/DelphiCoverageSensorTest.java
@@ -32,7 +32,6 @@ import au.com.integradev.delphi.core.Delphi;
 import au.com.integradev.delphi.coverage.DelphiCodeCoverageParser;
 import au.com.integradev.delphi.coverage.DelphiCoverageParser;
 import au.com.integradev.delphi.coverage.DelphiCoverageParserFactory;
-import au.com.integradev.delphi.msbuild.DelphiProjectHelper;
 import au.com.integradev.delphi.utils.DelphiUtils;
 import java.io.File;
 import java.util.UUID;
@@ -49,7 +48,6 @@ class DelphiCoverageSensorTest {
 
   private final DefaultFileSystem fileSystem = new DefaultFileSystem(BASE_DIR);
   private final SensorContextTester context = SensorContextTester.create(fileSystem.baseDir());
-  private final DelphiProjectHelper delphiProjectHelper = mock(DelphiProjectHelper.class);
   private final DelphiCoverageParserFactory coverageParserFactory =
       mock(DelphiCoverageParserFactory.class);
   private final DelphiCoverageParser coverageParser = mock(DelphiCodeCoverageParser.class);
@@ -58,8 +56,7 @@ class DelphiCoverageSensorTest {
 
   @BeforeEach
   void setupSensor() {
-    sensor = new DelphiCoverageSensor(delphiProjectHelper, coverageParserFactory);
-    when(delphiProjectHelper.shouldExecuteOnProject()).thenReturn(true);
+    sensor = new DelphiCoverageSensor(coverageParserFactory);
     when(coverageParserFactory.create()).thenReturn(coverageParser);
   }
 

--- a/sonar-delphi-plugin/src/test/java/au/com/integradev/delphi/DelphiSensorTest.java
+++ b/sonar-delphi-plugin/src/test/java/au/com/integradev/delphi/DelphiSensorTest.java
@@ -21,12 +21,9 @@ package au.com.integradev.delphi;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.willThrow;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -61,7 +58,6 @@ class DelphiSensorTest {
     baseDir = Files.createTempDirectory("baseDir");
 
     sensor = new DelphiSensor(delphiProjectHelper, executor);
-    when(delphiProjectHelper.shouldExecuteOnProject()).thenReturn(true);
     when(delphiProjectHelper.getToolchain())
         .thenReturn(DelphiProperties.COMPILER_TOOLCHAIN_DEFAULT);
     when(delphiProjectHelper.getCompilerVersion())
@@ -171,24 +167,6 @@ class DelphiSensorTest {
     willThrow(expectedException).given(executor).setup();
 
     assertThatThrownBy(() -> sensor.execute(mock())).isEqualTo(expectedException);
-  }
-
-  @Test
-  void testWhenShouldExecuteOnProjectReturnsFalseThenExecutorIsNotCalled() {
-    when(delphiProjectHelper.shouldExecuteOnProject()).thenReturn(false);
-
-    sensor.execute(mock());
-
-    verify(executor, never()).execute(any(), any());
-  }
-
-  @Test
-  void testWhenShouldExecuteOnProjectReturnsTrueThenExecutorIsCalled() {
-    when(delphiProjectHelper.shouldExecuteOnProject()).thenReturn(true);
-
-    sensor.execute(mock());
-
-    verify(executor, times(1)).execute(any(), any());
   }
 
   @Test


### PR DESCRIPTION
This PR corrects some little problems with how we handle `MAIN` vs `TEST` sources.
- It looks like the "lines" metric is forced off on `TEST` sources, and the official analyzers don't report metrics for test sources.
- The sonar scanner emits warnings when duplications are reported on `TEST` sources.
- Coverage should only be reported on `MAIN` sources.