### PR TITLE
Fix `RedundantInherited` quickfix removing too much surrounding code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Support for `DCCARM64EC` toolchain, introduced in Delphi 13.1.
 - `NoreturnContract` analysis rule, which flags `noreturn` routines that return normally.
 
+### Fixed
+
+- Quick fixes removing too much surrounding code in `RedundantInherited`.
+
 ## [1.18.3] - 2025-11-11
 
 ### Fixed

--- a/delphi-checks/src/main/java/au/com/integradev/delphi/checks/RedundantInheritedCheck.java
+++ b/delphi-checks/src/main/java/au/com/integradev/delphi/checks/RedundantInheritedCheck.java
@@ -27,6 +27,7 @@ import org.sonar.check.Rule;
 import org.sonar.plugins.communitydelphi.api.ast.CompoundStatementNode;
 import org.sonar.plugins.communitydelphi.api.ast.DelphiNode;
 import org.sonar.plugins.communitydelphi.api.ast.ExpressionStatementNode;
+import org.sonar.plugins.communitydelphi.api.ast.IfStatementNode;
 import org.sonar.plugins.communitydelphi.api.ast.RoutineImplementationNode;
 import org.sonar.plugins.communitydelphi.api.ast.StatementListNode;
 import org.sonar.plugins.communitydelphi.api.ast.StatementNode;
@@ -60,16 +61,14 @@ public class RedundantInheritedCheck extends DelphiCheck {
 
   private static List<QuickFix> getQuickFixes(
       DelphiNode violationNode, DelphiCheckContext context) {
-    DelphiNode violationStatement = violationNode;
-    DelphiNode parent = violationNode.getParent();
-    while (!(parent instanceof StatementListNode)) {
-      violationStatement = parent;
-      parent = parent.getParent();
-      if (parent == null) {
-        return Collections.emptyList();
-      }
+    StatementNode violationStatement = violationNode.getFirstParentOfType(StatementNode.class);
+
+    if (!(violationStatement.getParent() instanceof StatementListNode)) {
+      return quickFix(
+          QuickFixEdit.delete(getDirectStatementDeleteRange(violationNode, violationStatement)));
     }
-    StatementListNode statementListNode = (StatementListNode) parent;
+
+    StatementListNode statementListNode = (StatementListNode) violationStatement.getParent();
     int statementIndex = statementListNode.getStatements().indexOf(violationStatement);
 
     int startLine = violationStatement.getBeginLine();
@@ -90,10 +89,30 @@ public class RedundantInheritedCheck extends DelphiCheck {
       startCol = lastDeletableToken.getEndColumn();
     }
 
-    return List.of(
-        QuickFix.newFix("Remove redundant inherited call")
-            .withEdit(
-                QuickFixEdit.delete(FilePosition.from(startLine, startCol, endLine, endCol))));
+    return quickFix(QuickFixEdit.delete(FilePosition.from(startLine, startCol, endLine, endCol)));
+  }
+
+  private static List<QuickFix> quickFix(QuickFixEdit edit) {
+    return List.of(QuickFix.newFix("Remove redundant inherited call").withEdit(edit));
+  }
+
+  private static FilePosition getDirectStatementDeleteRange(
+      DelphiNode violationNode, StatementNode violationStatement) {
+    DelphiNode parent = violationStatement.getParent();
+    if (parent instanceof IfStatementNode) {
+      IfStatementNode ifStatement = (IfStatementNode) parent;
+      if (ifStatement.getElseStatement() == violationStatement) {
+        DelphiNode elseToken = parent.getFirstChildWithTokenType(DelphiTokenType.ELSE);
+
+        return FilePosition.from(
+            elseToken.getBeginLine(),
+            elseToken.getBeginColumn(),
+            violationStatement.getEndLine(),
+            violationStatement.getEndColumn());
+      }
+    }
+
+    return FilePosition.from(violationNode);
   }
 
   private static DelphiToken nextNonWhitespaceToken(

--- a/delphi-checks/src/test/java/au/com/integradev/delphi/checks/RedundantInheritedCheckTest.java
+++ b/delphi-checks/src/test/java/au/com/integradev/delphi/checks/RedundantInheritedCheckTest.java
@@ -211,6 +211,135 @@ class RedundantInheritedCheckTest {
   }
 
   @Test
+  void testThenBranchShouldAddQuickFix() {
+    CheckVerifier.newVerifier()
+        .withCheck(new RedundantInheritedCheck())
+        .onFile(
+            new DelphiTestUnitBuilder()
+                .appendDecl("type")
+                .appendDecl("  TBase = class(TObject);")
+                .appendDecl("  TChild = class(TBase)")
+                .appendDecl("    procedure MyProcedure(Sender: TObject);")
+                .appendDecl("  end;")
+                .appendImpl("procedure TChild.MyProcedure(Sender: TObject);")
+                .appendImpl("begin")
+                .appendImpl("  if Sender = nil then")
+                .appendImpl("    // Fix qf1@[+1:4 to +1:13] <<>>")
+                .appendImpl("    inherited; // Noncompliant")
+                .appendImpl("end;"))
+        .verifyIssues();
+  }
+
+  @Test
+  void testElseBranchShouldAddQuickFix() {
+    CheckVerifier.newVerifier()
+        .withCheck(new RedundantInheritedCheck())
+        .onFile(
+            new DelphiTestUnitBuilder()
+                .appendDecl("type")
+                .appendDecl("  TBase = class(TObject);")
+                .appendDecl("  TChild = class(TBase)")
+                .appendDecl("    procedure MyProcedure(Sender: TObject);")
+                .appendDecl("  end;")
+                .appendImpl("procedure TChild.MyProcedure(Sender: TObject);")
+                .appendImpl("begin")
+                .appendImpl("  if Sender = nil then")
+                .appendImpl("  begin")
+                .appendImpl("    Exit;")
+                .appendImpl("  end")
+                .appendImpl("  // Fix qf1@[+1:2 to +2:13] <<>>")
+                .appendImpl("  else")
+                .appendImpl("    inherited; // Noncompliant")
+                .appendImpl("end;"))
+        .verifyIssues();
+  }
+
+  @Test
+  void testInheritedSurroundedByStatementsShouldAddQuickFix() {
+    CheckVerifier.newVerifier()
+        .withCheck(new RedundantInheritedCheck())
+        .onFile(
+            new DelphiTestUnitBuilder()
+                .appendDecl("type")
+                .appendDecl("  TBase = class(TObject);")
+                .appendDecl("  TChild = class(TBase)")
+                .appendDecl("    procedure MyProcedure;")
+                .appendDecl("  end;")
+                .appendImpl("procedure TChild.MyProcedure;")
+                .appendImpl("begin")
+                .appendImpl("  A := 1;")
+                .appendImpl("  // Fix qf1@[+1:2 to +1:13] <<>>")
+                .appendImpl("  inherited; // Noncompliant")
+                .appendImpl("  A := 2;")
+                .appendImpl("end;"))
+        .verifyIssues();
+  }
+
+  @Test
+  void testLoopBodyShouldAddQuickFix() {
+    CheckVerifier.newVerifier()
+        .withCheck(new RedundantInheritedCheck())
+        .onFile(
+            new DelphiTestUnitBuilder()
+                .appendDecl("type")
+                .appendDecl("  TBase = class(TObject);")
+                .appendDecl("  TChild = class(TBase)")
+                .appendDecl("    procedure MyProcedure(Sender: TObject);")
+                .appendDecl("  end;")
+                .appendImpl("procedure TChild.MyProcedure(Sender: TObject);")
+                .appendImpl("begin")
+                .appendImpl("  while Sender = nil do")
+                .appendImpl("    // Fix qf1@[+1:4 to +1:13] <<>>")
+                .appendImpl("    inherited; // Noncompliant")
+                .appendImpl("end;"))
+        .verifyIssues();
+  }
+
+  @Test
+  void testCaseItemDirectStatementShouldAddQuickFix() {
+    CheckVerifier.newVerifier()
+        .withCheck(new RedundantInheritedCheck())
+        .onFile(
+            new DelphiTestUnitBuilder()
+                .appendDecl("type")
+                .appendDecl("  TBase = class(TObject);")
+                .appendDecl("  TChild = class(TBase)")
+                .appendDecl("    procedure MyProcedure(Sender: TObject);")
+                .appendDecl("  end;")
+                .appendImpl("procedure TChild.MyProcedure(Sender: TObject);")
+                .appendImpl("begin")
+                .appendImpl("  case Integer(Sender) of")
+                .appendImpl("    // Fix qf1@[+1:7 to +1:16] <<>>")
+                .appendImpl("    0: inherited; // Noncompliant")
+                .appendImpl("  end;")
+                .appendImpl("end;"))
+        .verifyIssues();
+  }
+
+  @Test
+  void testOnHandlerDirectStatementShouldAddQuickFix() {
+    CheckVerifier.newVerifier()
+        .withCheck(new RedundantInheritedCheck())
+        .onFile(
+            new DelphiTestUnitBuilder()
+                .appendDecl("type")
+                .appendDecl("  TBase = class(TObject);")
+                .appendDecl("  TChild = class(TBase)")
+                .appendDecl("    procedure MyProcedure;")
+                .appendDecl("  end;")
+                .appendImpl("procedure TChild.MyProcedure;")
+                .appendImpl("begin")
+                .appendImpl("  try")
+                .appendImpl("    DoThing;")
+                .appendImpl("  except")
+                .appendImpl("    // Fix qf1@[+1:23 to +1:32] <<>>")
+                .appendImpl("    on E: Exception do inherited; // Noncompliant")
+                .appendImpl("  end;")
+                .appendImpl("end;"))
+        .verifyIssues();
+  }
+
+  @Test
   void testIssuesFollowingIncludeDirectiveShouldAddQuickFixes() {
     CheckVerifier.newVerifier()
         .withCheck(new RedundantInheritedCheck())

--- a/delphi-checks/src/test/java/au/com/integradev/delphi/checks/RedundantInheritedCheckTest.java
+++ b/delphi-checks/src/test/java/au/com/integradev/delphi/checks/RedundantInheritedCheckTest.java
@@ -39,11 +39,11 @@ class RedundantInheritedCheckTest {
                 .appendDecl("  end;")
                 .appendImpl("procedure TChild.MyProcedure;")
                 .appendImpl("begin")
-                .appendImpl("  inherited; // Compliant")
+                .appendImpl("  inherited;")
                 .appendImpl("  begin")
-                .appendImpl("    inherited; // Compliant")
+                .appendImpl("    inherited;")
                 .appendImpl("  end;")
-                .appendImpl("  inherited; // Compliant")
+                .appendImpl("  inherited;")
                 .appendImpl("end;"))
         .verifyNoIssues();
   }
@@ -63,11 +63,11 @@ class RedundantInheritedCheckTest {
                 .appendDecl("  end;")
                 .appendImpl("procedure TChild.MyProcedure;")
                 .appendImpl("begin")
-                .appendImpl("  inherited; // Compliant")
+                .appendImpl("  inherited;")
                 .appendImpl("  begin")
-                .appendImpl("    inherited; // Compliant")
+                .appendImpl("    inherited;")
                 .appendImpl("  end;")
-                .appendImpl("  inherited; // Compliant")
+                .appendImpl("  inherited;")
                 .appendImpl("end;"))
         .verifyNoIssues();
   }
@@ -90,11 +90,11 @@ class RedundantInheritedCheckTest {
                 .appendDecl("  end;")
                 .appendImpl("procedure TGrandChild.MyProcedure;")
                 .appendImpl("begin")
-                .appendImpl("  inherited; // Compliant")
+                .appendImpl("  inherited;")
                 .appendImpl("  begin")
-                .appendImpl("    inherited; // Compliant")
+                .appendImpl("    inherited;")
                 .appendImpl("  end;")
-                .appendImpl("  inherited; // Compliant")
+                .appendImpl("  inherited;")
                 .appendImpl("end;"))
         .verifyNoIssues();
   }
@@ -115,11 +115,11 @@ class RedundantInheritedCheckTest {
                 .appendDecl("  end;")
                 .appendImpl("procedure TGrandChild.MyProcedure;")
                 .appendImpl("begin")
-                .appendImpl("  inherited; // Compliant")
+                .appendImpl("  inherited;")
                 .appendImpl("  begin")
-                .appendImpl("    inherited; // Compliant")
+                .appendImpl("    inherited;")
                 .appendImpl("  end;")
-                .appendImpl("  inherited; // Compliant")
+                .appendImpl("  inherited;")
                 .appendImpl("end;"))
         .verifyNoIssues();
   }
@@ -139,7 +139,7 @@ class RedundantInheritedCheckTest {
                 .appendDecl("  end;")
                 .appendImpl("procedure TChild.MyProcedure;")
                 .appendImpl("begin")
-                .appendImpl("  inherited; // Compliant")
+                .appendImpl("  inherited;")
                 .appendImpl("end;"))
         .verifyNoIssues();
   }
@@ -177,7 +177,7 @@ class RedundantInheritedCheckTest {
                 .appendDecl("  end;")
                 .appendImpl("procedure TFoo.Handler;")
                 .appendImpl("begin")
-                .appendImpl("  inherited; // Compliant")
+                .appendImpl("  inherited;")
                 .appendImpl("end;"))
         .verifyNoIssues();
   }

--- a/delphi-checks/src/test/java/au/com/integradev/delphi/checks/RedundantInheritedCheckTest.java
+++ b/delphi-checks/src/test/java/au/com/integradev/delphi/checks/RedundantInheritedCheckTest.java
@@ -183,6 +183,44 @@ class RedundantInheritedCheckTest {
   }
 
   @Test
+  void testAsmRoutineShouldNotAddIssue() {
+    CheckVerifier.newVerifier()
+        .withCheck(new RedundantInheritedCheck())
+        .onFile(
+            new DelphiTestUnitBuilder()
+                .appendImpl("procedure Foo;")
+                .appendImpl("asm")
+                .appendImpl("  MOV EAX, 1")
+                .appendImpl("end;"))
+        .verifyNoIssues();
+  }
+
+  @Test
+  void testEmptyRoutineShouldNotAddIssue() {
+    CheckVerifier.newVerifier()
+        .withCheck(new RedundantInheritedCheck())
+        .onFile(
+            new DelphiTestUnitBuilder()
+                .appendImpl("procedure Foo;")
+                .appendImpl("begin")
+                .appendImpl("end;"))
+        .verifyNoIssues();
+  }
+
+  @Test
+  void testNonMethodShouldAddIssue() {
+    CheckVerifier.newVerifier()
+        .withCheck(new RedundantInheritedCheck())
+        .onFile(
+            new DelphiTestUnitBuilder()
+                .appendImpl("procedure Foo;")
+                .appendImpl("begin")
+                .appendImpl("  inherited; // Noncompliant")
+                .appendImpl("end;"))
+        .verifyIssues();
+  }
+
+  @Test
   void testNotOverridingMethodShouldAddIssues() {
     CheckVerifier.newVerifier()
         .withCheck(new RedundantInheritedCheck())
@@ -271,6 +309,45 @@ class RedundantInheritedCheckTest {
                 .appendImpl("  // Fix qf1@[+1:2 to +1:13] <<>>")
                 .appendImpl("  inherited; // Noncompliant")
                 .appendImpl("  A := 2;")
+                .appendImpl("end;"))
+        .verifyIssues();
+  }
+
+  @Test
+  void testInheritedWithTrailingExtraSemicolonShouldAddQuickFix() {
+    CheckVerifier.newVerifier()
+        .withCheck(new RedundantInheritedCheck())
+        .onFile(
+            new DelphiTestUnitBuilder()
+                .appendDecl("type")
+                .appendDecl("  TBase = class(TObject);")
+                .appendDecl("  TChild = class(TBase)")
+                .appendDecl("    procedure MyProcedure;")
+                .appendDecl("  end;")
+                .appendImpl("procedure TChild.MyProcedure;")
+                .appendImpl("begin")
+                .appendImpl("  // Fix qf1@[+1:2 to +1:14] <<>>")
+                .appendImpl("  inherited; ; // Noncompliant")
+                .appendImpl("end;"))
+        .verifyIssues();
+  }
+
+  @Test
+  void testInheritedWithTrailingExtraSemicolonBeforeNextStatementShouldAddQuickFix() {
+    CheckVerifier.newVerifier()
+        .withCheck(new RedundantInheritedCheck())
+        .onFile(
+            new DelphiTestUnitBuilder()
+                .appendDecl("type")
+                .appendDecl("  TBase = class(TObject);")
+                .appendDecl("  TChild = class(TBase)")
+                .appendDecl("    procedure MyProcedure;")
+                .appendDecl("  end;")
+                .appendImpl("procedure TChild.MyProcedure;")
+                .appendImpl("begin")
+                .appendImpl("  // Fix qf1@[+1:2 to +1:15] <<>>")
+                .appendImpl("  inherited; ; // Noncompliant")
+                .appendImpl("  A := 1;")
                 .appendImpl("end;"))
         .verifyIssues();
   }


### PR DESCRIPTION
This PR fixes some overly-eager quickfix deletions in `RedundantInherited`.

Fixes #430.