### PR TITLE
Add support for `if` expressions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Full support for the `HIGHCHARUNICODE` compiler directive.
 - Support for the `DCC_CodePage` property in dproj files.
 - `sonar.delphi.codePage` property to specify the code page that will be used to interpret ANSI data.
+- Support for `if` expressions (e.g. `X := if Foo then Bar else Baz;`), introduced in Delphi 13.
 
 ### Changed
 

--- a/delphi-frontend/src/main/antlr3/au/com/integradev/delphi/antlr/Delphi.g
+++ b/delphi-frontend/src/main/antlr3/au/com/integradev/delphi/antlr/Delphi.g
@@ -72,6 +72,7 @@ tokens {
   TkArgument;
   TkAnonymousMethod;
   TkAnonymousMethodHeading;
+  TkIfExpression;
   TkLessThanEqual;
   TkGreaterThanEqual;
 }
@@ -922,6 +923,10 @@ attribute                    : (ASSEMBLY ':')? expression (':' expression)*
 //----------------------------------------------------------------------------
 expression                   : relationalExpression
                              | anonymousMethod
+                             | ifExpression
+                             ;
+ifExpression                 : IF expression THEN expression ELSE expression
+                             -> ^(TkIfExpression<IfExpressionNodeImpl> IF expression THEN expression ELSE expression)
                              ;
 // ANTLR sets the begin and end tokens for nested binary expression nodes
 // in relationalOperator, not relationalExpression, meaning that their

--- a/delphi-frontend/src/main/java/au/com/integradev/delphi/antlr/ast/node/IfExpressionNodeImpl.java
+++ b/delphi-frontend/src/main/java/au/com/integradev/delphi/antlr/ast/node/IfExpressionNodeImpl.java
@@ -1,0 +1,79 @@
+/*
+ * Sonar Delphi Plugin
+ * Copyright (C) 2026 Integrated Application Development
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02
+ */
+package au.com.integradev.delphi.antlr.ast.node;
+
+import au.com.integradev.delphi.antlr.ast.visitors.DelphiParserVisitor;
+import au.com.integradev.delphi.symbol.resolve.ExpressionTypeResolver;
+import javax.annotation.Nonnull;
+import org.antlr.runtime.Token;
+import org.sonar.plugins.communitydelphi.api.ast.ExpressionNode;
+import org.sonar.plugins.communitydelphi.api.ast.IfExpressionNode;
+import org.sonar.plugins.communitydelphi.api.type.Type;
+
+public final class IfExpressionNodeImpl extends ExpressionNodeImpl implements IfExpressionNode {
+  private String image;
+
+  public IfExpressionNodeImpl(Token token) {
+    super(token);
+  }
+
+  public IfExpressionNodeImpl(int tokenType) {
+    super(tokenType);
+  }
+
+  @Override
+  public <T> T accept(DelphiParserVisitor<T> visitor, T data) {
+    return visitor.visit(this, data);
+  }
+
+  @Override
+  public ExpressionNode getGuardExpression() {
+    return (ExpressionNode) getChild(1);
+  }
+
+  @Override
+  public ExpressionNode getThenExpression() {
+    return (ExpressionNode) getChild(3);
+  }
+
+  @Override
+  public ExpressionNode getElseExpression() {
+    return (ExpressionNode) getChild(5);
+  }
+
+  @Override
+  public String getImage() {
+    if (image == null) {
+      image =
+          "if "
+              + getGuardExpression().getImage()
+              + " then "
+              + getThenExpression().getImage()
+              + " else "
+              + getElseExpression().getImage();
+    }
+    return image;
+  }
+
+  @Override
+  @Nonnull
+  protected Type createType() {
+    return new ExpressionTypeResolver(getTypeFactory()).resolve(this);
+  }
+}

--- a/delphi-frontend/src/main/java/au/com/integradev/delphi/antlr/ast/visitors/CognitiveComplexityVisitor.java
+++ b/delphi-frontend/src/main/java/au/com/integradev/delphi/antlr/ast/visitors/CognitiveComplexityVisitor.java
@@ -31,6 +31,7 @@ import org.sonar.plugins.communitydelphi.api.ast.DelphiNode;
 import org.sonar.plugins.communitydelphi.api.ast.ExceptBlockNode;
 import org.sonar.plugins.communitydelphi.api.ast.ExpressionNode;
 import org.sonar.plugins.communitydelphi.api.ast.ForStatementNode;
+import org.sonar.plugins.communitydelphi.api.ast.IfExpressionNode;
 import org.sonar.plugins.communitydelphi.api.ast.IfStatementNode;
 import org.sonar.plugins.communitydelphi.api.ast.RepeatStatementNode;
 import org.sonar.plugins.communitydelphi.api.ast.StatementNode;
@@ -86,6 +87,19 @@ public class CognitiveComplexityVisitor implements DelphiParserVisitor<Data> {
         --data.nesting;
       }
     }
+
+    return data;
+  }
+
+  @Override
+  public Data visit(IfExpressionNode expression, Data data) {
+    data.increaseComplexityByNesting();
+    expression.getGuardExpression().accept(this, data);
+
+    ++data.nesting;
+    expression.getThenExpression().accept(this, data);
+    expression.getElseExpression().accept(this, data);
+    --data.nesting;
 
     return data;
   }

--- a/delphi-frontend/src/main/java/au/com/integradev/delphi/antlr/ast/visitors/CyclomaticComplexityVisitor.java
+++ b/delphi-frontend/src/main/java/au/com/integradev/delphi/antlr/ast/visitors/CyclomaticComplexityVisitor.java
@@ -23,6 +23,7 @@ import org.sonar.plugins.communitydelphi.api.ast.AnonymousMethodNode;
 import org.sonar.plugins.communitydelphi.api.ast.BinaryExpressionNode;
 import org.sonar.plugins.communitydelphi.api.ast.CaseItemStatementNode;
 import org.sonar.plugins.communitydelphi.api.ast.ForStatementNode;
+import org.sonar.plugins.communitydelphi.api.ast.IfExpressionNode;
 import org.sonar.plugins.communitydelphi.api.ast.IfStatementNode;
 import org.sonar.plugins.communitydelphi.api.ast.RepeatStatementNode;
 import org.sonar.plugins.communitydelphi.api.ast.RoutineImplementationNode;
@@ -78,6 +79,12 @@ public class CyclomaticComplexityVisitor implements DelphiParserVisitor<Data> {
   public Data visit(IfStatementNode statement, Data data) {
     ++data.complexity;
     return DelphiParserVisitor.super.visit(statement, data);
+  }
+
+  @Override
+  public Data visit(IfExpressionNode expression, Data data) {
+    ++data.complexity;
+    return DelphiParserVisitor.super.visit(expression, data);
   }
 
   @Override

--- a/delphi-frontend/src/main/java/au/com/integradev/delphi/antlr/ast/visitors/DelphiParserVisitor.java
+++ b/delphi-frontend/src/main/java/au/com/integradev/delphi/antlr/ast/visitors/DelphiParserVisitor.java
@@ -81,6 +81,7 @@ import org.sonar.plugins.communitydelphi.api.ast.GenericDefinitionNode;
 import org.sonar.plugins.communitydelphi.api.ast.GotoStatementNode;
 import org.sonar.plugins.communitydelphi.api.ast.HelperTypeNode;
 import org.sonar.plugins.communitydelphi.api.ast.IdentifierNode;
+import org.sonar.plugins.communitydelphi.api.ast.IfExpressionNode;
 import org.sonar.plugins.communitydelphi.api.ast.IfStatementNode;
 import org.sonar.plugins.communitydelphi.api.ast.ImplementationSectionNode;
 import org.sonar.plugins.communitydelphi.api.ast.ImportClauseNode;
@@ -621,6 +622,10 @@ public interface DelphiParserVisitor<T> {
   }
 
   default T visit(AnonymousMethodNode node, T data) {
+    return visit((ExpressionNode) node, data);
+  }
+
+  default T visit(IfExpressionNode node, T data) {
     return visit((ExpressionNode) node, data);
   }
 

--- a/delphi-frontend/src/main/java/au/com/integradev/delphi/cfg/ControlFlowGraphVisitor.java
+++ b/delphi-frontend/src/main/java/au/com/integradev/delphi/cfg/ControlFlowGraphVisitor.java
@@ -50,6 +50,7 @@ import org.sonar.plugins.communitydelphi.api.ast.ForLoopVarReferenceNode;
 import org.sonar.plugins.communitydelphi.api.ast.ForStatementNode;
 import org.sonar.plugins.communitydelphi.api.ast.ForToStatementNode;
 import org.sonar.plugins.communitydelphi.api.ast.GotoStatementNode;
+import org.sonar.plugins.communitydelphi.api.ast.IfExpressionNode;
 import org.sonar.plugins.communitydelphi.api.ast.IfStatementNode;
 import org.sonar.plugins.communitydelphi.api.ast.IntegerLiteralNode;
 import org.sonar.plugins.communitydelphi.api.ast.LabelStatementNode;
@@ -273,6 +274,22 @@ class ControlFlowGraphVisitor implements DelphiParserVisitor<ControlFlowGraphBui
     ProtoBlock thenBlock = builder.getCurrentBlock();
 
     // process condition
+    builder.addBlock(ProtoBlockFactory.branch(node, thenBlock, elseBlock));
+    return buildCondition(builder, node.getGuardExpression(), thenBlock, elseBlock);
+  }
+
+  @Override
+  public ControlFlowGraphBuilder visit(IfExpressionNode node, ControlFlowGraphBuilder builder) {
+    ProtoBlock after = builder.getCurrentBlock();
+
+    builder.addBlockBefore(after);
+    build(node.getElseExpression(), builder);
+    ProtoBlock elseBlock = builder.getCurrentBlock();
+
+    builder.addBlockBefore(after);
+    build(node.getThenExpression(), builder);
+    ProtoBlock thenBlock = builder.getCurrentBlock();
+
     builder.addBlock(ProtoBlockFactory.branch(node, thenBlock, elseBlock));
     return buildCondition(builder, node.getGuardExpression(), thenBlock, elseBlock);
   }

--- a/delphi-frontend/src/main/java/au/com/integradev/delphi/symbol/resolve/ExpressionTypeResolver.java
+++ b/delphi-frontend/src/main/java/au/com/integradev/delphi/symbol/resolve/ExpressionTypeResolver.java
@@ -36,6 +36,7 @@ import org.sonar.plugins.communitydelphi.api.ast.BinaryExpressionNode;
 import org.sonar.plugins.communitydelphi.api.ast.CommonDelphiNode;
 import org.sonar.plugins.communitydelphi.api.ast.DelphiNode;
 import org.sonar.plugins.communitydelphi.api.ast.ExpressionNode;
+import org.sonar.plugins.communitydelphi.api.ast.IfExpressionNode;
 import org.sonar.plugins.communitydelphi.api.ast.NameReferenceNode;
 import org.sonar.plugins.communitydelphi.api.ast.Node;
 import org.sonar.plugins.communitydelphi.api.ast.PrimaryExpressionNode;
@@ -57,6 +58,7 @@ import org.sonar.plugins.communitydelphi.api.type.Parameter;
 import org.sonar.plugins.communitydelphi.api.type.Type;
 import org.sonar.plugins.communitydelphi.api.type.Type.ClassReferenceType;
 import org.sonar.plugins.communitydelphi.api.type.Type.CollectionType;
+import org.sonar.plugins.communitydelphi.api.type.Type.IntegerType;
 import org.sonar.plugins.communitydelphi.api.type.Type.PointerType;
 import org.sonar.plugins.communitydelphi.api.type.Type.ProceduralType;
 import org.sonar.plugins.communitydelphi.api.type.TypeFactory;
@@ -91,6 +93,136 @@ public final class ExpressionTypeResolver {
     } else {
       return resolveOperatorType(operator, operand);
     }
+  }
+
+  public Type resolve(IfExpressionNode expression) {
+    return commonType(
+        expression.getThenExpression().getType(), expression.getElseExpression().getType());
+  }
+
+  /**
+   * Resolves the type of an {@code if} expression as the "least upper bound" of its {@code then}
+   * and {@code else} branch types, mirroring the type combinations accepted by the Delphi compiler.
+   *
+   * @see <a href="https://docwiki.embarcadero.com/RADStudio/en/Conditional_Operators_(Delphi)">
+   *     Conditional Operators (Delphi)</a>
+   */
+  private Type commonType(Type thenType, Type elseType) {
+    if (thenType.isUnknown()) {
+      return elseType;
+    }
+    if (elseType.isUnknown()) {
+      return thenType;
+    }
+    if (thenType.is(elseType)) {
+      return thenType;
+    }
+    if (thenType.isInteger() && elseType.isInteger()) {
+      return integerCommonType((IntegerType) thenType, (IntegerType) elseType);
+    }
+    if (isNumeric(thenType) && isNumeric(elseType)) {
+      return realCommonType(thenType, elseType);
+    }
+    if (isTextual(thenType) && isTextual(elseType)) {
+      return textualCommonType(thenType, elseType);
+    }
+    if (thenType.isStruct() && elseType.isStruct()) {
+      return structCommonType(thenType, elseType);
+    }
+    return unknownType();
+  }
+
+  /**
+   * Two integers widen to at least {@code Integer}; mixing a 32-bit unsigned ({@code Cardinal})
+   * with any signed integer, or involving any 64-bit integer, widens to {@code Int64}.
+   */
+  private Type integerCommonType(IntegerType thenType, IntegerType elseType) {
+    boolean any64Bit = thenType.size() >= 8 || elseType.size() >= 8;
+    boolean unsigned32Bit =
+        (!thenType.isSigned() && thenType.size() == 4)
+            || (!elseType.isSigned() && elseType.size() == 4);
+    boolean anySigned = thenType.isSigned() || elseType.isSigned();
+
+    if (any64Bit || (unsigned32Bit && anySigned)) {
+      return typeFactory.getIntrinsic(IntrinsicType.INT64);
+    }
+    return typeFactory.getIntrinsic(IntrinsicType.INTEGER);
+  }
+
+  /**
+   * A real combined with another real or an integer collapses to {@code Double}, unless both sides
+   * are integer-valued ({@code Comp}, {@code Currency}, or an integer), in which case it is {@code
+   * Comp}.
+   */
+  private Type realCommonType(Type thenType, Type elseType) {
+    if (isIntegerValued(thenType) && isIntegerValued(elseType)) {
+      return typeFactory.getIntrinsic(IntrinsicType.COMP);
+    }
+    return typeFactory.getIntrinsic(IntrinsicType.DOUBLE);
+  }
+
+  private boolean isIntegerValued(Type type) {
+    return type.isInteger()
+        || type.is(typeFactory.getIntrinsic(IntrinsicType.COMP))
+        || type.is(typeFactory.getIntrinsic(IntrinsicType.CURRENCY));
+  }
+
+  /**
+   * Characters and strings that involve a {@code UnicodeString} promote to {@code UnicodeString};
+   * other combinations are left unknown.
+   */
+  private Type textualCommonType(Type thenType, Type elseType) {
+    Type unicodeString = typeFactory.getIntrinsic(IntrinsicType.UNICODESTRING);
+    if (thenType.is(unicodeString) || elseType.is(unicodeString)) {
+      return unicodeString;
+    }
+    return unknownType();
+  }
+
+  /**
+   * When one struct is assignable to the other (e.g. a descendant and its ancestor), the less
+   * derived type wins; otherwise the nearest shared ancestor is used.
+   */
+  private static Type structCommonType(Type thenType, Type elseType) {
+    boolean thenToElse =
+        TypeComparer.compare(thenType, elseType) != EqualityType.INCOMPATIBLE_TYPES;
+    boolean elseToThen =
+        TypeComparer.compare(elseType, thenType) != EqualityType.INCOMPATIBLE_TYPES;
+
+    if (thenToElse && !elseToThen) {
+      return elseType;
+    }
+    if (elseToThen && !thenToElse) {
+      return thenType;
+    }
+    return findCommonAncestor(thenType, elseType);
+  }
+
+  private static boolean isNumeric(Type type) {
+    return type.isInteger() || type.isReal();
+  }
+
+  private static boolean isTextual(Type type) {
+    return type.isChar() || type.isString();
+  }
+
+  private static Type findCommonAncestor(Type left, Type right) {
+    if (!left.isStruct() || !right.isStruct()) {
+      return unknownType();
+    }
+
+    for (Type leftAncestor = left.parent();
+        !leftAncestor.isUnknown();
+        leftAncestor = leftAncestor.parent()) {
+      for (Type rightAncestor = right.parent();
+          !rightAncestor.isUnknown();
+          rightAncestor = rightAncestor.parent()) {
+        if (leftAncestor.is(rightAncestor)) {
+          return leftAncestor;
+        }
+      }
+    }
+    return unknownType();
   }
 
   public Type resolve(PrimaryExpressionNode expression) {

--- a/delphi-frontend/src/main/java/org/sonar/plugins/communitydelphi/api/ast/IfExpressionNode.java
+++ b/delphi-frontend/src/main/java/org/sonar/plugins/communitydelphi/api/ast/IfExpressionNode.java
@@ -1,0 +1,27 @@
+/*
+ * Sonar Delphi Plugin
+ * Copyright (C) 2026 Integrated Application Development
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02
+ */
+package org.sonar.plugins.communitydelphi.api.ast;
+
+public interface IfExpressionNode extends ExpressionNode {
+  ExpressionNode getGuardExpression();
+
+  ExpressionNode getThenExpression();
+
+  ExpressionNode getElseExpression();
+}

--- a/delphi-frontend/src/test/java/au/com/integradev/delphi/antlr/GrammarTest.java
+++ b/delphi-frontend/src/test/java/au/com/integradev/delphi/antlr/GrammarTest.java
@@ -142,6 +142,11 @@ class GrammarTest {
   }
 
   @Test
+  void testParseConditionalExpressions() {
+    assertParsed("ConditionalExpressions.pas");
+  }
+
+  @Test
   void testParseGenerics() {
     assertParsed("Generics.pas");
   }

--- a/delphi-frontend/src/test/java/au/com/integradev/delphi/cfg/ControlFlowGraphTest.java
+++ b/delphi-frontend/src/test/java/au/com/integradev/delphi/cfg/ControlFlowGraphTest.java
@@ -65,6 +65,7 @@ import org.sonar.plugins.communitydelphi.api.ast.FinallyBlockNode;
 import org.sonar.plugins.communitydelphi.api.ast.ForInStatementNode;
 import org.sonar.plugins.communitydelphi.api.ast.ForToStatementNode;
 import org.sonar.plugins.communitydelphi.api.ast.GotoStatementNode;
+import org.sonar.plugins.communitydelphi.api.ast.IfExpressionNode;
 import org.sonar.plugins.communitydelphi.api.ast.IfStatementNode;
 import org.sonar.plugins.communitydelphi.api.ast.IntegerLiteralNode;
 import org.sonar.plugins.communitydelphi.api.ast.NameDeclarationNode;
@@ -343,6 +344,20 @@ class ControlFlowGraphTest {
                 .branchesTo(1, 1)
                 .withTerminator(IfStatementNode.class),
             block(element(NameReferenceNode.class, "A")).succeedsTo(EXIT_ID)));
+  }
+
+  @Test
+  void testIfExpression() {
+    test(
+        List.of("X: Integer"),
+        "X := if A then Foo else Bar;",
+        checker(
+            block(element(NameReferenceNode.class, "A"))
+                .branchesTo(3, 2)
+                .withTerminator(IfExpressionNode.class),
+            block(element(NameReferenceNode.class, "Foo")).succeedsTo(1),
+            block(element(NameReferenceNode.class, "Bar")).succeedsTo(1),
+            block(element(NameReferenceNode.class, "X")).succeedsTo(0)));
   }
 
   @Test

--- a/delphi-frontend/src/test/java/au/com/integradev/delphi/symbol/resolve/ExpressionTypeResolverTest.java
+++ b/delphi-frontend/src/test/java/au/com/integradev/delphi/symbol/resolve/ExpressionTypeResolverTest.java
@@ -1,0 +1,220 @@
+/*
+ * Sonar Delphi Plugin
+ * Copyright (C) 2026 Integrated Application Development
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02
+ */
+package au.com.integradev.delphi.symbol.resolve;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.sonar.plugins.communitydelphi.api.type.StructKind.CLASS;
+import static org.sonar.plugins.communitydelphi.api.type.TypeFactory.unknownType;
+
+import au.com.integradev.delphi.utils.types.TypeFactoryUtils;
+import au.com.integradev.delphi.utils.types.TypeMocker;
+import org.junit.jupiter.api.Test;
+import org.sonar.plugins.communitydelphi.api.ast.ExpressionNode;
+import org.sonar.plugins.communitydelphi.api.ast.IfExpressionNode;
+import org.sonar.plugins.communitydelphi.api.type.IntrinsicType;
+import org.sonar.plugins.communitydelphi.api.type.Type;
+import org.sonar.plugins.communitydelphi.api.type.TypeFactory;
+
+/**
+ * The expected result type of every {@code if ... then ... else ...} expression in this test was
+ * obtained from the Delphi 13 (compiler version 37.0) {@code dcc64} compiler, by assigning the
+ * expression to an incompatible variable and reading the type named in the resulting {@code E2010
+ * Incompatible types} error.
+ */
+class ExpressionTypeResolverTest {
+  private static final TypeFactory FACTORY = TypeFactoryUtils.defaultFactory();
+  private static final ExpressionTypeResolver RESOLVER = new ExpressionTypeResolver(FACTORY);
+
+  private static Type intrinsic(IntrinsicType type) {
+    return FACTORY.getIntrinsic(type);
+  }
+
+  // ---- same type / unknown -------------------------------------------------
+
+  @Test
+  void testSameTypeOnBothBranchesReturnsThatType() {
+    assertResolvesBoth(IntrinsicType.INTEGER, IntrinsicType.INTEGER, IntrinsicType.INTEGER);
+    assertResolvesBoth(IntrinsicType.CARDINAL, IntrinsicType.CARDINAL, IntrinsicType.CARDINAL);
+    assertResolvesBoth(IntrinsicType.UINT64, IntrinsicType.UINT64, IntrinsicType.UINT64);
+    assertResolvesBoth(IntrinsicType.CURRENCY, IntrinsicType.CURRENCY, IntrinsicType.CURRENCY);
+    assertResolvesBoth(IntrinsicType.COMP, IntrinsicType.COMP, IntrinsicType.COMP);
+  }
+
+  @Test
+  void testUnknownThenBranchReturnsElseType() {
+    Type integer = intrinsic(IntrinsicType.INTEGER);
+    assertThat(resolve(unknownType(), integer).is(integer)).isTrue();
+  }
+
+  @Test
+  void testUnknownElseBranchReturnsThenType() {
+    Type integer = intrinsic(IntrinsicType.INTEGER);
+    assertThat(resolve(integer, unknownType()).is(integer)).isTrue();
+  }
+
+  // ---- integer widening ----------------------------------------------------
+
+  @Test
+  void testTwoSignedIntegersWidenToSignedAtLeastInteger() {
+    assertResolvesBoth(IntrinsicType.SHORTINT, IntrinsicType.SMALLINT, IntrinsicType.INTEGER);
+    assertResolvesBoth(IntrinsicType.SHORTINT, IntrinsicType.INTEGER, IntrinsicType.INTEGER);
+    assertResolvesBoth(IntrinsicType.SMALLINT, IntrinsicType.INTEGER, IntrinsicType.INTEGER);
+    assertResolvesBoth(IntrinsicType.INTEGER, IntrinsicType.INT64, IntrinsicType.INT64);
+    assertResolvesBoth(IntrinsicType.SHORTINT, IntrinsicType.INT64, IntrinsicType.INT64);
+  }
+
+  @Test
+  void testTwoUnsignedIntegersWidenToSignedInteger() {
+    assertResolvesBoth(IntrinsicType.BYTE, IntrinsicType.WORD, IntrinsicType.INTEGER);
+    assertResolvesBoth(IntrinsicType.BYTE, IntrinsicType.CARDINAL, IntrinsicType.INTEGER);
+    assertResolvesBoth(IntrinsicType.WORD, IntrinsicType.CARDINAL, IntrinsicType.INTEGER);
+  }
+
+  @Test
+  void testSmallSignedAndUnsignedWidenToInteger() {
+    assertResolvesBoth(IntrinsicType.SHORTINT, IntrinsicType.BYTE, IntrinsicType.INTEGER);
+    assertResolvesBoth(IntrinsicType.SHORTINT, IntrinsicType.WORD, IntrinsicType.INTEGER);
+    assertResolvesBoth(IntrinsicType.SMALLINT, IntrinsicType.WORD, IntrinsicType.INTEGER);
+    assertResolvesBoth(IntrinsicType.BYTE, IntrinsicType.INTEGER, IntrinsicType.INTEGER);
+    assertResolvesBoth(IntrinsicType.WORD, IntrinsicType.INTEGER, IntrinsicType.INTEGER);
+  }
+
+  @Test
+  void testSignedMixedWithCardinalWidenToInt64() {
+    assertResolvesBoth(IntrinsicType.SHORTINT, IntrinsicType.CARDINAL, IntrinsicType.INT64);
+    assertResolvesBoth(IntrinsicType.SMALLINT, IntrinsicType.CARDINAL, IntrinsicType.INT64);
+    assertResolvesBoth(IntrinsicType.INTEGER, IntrinsicType.CARDINAL, IntrinsicType.INT64);
+  }
+
+  @Test
+  void testAnythingMixedWith64BitWidensToInt64() {
+    assertResolvesBoth(IntrinsicType.CARDINAL, IntrinsicType.INT64, IntrinsicType.INT64);
+    assertResolvesBoth(IntrinsicType.CARDINAL, IntrinsicType.UINT64, IntrinsicType.INT64);
+    assertResolvesBoth(IntrinsicType.INTEGER, IntrinsicType.UINT64, IntrinsicType.INT64);
+    assertResolvesBoth(IntrinsicType.INT64, IntrinsicType.UINT64, IntrinsicType.INT64);
+    assertResolvesBoth(IntrinsicType.WORD, IntrinsicType.INT64, IntrinsicType.INT64);
+  }
+
+  // ---- real promotion ------------------------------------------------------
+
+  @Test
+  void testTwoRealsCollapseToDouble() {
+    assertResolvesBoth(IntrinsicType.SINGLE, IntrinsicType.DOUBLE, IntrinsicType.DOUBLE);
+    assertResolvesBoth(IntrinsicType.SINGLE, IntrinsicType.EXTENDED, IntrinsicType.DOUBLE);
+    assertResolvesBoth(IntrinsicType.DOUBLE, IntrinsicType.EXTENDED, IntrinsicType.DOUBLE);
+    assertResolvesBoth(IntrinsicType.SINGLE, IntrinsicType.CURRENCY, IntrinsicType.DOUBLE);
+    assertResolvesBoth(IntrinsicType.DOUBLE, IntrinsicType.CURRENCY, IntrinsicType.DOUBLE);
+    assertResolvesBoth(IntrinsicType.EXTENDED, IntrinsicType.CURRENCY, IntrinsicType.DOUBLE);
+    assertResolvesBoth(IntrinsicType.SINGLE, IntrinsicType.COMP, IntrinsicType.DOUBLE);
+    assertResolvesBoth(IntrinsicType.DOUBLE, IntrinsicType.COMP, IntrinsicType.DOUBLE);
+    assertResolvesBoth(IntrinsicType.EXTENDED, IntrinsicType.COMP, IntrinsicType.DOUBLE);
+  }
+
+  @Test
+  void testCurrencyAndCompCollapseToComp() {
+    assertResolvesBoth(IntrinsicType.CURRENCY, IntrinsicType.COMP, IntrinsicType.COMP);
+  }
+
+  // ---- integer mixed with real ---------------------------------------------
+
+  @Test
+  void testIntegerMixedWithFloatingRealPromotesToDouble() {
+    assertResolvesBoth(IntrinsicType.INTEGER, IntrinsicType.SINGLE, IntrinsicType.DOUBLE);
+    assertResolvesBoth(IntrinsicType.INTEGER, IntrinsicType.DOUBLE, IntrinsicType.DOUBLE);
+    assertResolvesBoth(IntrinsicType.INTEGER, IntrinsicType.EXTENDED, IntrinsicType.DOUBLE);
+    assertResolvesBoth(IntrinsicType.INT64, IntrinsicType.DOUBLE, IntrinsicType.DOUBLE);
+  }
+
+  @Test
+  void testIntegerMixedWithCurrencyOrCompPromotesToComp() {
+    assertResolvesBoth(IntrinsicType.INTEGER, IntrinsicType.CURRENCY, IntrinsicType.COMP);
+    assertResolvesBoth(IntrinsicType.INTEGER, IntrinsicType.COMP, IntrinsicType.COMP);
+    assertResolvesBoth(IntrinsicType.BYTE, IntrinsicType.CURRENCY, IntrinsicType.COMP);
+    assertResolvesBoth(IntrinsicType.INT64, IntrinsicType.COMP, IntrinsicType.COMP);
+  }
+
+  // ---- characters and strings ----------------------------------------------
+
+  @Test
+  void testCharMixedWithUnicodeStringPromotesToString() {
+    assertResolvesBoth(
+        IntrinsicType.CHAR, IntrinsicType.UNICODESTRING, IntrinsicType.UNICODESTRING);
+  }
+
+  @Test
+  void testStringMixedWithOtherStringPromotesToUnicodeString() {
+    assertResolvesBoth(
+        IntrinsicType.UNICODESTRING, IntrinsicType.ANSISTRING, IntrinsicType.UNICODESTRING);
+    assertResolvesBoth(
+        IntrinsicType.UNICODESTRING, IntrinsicType.SHORTSTRING, IntrinsicType.UNICODESTRING);
+  }
+
+  // ---- class types ---------------------------------------------------------
+
+  @Test
+  void testDescendantAndAncestorClassReturnsAncestor() {
+    Type base = TypeMocker.struct("TBase", CLASS);
+    Type derived = TypeMocker.struct("TDerived", CLASS, base);
+    assertThat(resolve(derived, base).is(base)).isTrue();
+    assertThat(resolve(base, derived).is(base)).isTrue();
+  }
+
+  @Test
+  void testSiblingClassesReturnsCommonAncestor() {
+    Type base = TypeMocker.struct("TBase", CLASS);
+    Type left = TypeMocker.struct("TLeft", CLASS, base);
+    Type right = TypeMocker.struct("TRight", CLASS, base);
+    assertThat(resolve(left, right).is(base)).isTrue();
+    assertThat(resolve(right, left).is(base)).isTrue();
+  }
+
+  // ---- incompatible branches (a compile error in Delphi) -------------------
+
+  @Test
+  void testUnrelatedTypesReturnUnknown() {
+    Type fooClass = TypeMocker.struct("TFoo", CLASS);
+    Type integer = intrinsic(IntrinsicType.INTEGER);
+    assertThat(resolve(fooClass, integer).isUnknown()).isTrue();
+    assertThat(resolve(integer, fooClass).isUnknown()).isTrue();
+    assertThat(resolve(intrinsic(IntrinsicType.UNICODESTRING), integer).isUnknown()).isTrue();
+  }
+
+  private void assertResolvesBoth(
+      IntrinsicType then, IntrinsicType elseType, IntrinsicType expect) {
+    assertThat(resolve(intrinsic(then), intrinsic(elseType)).is(intrinsic(expect)))
+        .as("%s | %s -> %s", then, elseType, expect)
+        .isTrue();
+    assertThat(resolve(intrinsic(elseType), intrinsic(then)).is(intrinsic(expect)))
+        .as("%s | %s -> %s", elseType, then, expect)
+        .isTrue();
+  }
+
+  private static Type resolve(Type thenType, Type elseType) {
+    IfExpressionNode node = mock(IfExpressionNode.class);
+    ExpressionNode thenExpression = mock(ExpressionNode.class);
+    ExpressionNode elseExpression = mock(ExpressionNode.class);
+    when(thenExpression.getType()).thenReturn(thenType);
+    when(elseExpression.getType()).thenReturn(elseType);
+    when(node.getThenExpression()).thenReturn(thenExpression);
+    when(node.getElseExpression()).thenReturn(elseExpression);
+    return RESOLVER.resolve(node);
+  }
+}

--- a/delphi-frontend/src/test/resources/au/com/integradev/delphi/grammar/ConditionalExpressions.pas
+++ b/delphi-frontend/src/test/resources/au/com/integradev/delphi/grammar/ConditionalExpressions.pas
@@ -1,0 +1,36 @@
+unit ConditionalExpressions;
+
+interface
+
+implementation
+
+function Describe(aValue : Integer) : string;
+begin
+  Result := if aValue > 0 then 'positive' else 'non-positive';
+end;
+
+function PickInt(aFlag : Boolean; aLhs, aRhs : Integer) : Integer;
+begin
+  Result := if aFlag then aLhs else aRhs;
+end;
+
+procedure UseInArgument;
+begin
+  Describe(if True then 1 else 2);
+end;
+
+function Nested(aA, aB : Boolean) : Integer;
+begin
+  Result :=
+    if aA then
+      if aB then 1 else 2
+    else
+      if aB then 3 else 4;
+end;
+
+function Mixed(aFlag : Boolean) : Integer;
+begin
+  Result := (if aFlag then 10 else 20) + 1;
+end;
+
+end.


### PR DESCRIPTION
Resolves #407. Introduces parsing, type resolution, and control-flow modelling of Delphi 13's conditional `if` operator (e.g. `X := if Foo then Bar else Baz`). The branches are modelled as mutually-exclusive paths in the CFG.

The expression's type is the LUB of the then/else branch types: exact matches and unknown-side fallbacks are returned directly; if only one branch's type is assignable to the other, the more permissive one wins; if both are bidirectionally assignable, the wider one (higher conversion score) is chosen; for unrelated struct types, a shared ancestor in the parent chain is used; otherwise the result is the unknown type.