### PR TITLE
Improve charset selection when parsing Delphi source files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,12 +22,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- The ANSI encoding configured by `sonar.delphi.codePage` or inferred from `DCC_CodePage` is now
+  preferred over the system encoding when parsing source files.
 - Metrics are no longer reported on test sources.
 - Duplications are no longer reported on test sources.
 - Coverage data is no longer reported on test sources.
 
 ### Fixed
 
+- The configured `sonar.sourceEncoding` was never used for search path units.
 - Quick fixes removing too much surrounding code in `RedundantInherited`.
 
 ## [1.18.3] - 2025-11-11

--- a/delphi-checks-testkit/src/main/java/au/com/integradev/delphi/builders/AbstractDelphiTestFile.java
+++ b/delphi-checks-testkit/src/main/java/au/com/integradev/delphi/builders/AbstractDelphiTestFile.java
@@ -85,7 +85,7 @@ abstract class AbstractDelphiTestFile<T extends AbstractDelphiTestFile<T>>
         new TypeFactoryImpl(
             DelphiProperties.COMPILER_TOOLCHAIN_DEFAULT, DelphiProperties.COMPILER_VERSION_DEFAULT);
     DelphiFileConfig mock = mock(DelphiFileConfig.class);
-    when(mock.getEncoding()).thenReturn(UTF_8.name());
+    when(mock.getCharset()).thenReturn(UTF_8);
     when(mock.getTypeFactory()).thenReturn(typeFactory);
     when(mock.getSearchPath()).thenReturn(SearchPath.create(Collections.emptyList()));
     when(mock.getDefinitions()).thenReturn(Collections.emptySet());

--- a/delphi-checks-testkit/src/main/java/au/com/integradev/delphi/checks/verifier/CheckVerifierImpl.java
+++ b/delphi-checks-testkit/src/main/java/au/com/integradev/delphi/checks/verifier/CheckVerifierImpl.java
@@ -323,7 +323,7 @@ public class CheckVerifierImpl implements CheckVerifier {
           try {
             return new DelphiFileStream(
                 delphiFile.getSourceCodeFile().getAbsolutePath(),
-                delphiFile.getSourceCodeFileEncoding());
+                delphiFile.getSourceCodeFileCharset());
           } catch (IOException e) {
             throw new UncheckedIOException(e);
           }

--- a/delphi-frontend/src/main/java/au/com/integradev/delphi/antlr/DelphiFileStream.java
+++ b/delphi-frontend/src/main/java/au/com/integradev/delphi/antlr/DelphiFileStream.java
@@ -29,34 +29,30 @@ import org.apache.commons.io.input.BOMInputStream;
 
 public class DelphiFileStream extends ANTLRStringStream {
   private final String fileName;
-  private final String encoding;
+  private final Charset charset;
 
-  public DelphiFileStream(String fileName, String encoding) throws IOException {
+  public DelphiFileStream(String fileName, Charset charset) throws IOException {
     this.fileName = fileName;
-    this.encoding = this.load(fileName, encoding);
+    this.charset = this.load(fileName, charset);
   }
 
-  private String load(String fileName, String encoding) throws IOException {
+  private Charset load(String fileName, Charset charset) throws IOException {
     if (fileName != null) {
       File f = new File(fileName);
       int size = (int) f.length();
       try (BOMInputStream input = bomInputStream(fileName).get()) {
         ByteOrderMark bom = input.getBOM();
         if (bom != null) {
-          encoding = bom.getCharsetName();
+          charset = Charset.forName(bom.getCharsetName());
         }
 
-        if (encoding == null) {
-          encoding = Charset.defaultCharset().name();
-        }
-
-        try (InputStreamReader reader = new InputStreamReader(input, encoding)) {
+        try (InputStreamReader reader = new InputStreamReader(input, charset)) {
           this.data = new char[size];
           super.n = reader.read(this.data);
         }
       }
     }
-    return encoding;
+    return charset;
   }
 
   @Override
@@ -64,8 +60,8 @@ public class DelphiFileStream extends ANTLRStringStream {
     return this.fileName;
   }
 
-  public String getEncoding() {
-    return this.encoding;
+  public Charset getCharset() {
+    return this.charset;
   }
 
   private static BOMInputStream.Builder bomInputStream(String fileName) throws IOException {

--- a/delphi-frontend/src/main/java/au/com/integradev/delphi/file/DefaultDelphiFile.java
+++ b/delphi-frontend/src/main/java/au/com/integradev/delphi/file/DefaultDelphiFile.java
@@ -36,7 +36,7 @@ class DefaultDelphiFile implements DelphiFile {
   private CompilerSwitchRegistry switchRegistry;
   private TextBlockLineEndingModeRegistry textBlockLineEndingModeRegistry;
   private TypeFactory typeFactory;
-  private String encoding;
+  private Charset charset;
   private Charset ansiCharset;
 
   DefaultDelphiFile() {
@@ -54,8 +54,8 @@ class DefaultDelphiFile implements DelphiFile {
   }
 
   @Override
-  public String getSourceCodeFileEncoding() {
-    return encoding;
+  public Charset getSourceCodeFileCharset() {
+    return charset;
   }
 
   @Override
@@ -101,8 +101,8 @@ class DefaultDelphiFile implements DelphiFile {
     this.sourceCodeLines = List.copyOf(sourceCodeLines);
   }
 
-  void setSourceCodeEncoding(String encoding) {
-    this.encoding = encoding;
+  void setSourceCodeCharset(Charset charset) {
+    this.charset = charset;
   }
 
   void setAnsiCharset(Charset ansiCharset) {

--- a/delphi-frontend/src/main/java/au/com/integradev/delphi/file/DefaultDelphiFileConfig.java
+++ b/delphi-frontend/src/main/java/au/com/integradev/delphi/file/DefaultDelphiFileConfig.java
@@ -22,11 +22,10 @@ import au.com.integradev.delphi.preprocessor.DelphiPreprocessorFactory;
 import au.com.integradev.delphi.preprocessor.search.SearchPath;
 import java.nio.charset.Charset;
 import java.util.Set;
-import javax.annotation.Nullable;
 import org.sonar.plugins.communitydelphi.api.type.TypeFactory;
 
 public class DefaultDelphiFileConfig implements DelphiFileConfig {
-  private final String encoding;
+  private final Charset charset;
   private final Charset ansiCharset;
   private final DelphiPreprocessorFactory preprocessorFactory;
   private final TypeFactory typeFactory;
@@ -35,14 +34,14 @@ public class DefaultDelphiFileConfig implements DelphiFileConfig {
   private final boolean skipImplementation;
 
   DefaultDelphiFileConfig(
-      String encoding,
+      Charset charset,
       Charset ansiCharset,
       DelphiPreprocessorFactory preprocessorFactory,
       TypeFactory typeFactory,
       SearchPath searchPath,
       Set<String> definitions,
       boolean skipImplementation) {
-    this.encoding = encoding;
+    this.charset = charset;
     this.ansiCharset = ansiCharset;
     this.preprocessorFactory = preprocessorFactory;
     this.typeFactory = typeFactory;
@@ -51,10 +50,9 @@ public class DefaultDelphiFileConfig implements DelphiFileConfig {
     this.skipImplementation = skipImplementation;
   }
 
-  @Nullable
   @Override
-  public String getEncoding() {
-    return encoding;
+  public Charset getCharset() {
+    return charset;
   }
 
   @Override

--- a/delphi-frontend/src/main/java/au/com/integradev/delphi/file/DelphiFile.java
+++ b/delphi-frontend/src/main/java/au/com/integradev/delphi/file/DelphiFile.java
@@ -39,7 +39,6 @@ import java.nio.charset.Charset;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
-import javax.annotation.Nullable;
 import org.antlr.runtime.BufferedTokenStream;
 import org.antlr.runtime.CommonToken;
 import org.antlr.runtime.RecognitionException;
@@ -55,7 +54,7 @@ public interface DelphiFile {
 
   List<String> getSourceCodeFileLines();
 
-  String getSourceCodeFileEncoding();
+  Charset getSourceCodeFileCharset();
 
   DelphiAst getAst();
 
@@ -84,10 +83,10 @@ public interface DelphiFile {
 
     private static DelphiFileConfig useInputFileEncoding(
         InputFile inputFile, DelphiFileConfig config) {
-      if (inputFile.charset() != null && !inputFile.charset().name().equals(config.getEncoding())) {
+      if (inputFile.charset() != null && !inputFile.charset().equals(config.getCharset())) {
         config =
             DelphiFile.createConfig(
-                inputFile.charset().name(),
+                inputFile.charset(),
                 config.getAnsiCharset(),
                 config.getPreprocessorFactory(),
                 config.getTypeFactory(),
@@ -112,18 +111,18 @@ public interface DelphiFile {
   }
 
   static DelphiFileConfig createConfig(
-      String encoding,
+      Charset charset,
       Charset ansiCharset,
       DelphiPreprocessorFactory preprocessorFactory,
       TypeFactory typeFactory,
       SearchPath searchPath,
       Set<String> definitions) {
     return createConfig(
-        encoding, ansiCharset, preprocessorFactory, typeFactory, searchPath, definitions, false);
+        charset, ansiCharset, preprocessorFactory, typeFactory, searchPath, definitions, false);
   }
 
   static DelphiFileConfig createConfig(
-      @Nullable String encoding,
+      Charset charset,
       Charset ansiCharset,
       DelphiPreprocessorFactory preprocessorFactory,
       TypeFactory typeFactory,
@@ -131,7 +130,7 @@ public interface DelphiFile {
       Set<String> definitions,
       boolean shouldSkipImplementation) {
     return new DefaultDelphiFileConfig(
-        encoding,
+        charset,
         ansiCharset,
         preprocessorFactory,
         typeFactory,
@@ -150,10 +149,10 @@ public interface DelphiFile {
       DefaultDelphiFile delphiFile, File sourceFile, DelphiFileConfig config) {
     try {
       String filePath = sourceFile.getAbsolutePath();
-      DelphiFileStream fileStream = new DelphiFileStream(filePath, config.getEncoding());
+      DelphiFileStream fileStream = new DelphiFileStream(filePath, config.getCharset());
       DelphiPreprocessor preprocessor = preprocess(fileStream, config);
       delphiFile.setSourceCodeFile(sourceFile);
-      delphiFile.setSourceCodeEncoding(fileStream.getEncoding());
+      delphiFile.setSourceCodeCharset(fileStream.getCharset());
       delphiFile.setAnsiCharset(config.getAnsiCharset());
       delphiFile.setTypeFactory(config.getTypeFactory());
       delphiFile.setAst(createAST(delphiFile, preprocessor.getTokenStream(), config));

--- a/delphi-frontend/src/main/java/au/com/integradev/delphi/file/DelphiFileConfig.java
+++ b/delphi-frontend/src/main/java/au/com/integradev/delphi/file/DelphiFileConfig.java
@@ -22,17 +22,15 @@ import au.com.integradev.delphi.preprocessor.DelphiPreprocessorFactory;
 import au.com.integradev.delphi.preprocessor.search.SearchPath;
 import java.nio.charset.Charset;
 import java.util.Set;
-import javax.annotation.Nullable;
 import org.sonar.plugins.communitydelphi.api.type.TypeFactory;
 
 public interface DelphiFileConfig {
   /**
-   * Returns the encoding that the source file is expected to be
+   * Returns the charset that the source file is expected to be read with
    *
-   * @return Name of encoding
+   * @return Source charset
    */
-  @Nullable
-  String getEncoding();
+  Charset getCharset();
 
   /**
    * Returns the charset that will be used for interpreting ANSI data in the source file

--- a/delphi-frontend/src/main/java/au/com/integradev/delphi/msbuild/DelphiProjectHelper.java
+++ b/delphi-frontend/src/main/java/au/com/integradev/delphi/msbuild/DelphiProjectHelper.java
@@ -66,6 +66,8 @@ import org.sonarsource.api.sonarlint.SonarLintSide;
 @SonarLintSide
 public class DelphiProjectHelper {
   private static final Logger LOG = LoggerFactory.getLogger(DelphiProjectHelper.class);
+  private static final String SOURCE_ENCODING_KEY = "sonar.sourceEncoding";
+
   private final Configuration settings;
   private final FileSystem fs;
   private final EnvironmentVariableProvider environmentVariableProvider;
@@ -480,7 +482,10 @@ public class DelphiProjectHelper {
     return fs.inputFile(fs.predicates().hasURI(Paths.get(path).toUri()));
   }
 
-  public String encoding() {
-    return fs != null ? fs.encoding().name() : Charset.defaultCharset().name();
+  public Charset getCharset() {
+    if (fs != null && settings.get(SOURCE_ENCODING_KEY).isPresent()) {
+      return fs.encoding();
+    }
+    return getAnsiCharset();
   }
 }

--- a/delphi-frontend/src/main/java/au/com/integradev/delphi/preprocessor/DelphiPreprocessor.java
+++ b/delphi-frontend/src/main/java/au/com/integradev/delphi/preprocessor/DelphiPreprocessor.java
@@ -260,7 +260,7 @@ public class DelphiPreprocessor {
   }
 
   private List<Token> preprocessIncludeFile(DelphiToken location, Path path) throws IOException {
-    var fileStream = new DelphiFileStream(path.toAbsolutePath().toString(), config.getEncoding());
+    var fileStream = new DelphiFileStream(path.toAbsolutePath().toString(), config.getCharset());
     DelphiLexer includeLexer = new DelphiIncludeLexer(fileStream, location);
 
     DelphiPreprocessor preprocessor =

--- a/delphi-frontend/src/main/java/au/com/integradev/delphi/reporting/DelphiIssueBuilderImpl.java
+++ b/delphi-frontend/src/main/java/au/com/integradev/delphi/reporting/DelphiIssueBuilderImpl.java
@@ -256,7 +256,7 @@ public final class DelphiIssueBuilderImpl implements DelphiIssueBuilder {
   private static DelphiFileStream getDelphiFileStream(DelphiFile delphiFile) {
     try {
       return new DelphiFileStream(
-          delphiFile.getSourceCodeFile().getAbsolutePath(), delphiFile.getSourceCodeFileEncoding());
+          delphiFile.getSourceCodeFile().getAbsolutePath(), delphiFile.getSourceCodeFileCharset());
     } catch (IOException e) {
       throw new UncheckedIOException(e);
     }

--- a/delphi-frontend/src/main/java/au/com/integradev/delphi/symbol/SymbolTableBuilder.java
+++ b/delphi-frontend/src/main/java/au/com/integradev/delphi/symbol/SymbolTableBuilder.java
@@ -74,7 +74,7 @@ public class SymbolTableBuilder {
   private final Set<UnitData> sourceFileUnits = new HashSet<>();
   private final HashMap<String, UnitData> allUnitsByName = new HashMap<>();
   private final Set<Path> unitPaths = new HashSet<>();
-  private String encoding;
+  private Charset charset = CharsetUtils.nativeCharset();
   private Charset ansiCharset = CharsetUtils.nativeCharset();
   private DelphiPreprocessorFactory preprocessorFactory;
   private TypeFactory typeFactory;
@@ -109,8 +109,8 @@ public class SymbolTableBuilder {
     return this;
   }
 
-  public SymbolTableBuilder encoding(String encoding) {
-    this.encoding = encoding;
+  public SymbolTableBuilder charset(Charset charset) {
+    this.charset = charset;
     return this;
   }
 
@@ -267,9 +267,9 @@ public class SymbolTableBuilder {
     return allUnitsByName.get(importName.toLowerCase());
   }
 
-  private DelphiFileConfig createFileConfig(UnitData unit, boolean shouldSkipImplementation) {
+  private DelphiFileConfig createFileConfig(boolean shouldSkipImplementation) {
     return DelphiFile.createConfig(
-        sourceFileUnits.contains(unit) ? encoding : null,
+        charset,
         ansiCharset,
         preprocessorFactory,
         typeFactory,
@@ -293,7 +293,7 @@ public class SymbolTableBuilder {
       }
 
       boolean shouldSkipImplementation = (resolutionLevel != ResolutionLevel.COMPLETE);
-      DelphiFileConfig fileConfig = createFileConfig(unit, shouldSkipImplementation);
+      DelphiFileConfig fileConfig = createFileConfig(shouldSkipImplementation);
       DelphiFile delphiFile = DelphiFile.from(unit.unitFile.toFile(), fileConfig);
 
       if (unit.resolved == ResolutionLevel.NONE) {

--- a/delphi-frontend/src/test/java/au/com/integradev/delphi/antlr/GrammarTest.java
+++ b/delphi-frontend/src/test/java/au/com/integradev/delphi/antlr/GrammarTest.java
@@ -275,7 +275,7 @@ class GrammarTest {
   void testUndefinedInaccessibleNestedIfDef() {
     fileConfig =
         DelphiFile.createConfig(
-            StandardCharsets.UTF_8.name(),
+            StandardCharsets.UTF_8,
             StandardCharsets.UTF_8,
             new DelphiPreprocessorFactory(
                 DelphiProperties.COMPILER_VERSION_DEFAULT, Platform.WINDOWS),

--- a/delphi-frontend/src/test/java/au/com/integradev/delphi/coverage/delphicodecoveragetool/DelphiCoverageToolParserTest.java
+++ b/delphi-frontend/src/test/java/au/com/integradev/delphi/coverage/delphicodecoveragetool/DelphiCoverageToolParserTest.java
@@ -77,7 +77,7 @@ class DelphiCoverageToolParserTest {
         TestInputFileBuilder.create("", baseDir, file)
             .setLanguage(Delphi.KEY)
             .setType(type)
-            .setContents(FileUtils.readFileToString(file, delphiProjectHelper.encoding()))
+            .setContents(FileUtils.readFileToString(file, delphiProjectHelper.getCharset()))
             .build();
     context.fileSystem().add(inputFile);
   }

--- a/delphi-frontend/src/test/java/au/com/integradev/delphi/executor/DelphiMasterExecutorTest.java
+++ b/delphi-frontend/src/test/java/au/com/integradev/delphi/executor/DelphiMasterExecutorTest.java
@@ -179,7 +179,7 @@ class DelphiMasterExecutorTest {
         new TypeFactoryImpl(
             DelphiProperties.COMPILER_TOOLCHAIN_DEFAULT, DelphiProperties.COMPILER_VERSION_DEFAULT);
     DelphiFileConfig mock = mock(DelphiFileConfig.class);
-    when(mock.getEncoding()).thenReturn(StandardCharsets.UTF_8.name());
+    when(mock.getCharset()).thenReturn(StandardCharsets.UTF_8);
     when(mock.getPreprocessorFactory())
         .thenReturn(
             new DelphiPreprocessorFactory(

--- a/delphi-frontend/src/test/java/au/com/integradev/delphi/executor/DelphiMetricsExecutorTest.java
+++ b/delphi-frontend/src/test/java/au/com/integradev/delphi/executor/DelphiMetricsExecutorTest.java
@@ -200,7 +200,7 @@ class DelphiMetricsExecutorTest {
         new TypeFactoryImpl(
             DelphiProperties.COMPILER_TOOLCHAIN_DEFAULT, DelphiProperties.COMPILER_VERSION_DEFAULT);
     DelphiFileConfig mock = mock(DelphiFileConfig.class);
-    when(mock.getEncoding()).thenReturn(StandardCharsets.UTF_8.name());
+    when(mock.getCharset()).thenReturn(StandardCharsets.UTF_8);
     when(mock.getPreprocessorFactory())
         .thenReturn(
             new DelphiPreprocessorFactory(

--- a/delphi-frontend/src/test/java/au/com/integradev/delphi/executor/DelphiSymbolTableExecutorTest.java
+++ b/delphi-frontend/src/test/java/au/com/integradev/delphi/executor/DelphiSymbolTableExecutorTest.java
@@ -1565,7 +1565,7 @@ class DelphiSymbolTableExecutorTest {
             DelphiProperties.COMPILER_TOOLCHAIN_DEFAULT, DelphiProperties.COMPILER_VERSION_DEFAULT);
 
     DelphiFileConfig fileConfig = mock(DelphiFileConfig.class);
-    when(fileConfig.getEncoding()).thenReturn(StandardCharsets.UTF_8.name());
+    when(fileConfig.getCharset()).thenReturn(StandardCharsets.UTF_8);
     when(fileConfig.getPreprocessorFactory()).thenReturn(preprocessorFactory);
     when(fileConfig.getTypeFactory()).thenReturn(typeFactory);
     when(fileConfig.getSearchPath()).thenReturn(SearchPath.create(Collections.emptyList()));
@@ -1583,6 +1583,7 @@ class DelphiSymbolTableExecutorTest {
 
     symbolTable =
         SymbolTable.builder()
+            .charset(StandardCharsets.UTF_8)
             .preprocessorFactory(preprocessorFactory)
             .typeFactory(typeFactory)
             .sourceFiles(sourceFiles)

--- a/delphi-frontend/src/test/java/au/com/integradev/delphi/executor/DelphiTokenExecutorTest.java
+++ b/delphi-frontend/src/test/java/au/com/integradev/delphi/executor/DelphiTokenExecutorTest.java
@@ -231,7 +231,7 @@ class DelphiTokenExecutorTest {
               DelphiProperties.COMPILER_VERSION_DEFAULT);
 
       DelphiFileConfig fileConfig = mock(DelphiFileConfig.class);
-      when(fileConfig.getEncoding()).thenReturn(StandardCharsets.UTF_8.name());
+      when(fileConfig.getCharset()).thenReturn(StandardCharsets.UTF_8);
       when(fileConfig.getPreprocessorFactory())
           .thenReturn(
               new DelphiPreprocessorFactory(

--- a/delphi-frontend/src/test/java/au/com/integradev/delphi/file/DelphiFileTest.java
+++ b/delphi-frontend/src/test/java/au/com/integradev/delphi/file/DelphiFileTest.java
@@ -66,7 +66,7 @@ class DelphiFileTest {
 
     DelphiFileConfig config =
         DelphiFile.createConfig(
-            StandardCharsets.UTF_8.name(),
+            StandardCharsets.UTF_8,
             StandardCharsets.UTF_8,
             new DelphiPreprocessorFactory(
                 DelphiProperties.COMPILER_VERSION_DEFAULT, Platform.WINDOWS),
@@ -84,7 +84,7 @@ class DelphiFileTest {
 
     DelphiFileConfig config =
         DelphiFile.createConfig(
-            StandardCharsets.UTF_8.name(),
+            StandardCharsets.UTF_8,
             StandardCharsets.UTF_8,
             new DelphiPreprocessorFactory(
                 DelphiProperties.COMPILER_VERSION_DEFAULT, Platform.WINDOWS),
@@ -102,7 +102,7 @@ class DelphiFileTest {
 
     DelphiFileConfig config =
         DelphiFile.createConfig(
-            StandardCharsets.UTF_8.name(),
+            StandardCharsets.UTF_8,
             StandardCharsets.UTF_8,
             new DelphiPreprocessorFactory(
                 DelphiProperties.COMPILER_VERSION_DEFAULT, Platform.WINDOWS),
@@ -115,6 +115,27 @@ class DelphiFileTest {
     assertThat(firstLine).doesNotStartWith("\ufeff");
   }
 
+  @Test
+  void testCharsetShouldDecodeShiftJisFile() {
+    File file = DelphiUtils.getResource("/au/com/integradev/delphi/file/ShiftJis.pas");
+    Charset shiftJis = Charset.forName("windows-31j");
+
+    DelphiFileConfig config =
+        DelphiFile.createConfig(
+            shiftJis,
+            shiftJis,
+            new DelphiPreprocessorFactory(
+                DelphiProperties.COMPILER_VERSION_DEFAULT, Platform.WINDOWS),
+            TypeFactoryUtils.defaultFactory(),
+            SearchPath.create(Collections.emptyList()),
+            Collections.emptySet());
+
+    DelphiFile delphiFile = DelphiFile.from(file, config);
+    assertThat(delphiFile.getSourceCodeFileCharset()).isEqualTo(shiftJis);
+    assertThat(delphiFile.getSourceCodeFileLines().get(1)).isEqualTo("カスタマイズ");
+    assertThat(delphiFile.getSourceCodeFileLines().get(3)).isEqualTo("unit Consts;");
+  }
+
   @ParameterizedTest
   @ValueSource(strings = {"SkipImplementation.pas", "SkipImplementationWithDirectiveNesting.pas"})
   void testShouldSkipImplementation(String filename) {
@@ -122,7 +143,7 @@ class DelphiFileTest {
 
     DelphiFileConfig config =
         DelphiFile.createConfig(
-            StandardCharsets.UTF_8.name(),
+            StandardCharsets.UTF_8,
             StandardCharsets.UTF_8,
             new DelphiPreprocessorFactory(
                 DelphiProperties.COMPILER_VERSION_DEFAULT, Platform.WINDOWS),

--- a/delphi-frontend/src/test/java/au/com/integradev/delphi/msbuild/DelphiProjectHelperTest.java
+++ b/delphi-frontend/src/test/java/au/com/integradev/delphi/msbuild/DelphiProjectHelperTest.java
@@ -55,6 +55,7 @@ import org.sonar.api.config.Configuration;
 
 class DelphiProjectHelperTest {
   private static final String PROJECTS_PATH = "/au/com/integradev/delphi/projects/";
+  private static final String SOURCE_ENCODING_KEY = "sonar.sourceEncoding";
   private static final File BASE_DIR = DelphiUtils.getResource(PROJECTS_PATH);
   private Configuration settings;
   private DefaultFileSystem fs;
@@ -78,6 +79,7 @@ class DelphiProjectHelperTest {
 
     when(settings.get(DelphiProperties.INSTALLATION_PATH_KEY))
         .thenReturn(Optional.of(installationPath));
+    when(settings.get(SOURCE_ENCODING_KEY)).thenReturn(Optional.empty());
     when(environmentVariableProvider.getenv()).thenReturn(Collections.emptyMap());
     when(environmentVariableProvider.getenv(anyString())).thenReturn(null);
 
@@ -331,12 +333,12 @@ class DelphiProjectHelperTest {
   @Test
   void testConfiguredCodePageOverridesProjectCodePage() {
     addInputFile(PROJECTS_PATH + "CodePageProject/Utf8.dproj");
-    when(settings.get(DelphiProperties.CODE_PAGE_KEY)).thenReturn(Optional.of("1252"));
+    when(settings.get(DelphiProperties.CODE_PAGE_KEY)).thenReturn(Optional.of("1251"));
 
     DelphiProjectHelper delphiProjectHelper =
         new DelphiProjectHelper(settings, fs, environmentVariableProvider);
 
-    assertThat(delphiProjectHelper.getAnsiCharset().name()).isEqualTo("windows-1252");
+    assertThat(delphiProjectHelper.getAnsiCharset().name()).isEqualTo("windows-1251");
   }
 
   @Test
@@ -420,6 +422,28 @@ class DelphiProjectHelperTest {
         new DelphiProjectHelper(settings, fs, environmentVariableProvider);
 
     assertThat(delphiProjectHelper.getAnsiCharset()).isEqualTo(Charset.forName("windows-1252"));
+  }
+
+  @Test
+  void testConfiguredSourceEncodingProvidesCharset() {
+    fs.setEncoding(StandardCharsets.UTF_16LE);
+    when(settings.get(SOURCE_ENCODING_KEY)).thenReturn(Optional.of("UTF-16LE"));
+
+    DelphiProjectHelper delphiProjectHelper =
+        new DelphiProjectHelper(settings, fs, environmentVariableProvider);
+
+    assertThat(delphiProjectHelper.getCharset()).isEqualTo(StandardCharsets.UTF_16LE);
+  }
+
+  @Test
+  void testMissingSourceEncodingFallsBackToAnsiCharset() {
+    addInputFile(PROJECTS_PATH + "CodePageProject/Windows1252.dproj");
+    fs.setEncoding(StandardCharsets.UTF_8);
+
+    DelphiProjectHelper delphiProjectHelper =
+        new DelphiProjectHelper(settings, fs, environmentVariableProvider);
+
+    assertThat(delphiProjectHelper.getCharset().name()).isEqualTo("windows-1252");
   }
 
   @Test

--- a/delphi-frontend/src/test/java/au/com/integradev/delphi/preprocessor/DelphiPreprocessorTest.java
+++ b/delphi-frontend/src/test/java/au/com/integradev/delphi/preprocessor/DelphiPreprocessorTest.java
@@ -133,7 +133,7 @@ class DelphiPreprocessorTest {
     String filePath =
         DelphiUtils.getResource(BASE_DIR + "includeTest/SameNameBacktrack.pas").getAbsolutePath();
     DelphiFileConfig config = DelphiFileUtils.mockConfig();
-    DelphiFileStream fileStream = new DelphiFileStream(filePath, config.getEncoding());
+    DelphiFileStream fileStream = new DelphiFileStream(filePath, config.getCharset());
 
     DelphiLexer lexer = new DelphiLexer(fileStream);
     DelphiPreprocessor preprocessor =
@@ -147,7 +147,7 @@ class DelphiPreprocessorTest {
   private static void executeWithDefines(String filename, String... defines) {
     DelphiFileConfig config =
         DelphiFile.createConfig(
-            UTF_8.name(),
+            UTF_8,
             UTF_8,
             new DelphiPreprocessorFactory(
                 DelphiProperties.COMPILER_VERSION_DEFAULT, Platform.WINDOWS),
@@ -168,7 +168,7 @@ class DelphiPreprocessorTest {
     execute(
         filename,
         DelphiFile.createConfig(
-            UTF_8.name(),
+            UTF_8,
             UTF_8,
             new DelphiPreprocessorFactory(
                 DelphiProperties.COMPILER_VERSION_DEFAULT, Platform.WINDOWS),
@@ -184,7 +184,7 @@ class DelphiPreprocessorTest {
   private static void execute(String filename, DelphiFileConfig config) {
     try {
       String filePath = DelphiUtils.getResource(BASE_DIR + filename).getAbsolutePath();
-      DelphiFileStream fileStream = new DelphiFileStream(filePath, config.getEncoding());
+      DelphiFileStream fileStream = new DelphiFileStream(filePath, config.getCharset());
 
       DelphiLexer lexer = new DelphiLexer(fileStream);
       DelphiPreprocessor preprocessor =

--- a/delphi-frontend/src/test/java/au/com/integradev/delphi/reporting/QuickFixEditTest.java
+++ b/delphi-frontend/src/test/java/au/com/integradev/delphi/reporting/QuickFixEditTest.java
@@ -56,7 +56,7 @@ class QuickFixEditTest {
   private static DelphiFileStream getTestStream() {
     try {
       return new DelphiFileStream(
-          DelphiUtils.getResource(TEST_UNIT_PATH).getAbsolutePath(), StandardCharsets.UTF_8.name());
+          DelphiUtils.getResource(TEST_UNIT_PATH).getAbsolutePath(), StandardCharsets.UTF_8);
     } catch (IOException e) {
       throw new UncheckedIOException(e);
     }
@@ -144,7 +144,7 @@ class QuickFixEditTest {
             DelphiProperties.COMPILER_TOOLCHAIN_DEFAULT, DelphiProperties.COMPILER_VERSION_DEFAULT);
 
     DelphiFileConfig fileConfig = mock(DelphiFileConfig.class);
-    when(fileConfig.getEncoding()).thenReturn(StandardCharsets.UTF_8.name());
+    when(fileConfig.getCharset()).thenReturn(StandardCharsets.UTF_8);
     when(fileConfig.getPreprocessorFactory()).thenReturn(preprocessorFactory);
     when(fileConfig.getTypeFactory()).thenReturn(typeFactory);
     when(fileConfig.getSearchPath()).thenReturn(SearchPath.create(Collections.emptyList()));

--- a/delphi-frontend/src/test/java/au/com/integradev/delphi/symbol/SymbolTableBuilderTest.java
+++ b/delphi-frontend/src/test/java/au/com/integradev/delphi/symbol/SymbolTableBuilderTest.java
@@ -30,8 +30,10 @@ import au.com.integradev.delphi.compiler.Platform;
 import au.com.integradev.delphi.preprocessor.DelphiPreprocessorFactory;
 import au.com.integradev.delphi.preprocessor.search.SearchPath;
 import au.com.integradev.delphi.symbol.SymbolTableBuilder.SymbolTableConstructionException;
+import au.com.integradev.delphi.utils.DelphiUtils;
 import au.com.integradev.delphi.utils.types.TypeFactoryUtils;
 import java.io.IOException;
+import java.nio.charset.Charset;
 import java.nio.file.FileSystem;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -261,6 +263,44 @@ class SymbolTableBuilderTest {
             .searchPath(SearchPath.create(List.of(includePath)));
 
     assertThatCode(symbolTable::build).doesNotThrowAnyException();
+  }
+
+  @Test
+  void testSearchPathImportsUseConfiguredCharset(
+      @TempDir Path standardLibraryPath, @TempDir Path tempDir) throws IOException {
+    createStandardLibrary(standardLibraryPath);
+
+    Path searchPathRoot = tempDir.resolve("include");
+    Files.createDirectories(searchPathRoot);
+
+    Path importUnitPath = searchPathRoot.resolve("Consts.pas");
+    Files.copy(
+        DelphiUtils.getResource("/au/com/integradev/delphi/file/ShiftJis.pas").toPath(),
+        importUnitPath);
+
+    Path sourceFilePath = tempDir.resolve("SourceFile.pas");
+    Files.writeString(
+        sourceFilePath,
+        "unit SourceFile;\n"
+            + "interface\n"
+            + "uses\n"
+            + "  Consts;\n"
+            + "implementation\n"
+            + "end.");
+
+    SymbolTable symbolTable =
+        SymbolTable.builder()
+            .charset(Charset.forName("windows-31j"))
+            .preprocessorFactory(
+                new DelphiPreprocessorFactory(
+                    DelphiProperties.COMPILER_VERSION_DEFAULT, Platform.WINDOWS))
+            .typeFactory(TypeFactoryUtils.defaultFactory())
+            .standardLibraryPath(standardLibraryPath)
+            .sourceFiles(List.of(sourceFilePath))
+            .searchPath(SearchPath.create(List.of(searchPathRoot)))
+            .build();
+
+    assertThat(symbolTable.getUnitByPath(importUnitPath.toString())).isNotNull();
   }
 
   private static void createStandardLibrary(Path path) throws IOException {

--- a/delphi-frontend/src/test/java/au/com/integradev/delphi/utils/files/DelphiFileUtils.java
+++ b/delphi-frontend/src/test/java/au/com/integradev/delphi/utils/files/DelphiFileUtils.java
@@ -54,7 +54,7 @@ public final class DelphiFileUtils {
 
   public static DelphiFileConfig mockConfig() {
     DelphiFileConfig mock = mock(DelphiFileConfig.class);
-    when(mock.getEncoding()).thenReturn(StandardCharsets.UTF_8.name());
+    when(mock.getCharset()).thenReturn(StandardCharsets.UTF_8);
     when(mock.getPreprocessorFactory())
         .thenReturn(
             new DelphiPreprocessorFactory(

--- a/delphi-frontend/src/test/resources/au/com/integradev/delphi/file/ShiftJis.pas
+++ b/delphi-frontend/src/test/resources/au/com/integradev/delphi/file/ShiftJis.pas
@@ -1,0 +1,13 @@
+{
+カスタマイズ
+}
+unit Consts;
+
+interface
+
+const
+  SUMMARY = 'sum';
+
+implementation
+
+end.

--- a/sonar-delphi-plugin/src/main/java/au/com/integradev/delphi/DelphiSensor.java
+++ b/sonar-delphi-plugin/src/main/java/au/com/integradev/delphi/DelphiSensor.java
@@ -113,7 +113,7 @@ public class DelphiSensor implements Sensor {
             .typeFactory(typeFactory)
             .sourceFiles(sourceFiles)
             .referencedFiles(referencedFiles)
-            .encoding(delphiProjectHelper.encoding())
+            .charset(delphiProjectHelper.getCharset())
             .ansiCharset(delphiProjectHelper.getAnsiCharset())
             .searchPath(searchPath)
             .conditionalDefines(delphiProjectHelper.getConditionalDefines())
@@ -131,7 +131,7 @@ public class DelphiSensor implements Sensor {
     ExecutorContext executorContext = new ExecutorContext(sensorContext, symbolTable);
     DelphiFileConfig config =
         DelphiFile.createConfig(
-            delphiProjectHelper.encoding(),
+            delphiProjectHelper.getCharset(),
             delphiProjectHelper.getAnsiCharset(),
             preprocessorFactory,
             typeFactory,

--- a/sonar-delphi-plugin/src/test/java/au/com/integradev/delphi/DelphiSensorTest.java
+++ b/sonar-delphi-plugin/src/test/java/au/com/integradev/delphi/DelphiSensorTest.java
@@ -32,9 +32,12 @@ import au.com.integradev.delphi.executor.DelphiMasterExecutor;
 import au.com.integradev.delphi.msbuild.DelphiProjectHelper;
 import java.io.IOException;
 import java.io.UncheckedIOException;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
 import java.util.regex.Pattern;
 import org.apache.commons.io.FileUtils;
 import org.junit.jupiter.api.AfterEach;
@@ -58,10 +61,20 @@ class DelphiSensorTest {
     baseDir = Files.createTempDirectory("baseDir");
 
     sensor = new DelphiSensor(delphiProjectHelper, executor);
+    when(delphiProjectHelper.getCharset()).thenReturn(StandardCharsets.UTF_8);
+    when(delphiProjectHelper.getAnsiCharset()).thenReturn(StandardCharsets.UTF_8);
     when(delphiProjectHelper.getToolchain())
         .thenReturn(DelphiProperties.COMPILER_TOOLCHAIN_DEFAULT);
     when(delphiProjectHelper.getCompilerVersion())
         .thenReturn(DelphiProperties.COMPILER_VERSION_DEFAULT);
+    when(delphiProjectHelper.getConditionalDefines()).thenReturn(Set.of());
+    when(delphiProjectHelper.getReferencedFiles()).thenReturn(List.of());
+    when(delphiProjectHelper.getSearchDirectories()).thenReturn(List.of());
+    when(delphiProjectHelper.getDebugSourceDirectories()).thenReturn(List.of());
+    when(delphiProjectHelper.getLibraryPathDirectories()).thenReturn(List.of());
+    when(delphiProjectHelper.getBrowsingPathDirectories()).thenReturn(List.of());
+    when(delphiProjectHelper.getUnitScopeNames()).thenReturn(Set.of());
+    when(delphiProjectHelper.getUnitAliases()).thenReturn(Map.of());
 
     Path standardLibraryPath = Files.createDirectories(baseDir.resolve("bds/source"));
 


### PR DESCRIPTION
The preference order is now:
- Charset detected by `sonar-scanner` (applies only to `InputFile`)
- Charset detected from BOM
- Charset provided by `sonar.sourceEncoding`
- ANSI charset specified by `sonar.delphi.codePage`
- ANSI charset specified by `DCC_Codepage`
- System native charset

And just to muddy up the changeset a bit, I've refactored raw "encoding" strings to `Charset`,

Fixes #439.