### PR TITLE
Handle empty `DCC_CodePage` values without emitting a warning

### DIFF
--- a/delphi-frontend/src/main/java/au/com/integradev/delphi/msbuild/DelphiProjectFactory.java
+++ b/delphi-frontend/src/main/java/au/com/integradev/delphi/msbuild/DelphiProjectFactory.java
@@ -152,7 +152,7 @@ final class DelphiProjectFactory {
 
   private static Integer createCodePage(MSBuildState state) {
     String codePage = state.getProperty("DCC_CodePage");
-    if (codePage == null) {
+    if (codePage.isEmpty()) {
       return null;
     }
 

--- a/delphi-frontend/src/test/java/au/com/integradev/delphi/msbuild/DelphiProjectFactoryTest.java
+++ b/delphi-frontend/src/test/java/au/com/integradev/delphi/msbuild/DelphiProjectFactoryTest.java
@@ -66,6 +66,12 @@ class DelphiProjectFactoryTest {
   private static final String CODE_PAGE_PROJECT =
       "/au/com/integradev/delphi/projects/CodePageProject/Utf8.dproj";
 
+  private static final String BLANK_CODE_PAGE_PROJECT =
+      "/au/com/integradev/delphi/projects/CodePageProject/Blank.dproj";
+
+  private static final String PADDED_CODE_PAGE_PROJECT =
+      "/au/com/integradev/delphi/projects/CodePageProject/Padded.dproj";
+
   private EnvironmentVariableProvider environmentVariableProvider;
 
   private DelphiProject createProject(String resource) {
@@ -200,5 +206,19 @@ class DelphiProjectFactoryTest {
     DelphiProject project = createProject(CODE_PAGE_PROJECT);
 
     assertThat(project.getCodePage()).isEqualTo(65001);
+  }
+
+  @Test
+  void testBlankCodePageProject() {
+    DelphiProject project = createProject(BLANK_CODE_PAGE_PROJECT);
+
+    assertThat(project.getCodePage()).isNull();
+  }
+
+  @Test
+  void testWhitespacePaddedCodePageProjectIsInvalid() {
+    DelphiProject project = createProject(PADDED_CODE_PAGE_PROJECT);
+
+    assertThat(project.getCodePage()).isNull();
   }
 }

--- a/delphi-frontend/src/test/java/au/com/integradev/delphi/msbuild/DelphiProjectHelperTest.java
+++ b/delphi-frontend/src/test/java/au/com/integradev/delphi/msbuild/DelphiProjectHelperTest.java
@@ -412,6 +412,19 @@ class DelphiProjectHelperTest {
   }
 
   @Test
+  void testBlankProjectCodePageFallsBackToNativeCharset() {
+    setNativeEncoding("windows-1252");
+
+    addInputFile(PROJECTS_PATH + "CodePageProject/Utf8.dproj");
+    addInputFile(PROJECTS_PATH + "CodePageProject/Blank.dproj");
+
+    DelphiProjectHelper delphiProjectHelper =
+        new DelphiProjectHelper(settings, fs, environmentVariableProvider);
+
+    assertThat(delphiProjectHelper.getAnsiCharset()).isEqualTo(Charset.forName("windows-1252"));
+  }
+
+  @Test
   void testAcpProjectCodePageUsesNativeCharsetWithoutConflictWhenItMatchesExplicitCodePage() {
     setNativeEncoding("windows-1252");
 

--- a/delphi-frontend/src/test/resources/au/com/integradev/delphi/projects/CodePageProject/Blank.dproj
+++ b/delphi-frontend/src/test/resources/au/com/integradev/delphi/projects/CodePageProject/Blank.dproj
@@ -1,0 +1,5 @@
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+    <PropertyGroup>
+        <DCC_CodePage></DCC_CodePage>
+    </PropertyGroup>
+</Project>

--- a/delphi-frontend/src/test/resources/au/com/integradev/delphi/projects/CodePageProject/Padded.dproj
+++ b/delphi-frontend/src/test/resources/au/com/integradev/delphi/projects/CodePageProject/Padded.dproj
@@ -1,0 +1,5 @@
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+    <PropertyGroup>
+        <DCC_CodePage> 65001 </DCC_CodePage>
+    </PropertyGroup>
+</Project>


### PR DESCRIPTION
This PR fixes a bug in #397 where we mishandled `DCC_CodePage` values.

It's easy to forget, but we handle empty and null values equivalently when handling MSBuild properties, as that's how MSBuild itself works. It's impossible for `MSBuildState#getProperty` to return a null value.

This was causing erroneous warnings to be emitted for projects that defined an empty `DCC_CodePage` property, or didn't define one at all.