### PR TITLE
Add support for `if` expressions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Incorrect array literal type inference around mixed...
+  - integer elements
+  - boolean elements
+  - character elements
+  - class elements
+  - interface elements
+
 ## [1.19.0] - 2026-06-09
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Support for `if` expressions, introduced in Delphi 13.
+- **API:** `IfExpressionNode` node type.
+
 ### Fixed
 
 - Incorrect array literal type inference around mixed...

--- a/delphi-frontend/src/main/antlr3/au/com/integradev/delphi/antlr/Delphi.g
+++ b/delphi-frontend/src/main/antlr3/au/com/integradev/delphi/antlr/Delphi.g
@@ -922,6 +922,7 @@ attribute                    : (ASSEMBLY ':')? expression (':' expression)*
 //----------------------------------------------------------------------------
 expression                   : relationalExpression
                              | anonymousMethod
+                             | ifExpression
                              ;
 // ANTLR sets the begin and end tokens for nested binary expression nodes
 // in relationalOperator, not relationalExpression, meaning that their
@@ -983,6 +984,8 @@ anonymousMethodHeading       : PROCEDURE routineParameters? ((';')? interfaceDir
                              -> ^(TkAnonymousMethodHeading<AnonymousMethodHeadingNodeImpl> PROCEDURE routineParameters? ((';')? interfaceDirective)*)
                              | FUNCTION routineParameters? routineReturnType ((';')? interfaceDirective)*
                              -> ^(TkAnonymousMethodHeading<AnonymousMethodHeadingNodeImpl> FUNCTION routineParameters? routineReturnType ((';')? interfaceDirective)*)
+                             ;
+ifExpression                 : IF<IfExpressionNodeImpl>^ expression THEN expression ELSE expression
                              ;
 expressionOrRange            : expression ('..'<RangeExpressionNodeImpl>^ expression)?
                              ;

--- a/delphi-frontend/src/main/java/au/com/integradev/delphi/antlr/ast/node/IfExpressionNodeImpl.java
+++ b/delphi-frontend/src/main/java/au/com/integradev/delphi/antlr/ast/node/IfExpressionNodeImpl.java
@@ -1,0 +1,75 @@
+/*
+ * Sonar Delphi Plugin
+ * Copyright (C) 2026 Integrated Application Development
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02
+ */
+package au.com.integradev.delphi.antlr.ast.node;
+
+import au.com.integradev.delphi.antlr.ast.visitors.DelphiParserVisitor;
+import au.com.integradev.delphi.symbol.resolve.ExpressionTypeResolver;
+import javax.annotation.Nonnull;
+import org.antlr.runtime.Token;
+import org.sonar.plugins.communitydelphi.api.ast.ExpressionNode;
+import org.sonar.plugins.communitydelphi.api.ast.IfExpressionNode;
+import org.sonar.plugins.communitydelphi.api.type.Type;
+
+public final class IfExpressionNodeImpl extends ExpressionNodeImpl implements IfExpressionNode {
+  private String image;
+
+  public IfExpressionNodeImpl(Token token) {
+    super(token);
+  }
+
+  @Override
+  public <T> T accept(DelphiParserVisitor<T> visitor, T data) {
+    return visitor.visit(this, data);
+  }
+
+  @Override
+  public ExpressionNode getGuardExpression() {
+    return (ExpressionNode) getChild(0);
+  }
+
+  @Override
+  public ExpressionNode getThenExpression() {
+    return (ExpressionNode) getChild(2);
+  }
+
+  @Override
+  public ExpressionNode getElseExpression() {
+    return (ExpressionNode) getChild(4);
+  }
+
+  @Override
+  public String getImage() {
+    if (image == null) {
+      image =
+          "if "
+              + getGuardExpression().getImage()
+              + " then "
+              + getThenExpression().getImage()
+              + " else "
+              + getElseExpression().getImage();
+    }
+    return image;
+  }
+
+  @Override
+  @Nonnull
+  protected Type createType() {
+    return new ExpressionTypeResolver(getTypeFactory()).resolve(this);
+  }
+}

--- a/delphi-frontend/src/main/java/au/com/integradev/delphi/antlr/ast/visitors/CognitiveComplexityVisitor.java
+++ b/delphi-frontend/src/main/java/au/com/integradev/delphi/antlr/ast/visitors/CognitiveComplexityVisitor.java
@@ -31,6 +31,7 @@ import org.sonar.plugins.communitydelphi.api.ast.DelphiNode;
 import org.sonar.plugins.communitydelphi.api.ast.ExceptBlockNode;
 import org.sonar.plugins.communitydelphi.api.ast.ExpressionNode;
 import org.sonar.plugins.communitydelphi.api.ast.ForStatementNode;
+import org.sonar.plugins.communitydelphi.api.ast.IfExpressionNode;
 import org.sonar.plugins.communitydelphi.api.ast.IfStatementNode;
 import org.sonar.plugins.communitydelphi.api.ast.RepeatStatementNode;
 import org.sonar.plugins.communitydelphi.api.ast.StatementNode;
@@ -85,6 +86,31 @@ public class CognitiveComplexityVisitor implements DelphiParserVisitor<Data> {
       if (bareElse) {
         --data.nesting;
       }
+    }
+
+    return data;
+  }
+
+  @Override
+  public Data visit(IfExpressionNode expression, Data data) {
+    data.increaseComplexityByNesting();
+    expression.getGuardExpression().accept(this, data);
+
+    ++data.nesting;
+    expression.getThenExpression().accept(this, data);
+    --data.nesting;
+
+    ExpressionNode elseBranch = expression.getElseExpression();
+    boolean bareElse = !(elseBranch.skipParentheses() instanceof IfExpressionNode);
+    if (bareElse) {
+      data.increaseComplexityByOne();
+      ++data.nesting;
+    } else {
+      data.updateComplexity(data.nesting - 1);
+    }
+    elseBranch.accept(this, data);
+    if (bareElse) {
+      --data.nesting;
     }
 
     return data;

--- a/delphi-frontend/src/main/java/au/com/integradev/delphi/antlr/ast/visitors/CyclomaticComplexityVisitor.java
+++ b/delphi-frontend/src/main/java/au/com/integradev/delphi/antlr/ast/visitors/CyclomaticComplexityVisitor.java
@@ -23,6 +23,7 @@ import org.sonar.plugins.communitydelphi.api.ast.AnonymousMethodNode;
 import org.sonar.plugins.communitydelphi.api.ast.BinaryExpressionNode;
 import org.sonar.plugins.communitydelphi.api.ast.CaseItemStatementNode;
 import org.sonar.plugins.communitydelphi.api.ast.ForStatementNode;
+import org.sonar.plugins.communitydelphi.api.ast.IfExpressionNode;
 import org.sonar.plugins.communitydelphi.api.ast.IfStatementNode;
 import org.sonar.plugins.communitydelphi.api.ast.RepeatStatementNode;
 import org.sonar.plugins.communitydelphi.api.ast.RoutineImplementationNode;
@@ -78,6 +79,12 @@ public class CyclomaticComplexityVisitor implements DelphiParserVisitor<Data> {
   public Data visit(IfStatementNode statement, Data data) {
     ++data.complexity;
     return DelphiParserVisitor.super.visit(statement, data);
+  }
+
+  @Override
+  public Data visit(IfExpressionNode expression, Data data) {
+    ++data.complexity;
+    return DelphiParserVisitor.super.visit(expression, data);
   }
 
   @Override

--- a/delphi-frontend/src/main/java/au/com/integradev/delphi/antlr/ast/visitors/DelphiParserVisitor.java
+++ b/delphi-frontend/src/main/java/au/com/integradev/delphi/antlr/ast/visitors/DelphiParserVisitor.java
@@ -81,6 +81,7 @@ import org.sonar.plugins.communitydelphi.api.ast.GenericDefinitionNode;
 import org.sonar.plugins.communitydelphi.api.ast.GotoStatementNode;
 import org.sonar.plugins.communitydelphi.api.ast.HelperTypeNode;
 import org.sonar.plugins.communitydelphi.api.ast.IdentifierNode;
+import org.sonar.plugins.communitydelphi.api.ast.IfExpressionNode;
 import org.sonar.plugins.communitydelphi.api.ast.IfStatementNode;
 import org.sonar.plugins.communitydelphi.api.ast.ImplementationSectionNode;
 import org.sonar.plugins.communitydelphi.api.ast.ImportClauseNode;
@@ -633,6 +634,10 @@ public interface DelphiParserVisitor<T> {
   }
 
   default T visit(BinaryExpressionNode node, T data) {
+    return visit((ExpressionNode) node, data);
+  }
+
+  default T visit(IfExpressionNode node, T data) {
     return visit((ExpressionNode) node, data);
   }
 

--- a/delphi-frontend/src/main/java/au/com/integradev/delphi/cfg/ControlFlowGraphVisitor.java
+++ b/delphi-frontend/src/main/java/au/com/integradev/delphi/cfg/ControlFlowGraphVisitor.java
@@ -28,6 +28,7 @@ import java.util.List;
 import java.util.Map.Entry;
 import java.util.Set;
 import java.util.stream.Collectors;
+import javax.annotation.Nullable;
 import org.sonar.plugins.communitydelphi.api.ast.AnonymousMethodNode;
 import org.sonar.plugins.communitydelphi.api.ast.ArgumentListNode;
 import org.sonar.plugins.communitydelphi.api.ast.ArgumentNode;
@@ -50,6 +51,7 @@ import org.sonar.plugins.communitydelphi.api.ast.ForLoopVarReferenceNode;
 import org.sonar.plugins.communitydelphi.api.ast.ForStatementNode;
 import org.sonar.plugins.communitydelphi.api.ast.ForToStatementNode;
 import org.sonar.plugins.communitydelphi.api.ast.GotoStatementNode;
+import org.sonar.plugins.communitydelphi.api.ast.IfExpressionNode;
 import org.sonar.plugins.communitydelphi.api.ast.IfStatementNode;
 import org.sonar.plugins.communitydelphi.api.ast.IntegerLiteralNode;
 import org.sonar.plugins.communitydelphi.api.ast.LabelStatementNode;
@@ -260,21 +262,41 @@ class ControlFlowGraphVisitor implements DelphiParserVisitor<ControlFlowGraphBui
    */
   @Override
   public ControlFlowGraphBuilder visit(IfStatementNode node, ControlFlowGraphBuilder builder) {
+    return buildBranches(
+        node, node.getGuardExpression(), node.getThenStatement(), node.getElseStatement(), builder);
+  }
+
+  @Override
+  public ControlFlowGraphBuilder visit(IfExpressionNode node, ControlFlowGraphBuilder builder) {
+    return buildBranches(
+        node,
+        node.getGuardExpression(),
+        node.getThenExpression(),
+        node.getElseExpression(),
+        builder);
+  }
+
+  private ControlFlowGraphBuilder buildBranches(
+      DelphiNode node,
+      ExpressionNode guard,
+      @Nullable DelphiNode thenNode,
+      @Nullable DelphiNode elseNode,
+      ControlFlowGraphBuilder builder) {
     ProtoBlock after = builder.getCurrentBlock();
 
     // process `else`
     builder.addBlockBefore(after);
-    build(node.getElseStatement(), builder);
+    build(elseNode, builder);
     ProtoBlock elseBlock = builder.getCurrentBlock();
 
     // process `then`
     builder.addBlockBefore(after);
-    build(node.getThenStatement(), builder);
+    build(thenNode, builder);
     ProtoBlock thenBlock = builder.getCurrentBlock();
 
     // process condition
     builder.addBlock(ProtoBlockFactory.branch(node, thenBlock, elseBlock));
-    return buildCondition(builder, node.getGuardExpression(), thenBlock, elseBlock);
+    return buildCondition(builder, guard, thenBlock, elseBlock);
   }
 
   private ControlFlowGraphBuilder buildCondition(

--- a/delphi-frontend/src/main/java/au/com/integradev/delphi/symbol/resolve/ArrayElementInferredTypeResolver.java
+++ b/delphi-frontend/src/main/java/au/com/integradev/delphi/symbol/resolve/ArrayElementInferredTypeResolver.java
@@ -31,10 +31,10 @@ import org.sonar.plugins.communitydelphi.api.type.Type.PointerType;
 import org.sonar.plugins.communitydelphi.api.type.TypeFactory;
 
 /** Resolves the element type the compiler infers for an array literal. */
-final class ArrayElementTypeResolver {
+final class ArrayElementInferredTypeResolver {
   private final TypeFactory typeFactory;
 
-  ArrayElementTypeResolver(TypeFactory typeFactory) {
+  ArrayElementInferredTypeResolver(TypeFactory typeFactory) {
     this.typeFactory = typeFactory;
   }
 

--- a/delphi-frontend/src/main/java/au/com/integradev/delphi/symbol/resolve/ArrayElementTypeResolver.java
+++ b/delphi-frontend/src/main/java/au/com/integradev/delphi/symbol/resolve/ArrayElementTypeResolver.java
@@ -1,0 +1,161 @@
+/*
+ * Sonar Delphi Plugin
+ * Copyright (C) 2026 Integrated Application Development
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02
+ */
+package au.com.integradev.delphi.symbol.resolve;
+
+import static org.sonar.plugins.communitydelphi.api.type.TypeFactory.unknownType;
+
+import au.com.integradev.delphi.type.TypeUtils;
+import java.math.BigInteger;
+import java.util.List;
+import org.sonar.plugins.communitydelphi.api.type.IntrinsicType;
+import org.sonar.plugins.communitydelphi.api.type.Type;
+import org.sonar.plugins.communitydelphi.api.type.Type.ClassReferenceType;
+import org.sonar.plugins.communitydelphi.api.type.Type.IntegerType;
+import org.sonar.plugins.communitydelphi.api.type.Type.PointerType;
+import org.sonar.plugins.communitydelphi.api.type.TypeFactory;
+
+/** Resolves the element type the compiler infers for an array literal. */
+final class ArrayElementTypeResolver {
+  private final TypeFactory typeFactory;
+
+  ArrayElementTypeResolver(TypeFactory typeFactory) {
+    this.typeFactory = typeFactory;
+  }
+
+  Type elementType(List<Type> elements) {
+    return elements.stream().map(this::normalize).reduce(this::combine).orElse(unknownType());
+  }
+
+  private Type normalize(Type type) {
+    if (type.isReal()) {
+      return typeFactory.getIntrinsic(IntrinsicType.EXTENDED);
+    }
+    if (isNilPointer(type)) {
+      return typeFactory.getIntrinsic(IntrinsicType.POINTER);
+    }
+    return type;
+  }
+
+  private Type combine(Type first, Type second) {
+    if (first.is(second)) {
+      return first;
+    }
+
+    if (first.isInteger() && second.isInteger()) {
+      return combineInteger((IntegerType) first, (IntegerType) second);
+    }
+
+    if (isTextual(first) && isTextual(second)) {
+      return typeFactory.getIntrinsic(IntrinsicType.UNICODESTRING);
+    }
+
+    if (isBooleanBased(first) && isBooleanBased(second)) {
+      return typeFactory.getIntrinsic(IntrinsicType.BOOLEAN);
+    }
+
+    Type firstBase = TypeUtils.findBaseType(first);
+    if (firstBase.isEnum() && firstBase.is(TypeUtils.findBaseType(second))) {
+      return firstBase;
+    }
+
+    if ((first.isClass() && second.isClass()) || (first.isInterface() && second.isInterface())) {
+      if (second.isDescendantOf(first)) {
+        return first;
+      }
+      if (first.isDescendantOf(second)) {
+        return second;
+      }
+      return rootOf(first);
+    }
+
+    if (first.isClassReference() && second.isClassReference()) {
+      return combineClassReference(first, second);
+    }
+
+    if (first.isPointer() && second.isPointer()) {
+      return typeFactory.getIntrinsic(IntrinsicType.POINTER);
+    }
+
+    return unknownType();
+  }
+
+  private Type combineInteger(IntegerType first, IntegerType second) {
+    IntegerType left = promote(first);
+    IntegerType right = promote(second);
+    if (left.is(right)) {
+      return left;
+    }
+
+    BigInteger min = left.min().min(right.min());
+    BigInteger max = left.max().max(right.max());
+    for (IntrinsicType candidate :
+        List.of(
+            IntrinsicType.INTEGER,
+            IntrinsicType.CARDINAL,
+            IntrinsicType.INT64,
+            IntrinsicType.UINT64)) {
+      IntegerType type = (IntegerType) typeFactory.getIntrinsic(candidate);
+      if (type.min().compareTo(min) <= 0 && type.max().compareTo(max) >= 0) {
+        return type;
+      }
+    }
+
+    return typeFactory.getIntrinsic(IntrinsicType.UINT64);
+  }
+
+  private IntegerType promote(IntegerType type) {
+    if (type.size() < 4) {
+      return (IntegerType) typeFactory.getIntrinsic(IntrinsicType.INTEGER);
+    }
+    return type;
+  }
+
+  private static Type combineClassReference(Type first, Type second) {
+    Type firstClass = ((ClassReferenceType) first).classType();
+    Type secondClass = ((ClassReferenceType) second).classType();
+    if (secondClass.isDescendantOf(firstClass)) {
+      return first;
+    }
+    if (firstClass.isDescendantOf(secondClass)) {
+      return second;
+    }
+    return unknownType();
+  }
+
+  private static Type rootOf(Type type) {
+    Type root = type;
+    for (Type parent = root.parent(); !parent.isUnknown(); parent = parent.parent()) {
+      root = parent;
+    }
+    return root;
+  }
+
+  private static boolean isNilPointer(Type type) {
+    return type.isPointer() && ((PointerType) type).isNilPointer();
+  }
+
+  private static boolean isTextual(Type type) {
+    Type base = TypeUtils.findBaseType(type);
+    return base.isString() || base.isChar();
+  }
+
+  private static boolean isBooleanBased(Type type) {
+    return TypeUtils.findBaseType(type).isBoolean();
+  }
+}

--- a/delphi-frontend/src/main/java/au/com/integradev/delphi/symbol/resolve/CommonTypeResolver.java
+++ b/delphi-frontend/src/main/java/au/com/integradev/delphi/symbol/resolve/CommonTypeResolver.java
@@ -1,0 +1,477 @@
+/*
+ * Sonar Delphi Plugin
+ * Copyright (C) 2026 Integrated Application Development
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02
+ */
+package au.com.integradev.delphi.symbol.resolve;
+
+import static org.sonar.plugins.communitydelphi.api.type.TypeFactory.unknownType;
+
+import au.com.integradev.delphi.type.TypeUtils;
+import au.com.integradev.delphi.type.factory.ArrayOption;
+import au.com.integradev.delphi.type.factory.TypeFactoryImpl;
+import java.math.BigInteger;
+import java.util.List;
+import java.util.Set;
+import org.sonar.plugins.communitydelphi.api.type.IntrinsicType;
+import org.sonar.plugins.communitydelphi.api.type.Type;
+import org.sonar.plugins.communitydelphi.api.type.Type.ArrayConstructorType;
+import org.sonar.plugins.communitydelphi.api.type.Type.ClassReferenceType;
+import org.sonar.plugins.communitydelphi.api.type.Type.CollectionType;
+import org.sonar.plugins.communitydelphi.api.type.Type.IntegerType;
+import org.sonar.plugins.communitydelphi.api.type.Type.PointerType;
+import org.sonar.plugins.communitydelphi.api.type.Type.ProceduralType;
+import org.sonar.plugins.communitydelphi.api.type.Type.ProceduralType.ProceduralKind;
+import org.sonar.plugins.communitydelphi.api.type.TypeFactory;
+
+/**
+ * Resolves the common type of an {@code if} expression's operands, documented by Embarcadero as the
+ * "least upper bound".
+ *
+ * <p>In practice, this is not a strict least upper bound:
+ *
+ * <ul>
+ *   <li>ties break toward the first operand (operand order matters)
+ *   <li>some results cannot hold both operands
+ * </ul>
+ *
+ * @see <a href="https://docwiki.embarcadero.com/RADStudio/en/Conditional_Operators_(Delphi)">
+ *     Conditional Operators (Delphi) </a>
+ */
+final class CommonTypeResolver {
+  private static final List<IntegerTier> INTEGER_TIERS =
+      List.of(
+          new IntegerTier(IntrinsicType.SHORTINT, IntrinsicType.BYTE),
+          new IntegerTier(IntrinsicType.SMALLINT, IntrinsicType.WORD),
+          new IntegerTier(IntrinsicType.INTEGER, IntrinsicType.CARDINAL),
+          new IntegerTier(IntrinsicType.INT64, IntrinsicType.UINT64));
+
+  private static final class IntegerTier {
+    final IntrinsicType signedType;
+    final IntrinsicType unsignedType;
+
+    IntegerTier(IntrinsicType signedType, IntrinsicType unsignedType) {
+      this.signedType = signedType;
+      this.unsignedType = unsignedType;
+    }
+  }
+
+  private final TypeFactory typeFactory;
+  private final ArrayElementInferredTypeResolver elementResolver;
+
+  CommonTypeResolver(TypeFactory typeFactory) {
+    this.typeFactory = typeFactory;
+    this.elementResolver = new ArrayElementInferredTypeResolver(typeFactory);
+  }
+
+  /** The common type of two operands, or unknown where Delphi rejects the combination. */
+  Type commonType(Type first, Type second) {
+    if (first.is(second)) {
+      return first;
+    }
+
+    if (isNilPointer(first) && !second.isPointer()) {
+      return nilCombinedType(second);
+    }
+    if (isNilPointer(second) && !first.isPointer()) {
+      return nilCombinedType(first);
+    }
+
+    if (first.isInteger() && second.isInteger()) {
+      return commonIntegerType(first, second);
+    }
+
+    if (isNumeric(first) && isNumeric(second)) {
+      return commonRealType(first, second);
+    }
+
+    if (isBooleanBased(first) && isBooleanBased(second)) {
+      return first;
+    }
+
+    if (first.isVariant() && second.isVariant()) {
+      return typeFactory.getIntrinsic(IntrinsicType.VARIANT);
+    }
+
+    if (isTextual(first) && isTextual(second)) {
+      return commonTextualType(first, second);
+    }
+
+    if (isPWideCharWithTextual(first, second)) {
+      return typeFactory.getIntrinsic(IntrinsicType.UNICODESTRING);
+    }
+
+    if (first.isPointer() && second.isPointer()) {
+      return commonPointerType(first, second);
+    }
+
+    if (first.isClass() && second.isClass()) {
+      return nearestCommonAncestor(first, second);
+    }
+
+    if (first.isInterface() && second.isInterface()) {
+      return nearestCommonAncestor(first, second);
+    }
+
+    if (first.isClassReference() && second.isClassReference()) {
+      return commonClassReferenceType(first, second);
+    }
+
+    if (first.isProcedural() && second.isProcedural()) {
+      return commonProceduralType(first, second);
+    }
+
+    if (first.isSet() && second.isSet()) {
+      return commonSetType(first, second);
+    }
+
+    if (first.isSet() && second.isArrayConstructor()) {
+      return setAbsorbingConstructor(first, (ArrayConstructorType) second);
+    }
+    if (second.isSet() && first.isArrayConstructor()) {
+      return setAbsorbingConstructor(second, (ArrayConstructorType) first);
+    }
+
+    if (first.isArrayConstructor() && second.isArrayConstructor()) {
+      return commonArrayConstructorType(
+          (ArrayConstructorType) first, (ArrayConstructorType) second);
+    }
+
+    return sharedBaseType(first, second);
+  }
+
+  private static Type sharedBaseType(Type first, Type second) {
+    Type baseType = TypeUtils.findBaseType(first);
+    if (baseType.is(TypeUtils.findBaseType(second))) {
+      return baseType;
+    }
+    return unknownType();
+  }
+
+  private static Type unalias(Type type) {
+    return TypeUtils.findAliasedType(type);
+  }
+
+  private Type commonArrayConstructorType(ArrayConstructorType first, ArrayConstructorType second) {
+    return allElementsOrdinal(first) && allElementsOrdinal(second) ? first : unknownType();
+  }
+
+  private static boolean isNilPointer(Type type) {
+    return type.isPointer() && ((PointerType) type).isNilPointer();
+  }
+
+  private Type nilCombinedType(Type other) {
+    if (other.isArrayConstructor()) {
+      return anonymousDynamicArray((ArrayConstructorType) other);
+    }
+    return acceptsNil(other) ? other : unknownType();
+  }
+
+  private Type anonymousDynamicArray(ArrayConstructorType constructor) {
+    Type element = elementResolver.elementType(constructor.elementTypes());
+    if (element.isUnknown()) {
+      return unknownType();
+    }
+    return ((TypeFactoryImpl) typeFactory).array(null, element, Set.of(ArrayOption.DYNAMIC));
+  }
+
+  private static boolean acceptsNil(Type type) {
+    return type.isClass()
+        || type.isInterface()
+        || type.isClassReference()
+        || type.isProcedural()
+        || type.isDynamicArray();
+  }
+
+  private static boolean isPWideCharWithTextual(Type first, Type second) {
+    return (unalias(first).is(IntrinsicType.PWIDECHAR) && isTextual(second))
+        || (unalias(second).is(IntrinsicType.PWIDECHAR) && isTextual(first));
+  }
+
+  private Type commonPointerType(Type first, Type second) {
+    PointerType firstPointer = (PointerType) first;
+    PointerType secondPointer = (PointerType) second;
+
+    if (firstPointer.isNilPointer()) {
+      return typeFactory.getIntrinsic(IntrinsicType.POINTER);
+    }
+
+    if (secondPointer.isNilPointer()
+        || firstPointer.isUntypedPointer()
+        || secondPointer.isUntypedPointer()) {
+      return first;
+    }
+
+    return typeFactory.getIntrinsic(IntrinsicType.POINTER);
+  }
+
+  private static Type nearestCommonAncestor(Type first, Type second) {
+    for (Type candidate = first; candidate.isStruct(); candidate = candidate.parent()) {
+      if (second.is(candidate) || second.isDescendantOf(candidate)) {
+        return candidate;
+      }
+    }
+    return unknownType();
+  }
+
+  private Type commonClassReferenceType(Type first, Type second) {
+    ClassReferenceType firstReference = (ClassReferenceType) unalias(first);
+    ClassReferenceType secondReference = (ClassReferenceType) unalias(second);
+
+    if (firstReference.classType().is(secondReference.classType())) {
+      // For a class reference tie, the compiler prefers the second (!!!) operand.
+      // This is a departure from every other case, where the first operand is preferred.
+      return second;
+    }
+
+    Type ancestor = nearestCommonAncestor(firstReference.classType(), secondReference.classType());
+    if (ancestor.isUnknown()) {
+      return unknownType();
+    }
+
+    if (ancestor.is(firstReference.classType())) {
+      return firstReference;
+    }
+
+    if (ancestor.is(secondReference.classType())) {
+      return secondReference;
+    }
+
+    return typeFactory.classOf(null, ancestor);
+  }
+
+  private Type commonSetType(Type first, Type second) {
+    Type firstElement = ((CollectionType) first).elementType();
+    Type secondElement = ((CollectionType) second).elementType();
+
+    if (containsRange(firstElement, secondElement)) {
+      return first;
+    }
+    if (containsRange(secondElement, firstElement)) {
+      return second;
+    }
+
+    Type firstElementBase = TypeUtils.findBaseType(firstElement);
+    Type secondElementBase = TypeUtils.findBaseType(secondElement);
+
+    if (firstElementBase.isInteger() && secondElementBase.isInteger()) {
+      return typeFactory.set(typeFactory.getIntrinsic(IntrinsicType.BYTE));
+    }
+
+    if (firstElementBase.isChar() && secondElementBase.isChar()) {
+      return typeFactory.set(typeFactory.getIntrinsic(IntrinsicType.ANSICHAR));
+    }
+
+    return unknownType();
+  }
+
+  private static boolean containsRange(Type container, Type contained) {
+    if (container instanceof IntegerType && contained instanceof IntegerType) {
+      IntegerType containerRange = (IntegerType) container;
+      IntegerType containedRange = (IntegerType) contained;
+      return containerRange.min().compareTo(containedRange.min()) <= 0
+          && containerRange.max().compareTo(containedRange.max()) >= 0;
+    }
+    return TypeUtils.findBaseType(contained).is(TypeUtils.findBaseType(container));
+  }
+
+  private static boolean allElementsOrdinal(ArrayConstructorType constructor) {
+    return constructor.elementTypes().stream().allMatch(CommonTypeResolver::isOrdinal);
+  }
+
+  private static boolean isOrdinal(Type type) {
+    return type.isInteger()
+        || type.isEnum()
+        || type.isChar()
+        || type.isBoolean()
+        || type.isSubrange();
+  }
+
+  private Type setAbsorbingConstructor(Type set, ArrayConstructorType constructor) {
+    Type element = ((CollectionType) set).elementType();
+
+    for (Type constructorElement : constructor.elementTypes()) {
+      if (commonType(element, constructorElement).isUnknown()) {
+        return unknownType();
+      }
+    }
+
+    return set;
+  }
+
+  private Type commonProceduralType(Type first, Type second) {
+    ProceduralType firstProcedural = (ProceduralType) first;
+    ProceduralType secondProcedural = (ProceduralType) second;
+
+    if (!signaturesMatch(firstProcedural, secondProcedural)) {
+      return unknownType();
+    }
+
+    if (firstProcedural.kind() == ProceduralKind.REFERENCE
+        && secondProcedural.kind() == ProceduralKind.ANONYMOUS) {
+      return first;
+    }
+
+    if (firstProcedural.kind() == ProceduralKind.ANONYMOUS
+        && secondProcedural.kind() == ProceduralKind.REFERENCE) {
+      return second;
+    }
+
+    return unknownType();
+  }
+
+  private static boolean signaturesMatch(ProceduralType first, ProceduralType second) {
+    if (first.parametersCount() != second.parametersCount()
+        || !first.returnType().is(second.returnType())) {
+      return false;
+    }
+
+    for (int i = 0; i < first.parametersCount(); i++) {
+      if (!first.parameters().get(i).getType().is(second.parameters().get(i).getType())) {
+        return false;
+      }
+    }
+
+    return true;
+  }
+
+  private Type commonIntegerType(Type first, Type second) {
+    IntegerType firstInteger = (IntegerType) first;
+    IntegerType secondInteger = (IntegerType) second;
+    BigInteger min = firstInteger.min().min(secondInteger.min());
+    BigInteger max = firstInteger.max().max(secondInteger.max());
+
+    for (IntegerTier tier : INTEGER_TIERS) {
+      IntegerType signedType = (IntegerType) typeFactory.getIntrinsic(tier.signedType);
+      IntegerType unsignedType = (IntegerType) typeFactory.getIntrinsic(tier.unsignedType);
+
+      boolean signedHolds = holdsRange(signedType, min, max);
+      boolean unsignedHolds = holdsRange(unsignedType, min, max);
+
+      if (signedHolds && unsignedHolds) {
+        return resultForSignedUnsignedTie(signedType);
+      } else if (signedHolds) {
+        return signedType;
+      } else if (unsignedHolds) {
+        return unsignedType;
+      }
+    }
+
+    // Nothing holds both an Int64 and a UInt64; the compiler treats the result as unsigned.
+    return typeFactory.getIntrinsic(IntrinsicType.UINT64);
+  }
+
+  private static boolean holdsRange(IntegerType type, BigInteger min, BigInteger max) {
+    return type.min().compareTo(min) <= 0 && type.max().compareTo(max) >= 0;
+  }
+
+  /**
+   * @param signedType the narrowest signed type holding the combined range
+   */
+  private Type resultForSignedUnsignedTie(IntegerType signedType) {
+    switch (signedType.size()) {
+      case 2:
+        return ((TypeFactoryImpl) typeFactory).anonymousUInt15();
+      case 4:
+        return ((TypeFactoryImpl) typeFactory).anonymousUInt31();
+      default:
+        return signedType;
+    }
+  }
+
+  private Type commonRealType(Type first, Type second) {
+    if (isFloatingPoint(first) || isFloatingPoint(second) || extendedHoldsFixedPointTypes()) {
+      return typeFactory.getIntrinsic(IntrinsicType.EXTENDED);
+    }
+
+    if (isCurrency(first) || isCurrency(second)) {
+      return typeFactory.getIntrinsic(IntrinsicType.CURRENCY);
+    }
+
+    return typeFactory.getIntrinsic(IntrinsicType.COMP);
+  }
+
+  /** An Extended larger than 8 bytes can hold Comp or Currency without losing precision. */
+  private boolean extendedHoldsFixedPointTypes() {
+    return typeFactory.getIntrinsic(IntrinsicType.EXTENDED).size() > 8;
+  }
+
+  private static boolean isCurrency(Type type) {
+    return unalias(type).is(IntrinsicType.CURRENCY);
+  }
+
+  private Type commonTextualType(Type first, Type second) {
+    Type firstBase = TypeUtils.findBaseType(first);
+    Type secondBase = TypeUtils.findBaseType(second);
+
+    if (firstBase.is(secondBase)) {
+      boolean stringsKeepTheirDeclaredType = firstBase.isString();
+      return stringsKeepTheirDeclaredType ? first : firstBase;
+    }
+
+    if (isShortString(first) || isShortString(second)) {
+      return commonShortStringType(first, second);
+    } else if (firstBase.is(IntrinsicType.UNICODESTRING)) {
+      return first;
+    } else if (secondBase.is(IntrinsicType.UNICODESTRING)) {
+      return second;
+    } else if (firstBase.is(IntrinsicType.WIDESTRING)) {
+      return first;
+    } else if (secondBase.is(IntrinsicType.WIDESTRING)) {
+      return second;
+    } else if (firstBase.is(IntrinsicType.WIDECHAR) || secondBase.is(IntrinsicType.WIDECHAR)) {
+      return typeFactory.getIntrinsic(IntrinsicType.UNICODESTRING);
+    } else {
+      return firstBase.isAnsiString() ? first : second;
+    }
+  }
+
+  private Type commonShortStringType(Type first, Type second) {
+    Type shortString = isShortString(first) ? first : second;
+    Type other = isShortString(first) ? second : first;
+    Type otherBase = TypeUtils.findBaseType(other);
+
+    if (otherBase.is(IntrinsicType.ANSICHAR)) {
+      return shortString;
+    }
+    if (otherBase.is(IntrinsicType.UNICODESTRING)) {
+      return other;
+    }
+    return unknownType();
+  }
+
+  private static boolean isNumeric(Type type) {
+    return type.isInteger() || type.isReal();
+  }
+
+  private static boolean isFloatingPoint(Type type) {
+    type = unalias(type);
+    return type.isReal() && !type.is(IntrinsicType.COMP) && !type.is(IntrinsicType.CURRENCY);
+  }
+
+  private static boolean isBooleanBased(Type type) {
+    return TypeUtils.findBaseType(type).isBoolean();
+  }
+
+  private static boolean isTextual(Type type) {
+    type = TypeUtils.findBaseType(type);
+    return type.isString() || type.isChar();
+  }
+
+  private static boolean isShortString(Type type) {
+    return TypeUtils.findBaseType(type).is(IntrinsicType.SHORTSTRING);
+  }
+}

--- a/delphi-frontend/src/main/java/au/com/integradev/delphi/symbol/resolve/ExpressionTypeResolver.java
+++ b/delphi-frontend/src/main/java/au/com/integradev/delphi/symbol/resolve/ExpressionTypeResolver.java
@@ -36,6 +36,7 @@ import org.sonar.plugins.communitydelphi.api.ast.BinaryExpressionNode;
 import org.sonar.plugins.communitydelphi.api.ast.CommonDelphiNode;
 import org.sonar.plugins.communitydelphi.api.ast.DelphiNode;
 import org.sonar.plugins.communitydelphi.api.ast.ExpressionNode;
+import org.sonar.plugins.communitydelphi.api.ast.IfExpressionNode;
 import org.sonar.plugins.communitydelphi.api.ast.NameReferenceNode;
 import org.sonar.plugins.communitydelphi.api.ast.Node;
 import org.sonar.plugins.communitydelphi.api.ast.PrimaryExpressionNode;
@@ -64,9 +65,11 @@ import org.sonar.plugins.communitydelphi.api.type.Typed;
 
 public final class ExpressionTypeResolver {
   private final TypeFactory typeFactory;
+  private final CommonTypeResolver commonTypeResolver;
 
   public ExpressionTypeResolver(TypeFactory typeFactory) {
     this.typeFactory = typeFactory;
+    this.commonTypeResolver = new CommonTypeResolver(typeFactory);
   }
 
   public Type resolve(BinaryExpressionNode expression) {
@@ -91,6 +94,11 @@ public final class ExpressionTypeResolver {
     } else {
       return resolveOperatorType(operator, operand);
     }
+  }
+
+  public Type resolve(IfExpressionNode expression) {
+    return commonTypeResolver.commonType(
+        expression.getThenExpression().getType(), expression.getElseExpression().getType());
   }
 
   public Type resolve(PrimaryExpressionNode expression) {

--- a/delphi-frontend/src/main/java/au/com/integradev/delphi/symbol/resolve/TypeInferrer.java
+++ b/delphi-frontend/src/main/java/au/com/integradev/delphi/symbol/resolve/TypeInferrer.java
@@ -37,11 +37,11 @@ import org.sonar.plugins.communitydelphi.api.type.Typed;
 
 public final class TypeInferrer {
   private final TypeFactory typeFactory;
-  private final ArrayElementTypeResolver elementResolver;
+  private final ArrayElementInferredTypeResolver elementResolver;
 
   public TypeInferrer(TypeFactory typeFactory) {
     this.typeFactory = typeFactory;
-    this.elementResolver = new ArrayElementTypeResolver(typeFactory);
+    this.elementResolver = new ArrayElementInferredTypeResolver(typeFactory);
   }
 
   public Type infer(Typed typed) {

--- a/delphi-frontend/src/main/java/au/com/integradev/delphi/symbol/resolve/TypeInferrer.java
+++ b/delphi-frontend/src/main/java/au/com/integradev/delphi/symbol/resolve/TypeInferrer.java
@@ -20,7 +20,9 @@ package au.com.integradev.delphi.symbol.resolve;
 
 import au.com.integradev.delphi.type.factory.ArrayOption;
 import au.com.integradev.delphi.type.factory.TypeFactoryImpl;
+import java.util.List;
 import java.util.Set;
+import java.util.stream.Collectors;
 import org.sonar.plugins.communitydelphi.api.ast.ArrayConstructorNode;
 import org.sonar.plugins.communitydelphi.api.ast.ExpressionNode;
 import org.sonar.plugins.communitydelphi.api.ast.IntegerLiteralNode;
@@ -35,9 +37,11 @@ import org.sonar.plugins.communitydelphi.api.type.Typed;
 
 public final class TypeInferrer {
   private final TypeFactory typeFactory;
+  private final ArrayElementTypeResolver elementResolver;
 
   public TypeInferrer(TypeFactory typeFactory) {
     this.typeFactory = typeFactory;
+    this.elementResolver = new ArrayElementTypeResolver(typeFactory);
   }
 
   public Type infer(Typed typed) {
@@ -67,12 +71,15 @@ public final class TypeInferrer {
   }
 
   private Type inferArrayConstructor(ArrayConstructorNode arrayConstructor) {
-    Type element =
+    List<Type> elements =
         arrayConstructor.getElements().stream()
             .map(this::infer)
-            .max(TypeInferrer::compareTypeSize)
-            .orElse(TypeFactory.voidType());
+            .collect(Collectors.toUnmodifiableList());
 
+    Type element = elementResolver.elementType(elements);
+    if (element.isUnknown()) {
+      return TypeFactory.unknownType();
+    }
     return ((TypeFactoryImpl) typeFactory).array(null, element, Set.of(ArrayOption.DYNAMIC));
   }
 
@@ -96,17 +103,5 @@ public final class TypeInferrer {
       type = typeFactory.getIntrinsic(IntrinsicType.EXTENDED);
     }
     return type;
-  }
-
-  private static int compareTypeSize(Type a, Type b) {
-    if (a.size() > b.size()) {
-      return 1;
-    } else if (a.size() < b.size()) {
-      return -1;
-    } else if (a instanceof IntegerType && b instanceof IntegerType) {
-      return ((IntegerType) a).max().compareTo(((IntegerType) b).max());
-    } else {
-      return 0;
-    }
   }
 }

--- a/delphi-frontend/src/main/java/au/com/integradev/delphi/type/TypeUtils.java
+++ b/delphi-frontend/src/main/java/au/com/integradev/delphi/type/TypeUtils.java
@@ -30,12 +30,18 @@ public final class TypeUtils {
   }
 
   public static Type findBaseType(Type type) {
-    while (type.isAlias()) {
-      type = ((AliasType) type).aliasedType();
-    }
+    type = findAliasedType(type);
 
     if (type.isSubrange()) {
       type = ((SubrangeType) type).hostType();
+    }
+
+    return type;
+  }
+
+  public static Type findAliasedType(Type type) {
+    while (type.isAlias()) {
+      type = ((AliasType) type).aliasedType();
     }
 
     return type;

--- a/delphi-frontend/src/main/java/org/sonar/plugins/communitydelphi/api/ast/IfExpressionNode.java
+++ b/delphi-frontend/src/main/java/org/sonar/plugins/communitydelphi/api/ast/IfExpressionNode.java
@@ -1,0 +1,27 @@
+/*
+ * Sonar Delphi Plugin
+ * Copyright (C) 2026 Integrated Application Development
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02
+ */
+package org.sonar.plugins.communitydelphi.api.ast;
+
+public interface IfExpressionNode extends ExpressionNode {
+  ExpressionNode getGuardExpression();
+
+  ExpressionNode getThenExpression();
+
+  ExpressionNode getElseExpression();
+}

--- a/delphi-frontend/src/test/java/au/com/integradev/delphi/antlr/GrammarTest.java
+++ b/delphi-frontend/src/test/java/au/com/integradev/delphi/antlr/GrammarTest.java
@@ -371,4 +371,9 @@ class GrammarTest {
   void testGenericConstraints() {
     assertParsed("GenericConstraints.pas");
   }
+
+  @Test
+  void testIfExpressions() {
+    assertParsed("IfExpressions.pas");
+  }
 }

--- a/delphi-frontend/src/test/java/au/com/integradev/delphi/antlr/ast/node/IfExpressionNodeImplTest.java
+++ b/delphi-frontend/src/test/java/au/com/integradev/delphi/antlr/ast/node/IfExpressionNodeImplTest.java
@@ -1,0 +1,87 @@
+/*
+ * Sonar Delphi Plugin
+ * Copyright (C) 2026 Integrated Application Development
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02
+ */
+package au.com.integradev.delphi.antlr.ast.node;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import au.com.integradev.delphi.utils.files.DelphiFileUtils;
+import org.junit.jupiter.api.Test;
+import org.sonar.plugins.communitydelphi.api.ast.IfExpressionNode;
+import org.sonar.plugins.communitydelphi.api.token.DelphiTokenType;
+
+class IfExpressionNodeImplTest {
+  @Test
+  void testBranches() {
+    IfExpressionNode node = parse("Foo := if Bar then Baz else Flarp;");
+
+    assertThat(node.getGuardExpression().getImage()).isEqualTo("Bar");
+    assertThat(node.getThenExpression().getImage()).isEqualTo("Baz");
+    assertThat(node.getElseExpression().getImage()).isEqualTo("Flarp");
+  }
+
+  @Test
+  void testImage() {
+    IfExpressionNode node = parse("Foo := if Bar then Baz else Flarp;");
+
+    assertThat(node.getImage()).isEqualTo("if Bar then Baz else Flarp");
+  }
+
+  @Test
+  void testTokenType() {
+    IfExpressionNode node = parse("Foo := if Bar then Baz else Flarp;");
+
+    assertThat(node.getTokenType()).isEqualTo(DelphiTokenType.IF);
+  }
+
+  @Test
+  void testElseBranchBindsToNearestIf() {
+    IfExpressionNode node = parse("Foo := if Bar then Baz else if Flarp then Bim else Bum;");
+
+    assertThat(node.getThenExpression().getImage()).isEqualTo("Baz");
+    assertThat(node.getElseExpression()).isInstanceOf(IfExpressionNode.class);
+    assertThat(node.getElseExpression().getImage()).isEqualTo("if Flarp then Bim else Bum");
+  }
+
+  @Test
+  void testUnparenthesizedNestedIfInThenBranch() {
+    IfExpressionNode node = parse("Foo := if Bar then if Baz then Bim else Bum else Flarp;");
+
+    assertThat(node.getThenExpression()).isInstanceOf(IfExpressionNode.class);
+    assertThat(node.getThenExpression().getImage()).isEqualTo("if Baz then Bim else Bum");
+    assertThat(node.getElseExpression().getImage()).isEqualTo("Flarp");
+  }
+
+  private static IfExpressionNode parse(String statement) {
+    return DelphiFileUtils.parse(
+            "unit Test;",
+            "",
+            "interface",
+            "",
+            "implementation",
+            "",
+            "procedure Test;",
+            "begin",
+            "  " + statement,
+            "end;",
+            "",
+            "end.")
+        .getAst()
+        .getFirstDescendantOfType(IfExpressionNode.class);
+  }
+}

--- a/delphi-frontend/src/test/java/au/com/integradev/delphi/antlr/ast/visitors/CognitiveComplexityVisitorTest.java
+++ b/delphi-frontend/src/test/java/au/com/integradev/delphi/antlr/ast/visitors/CognitiveComplexityVisitorTest.java
@@ -127,6 +127,66 @@ class CognitiveComplexityVisitorTest {
         .isEqualTo(4);
   }
 
+  @Test
+  void testIfExpression() {
+    assertThat(
+            getComplexity(
+                "function Foo: Integer;\n"
+                    + "begin\n"
+                    + "  Result := if Bar then 1 else 2;\n" // <2> 1
+                    + "end;\n"))
+        .isEqualTo(2);
+  }
+
+  @Test
+  void testNestedIfExpression() {
+    assertThat(
+            getComplexity(
+                "function Foo: Integer;\n"
+                    + "begin\n"
+                    + "  Result := if Bar then 1 else if Baz then 2 else 3;\n"
+                    + "end;\n"))
+        .isEqualTo(3);
+  }
+
+  @Test
+  void testParenthesizedElseIfExpression() {
+    assertThat(
+            getComplexity(
+                "function Foo: Integer;\n"
+                    + "begin\n"
+                    + "  Result := if Bar then 1 else ((if Baz then 2 else 3));\n"
+                    + "end;\n"))
+        .isEqualTo(3);
+  }
+
+  @Test
+  void testChainedIfExpression() {
+    assertThat(
+            getComplexity(
+                "function Foo: Integer;\n"
+                    + "begin\n"
+                    + "  Result := if Bar then 1\n" // <1> 1
+                    + "    else if Baz then 2\n" // <2> 1
+                    + "    else if Flarp then 3\n" // <3> 1
+                    + "    else 4;\n" // <4> 1
+                    + "end;\n"))
+        .isEqualTo(4);
+  }
+
+  @Test
+  void testIfExpressionInsideIfStatement() {
+    assertThat(
+            getComplexity(
+                "function Foo: Integer;\n"
+                    + "begin\n"
+                    + "  if Bar then begin\n" // <1> 1
+                    + "    Result := if Baz then 1 else 2;\n" // <4> 3
+                    + "  end;\n"
+                    + "end;\n"))
+        .isEqualTo(4);
+  }
+
   private int getComplexity(String function) {
     Path path = tempDir.resolve("SourceFile.pas");
     try {

--- a/delphi-frontend/src/test/java/au/com/integradev/delphi/antlr/ast/visitors/CyclomaticComplexityVisitorTest.java
+++ b/delphi-frontend/src/test/java/au/com/integradev/delphi/antlr/ast/visitors/CyclomaticComplexityVisitorTest.java
@@ -127,6 +127,28 @@ class CyclomaticComplexityVisitorTest {
         .isEqualTo(15);
   }
 
+  @Test
+  void testIfExpression() {
+    assertThat(
+            getComplexity(
+                "function Foo: Integer;\n" // 1
+                    + "begin\n"
+                    + "  Result := if X then 1 else 2;\n" // 2
+                    + "end;\n"))
+        .isEqualTo(2);
+  }
+
+  @Test
+  void testChainedIfExpression() {
+    assertThat(
+            getComplexity(
+                "function Foo: Integer;\n" // 1
+                    + "begin\n"
+                    + "  Result := if X then 1 else if Y then 2 else 3;\n" // 2 3
+                    + "end;\n"))
+        .isEqualTo(3);
+  }
+
   private int getComplexity(String function) {
     Path path = tempDir.resolve("SourceFile.pas");
     try {

--- a/delphi-frontend/src/test/java/au/com/integradev/delphi/cfg/ControlFlowGraphTest.java
+++ b/delphi-frontend/src/test/java/au/com/integradev/delphi/cfg/ControlFlowGraphTest.java
@@ -65,6 +65,7 @@ import org.sonar.plugins.communitydelphi.api.ast.FinallyBlockNode;
 import org.sonar.plugins.communitydelphi.api.ast.ForInStatementNode;
 import org.sonar.plugins.communitydelphi.api.ast.ForToStatementNode;
 import org.sonar.plugins.communitydelphi.api.ast.GotoStatementNode;
+import org.sonar.plugins.communitydelphi.api.ast.IfExpressionNode;
 import org.sonar.plugins.communitydelphi.api.ast.IfStatementNode;
 import org.sonar.plugins.communitydelphi.api.ast.IntegerLiteralNode;
 import org.sonar.plugins.communitydelphi.api.ast.NameDeclarationNode;
@@ -343,6 +344,34 @@ class ControlFlowGraphTest {
                 .branchesTo(1, 1)
                 .withTerminator(IfStatementNode.class),
             block(element(NameReferenceNode.class, "A")).succeedsTo(EXIT_ID)));
+  }
+
+  @Test
+  void testIfExpression() {
+    test(
+        List.of("X: Integer"),
+        "X := if C then A else B;",
+        checker(
+            block(element(NameReferenceNode.class, "C"))
+                .branchesTo(3, 2)
+                .withTerminator(IfExpressionNode.class),
+            block(element(NameReferenceNode.class, "A")).succeedsTo(1),
+            block(element(NameReferenceNode.class, "B")).succeedsTo(1),
+            block(element(NameReferenceNode.class, "X")).succeedsTo(0)));
+  }
+
+  @Test
+  void testIfExpressionInGuardOfIfStatement() {
+    test(
+        "if (if C then A else B) then D;",
+        checker(
+            block(element(NameReferenceNode.class, "C"))
+                .branchesTo(4, 3)
+                .withTerminator(IfExpressionNode.class),
+            block(element(NameReferenceNode.class, "A")).succeedsTo(2),
+            block(element(NameReferenceNode.class, "B")).succeedsTo(2),
+            block().branchesTo(1, 0).withTerminator(IfStatementNode.class),
+            block(element(NameReferenceNode.class, "D")).succeedsTo(EXIT_ID)));
   }
 
   @Test

--- a/delphi-frontend/src/test/java/au/com/integradev/delphi/symbol/resolve/ArrayElementInferredTypeResolverTest.java
+++ b/delphi-frontend/src/test/java/au/com/integradev/delphi/symbol/resolve/ArrayElementInferredTypeResolverTest.java
@@ -34,10 +34,11 @@ import org.sonar.plugins.communitydelphi.api.type.IntrinsicType;
 import org.sonar.plugins.communitydelphi.api.type.Type;
 import org.sonar.plugins.communitydelphi.api.type.Type.StructType;
 
-class ArrayElementTypeResolverTest {
+class ArrayElementInferredTypeResolverTest {
   private static final TypeFactoryImpl FACTORY =
       (TypeFactoryImpl) TypeFactoryUtils.defaultFactory();
-  private static final ArrayElementTypeResolver RESOLVER = new ArrayElementTypeResolver(FACTORY);
+  private static final ArrayElementInferredTypeResolver RESOLVER =
+      new ArrayElementInferredTypeResolver(FACTORY);
 
   @ParameterizedTest
   @CsvSource({

--- a/delphi-frontend/src/test/java/au/com/integradev/delphi/symbol/resolve/ArrayElementTypeResolverTest.java
+++ b/delphi-frontend/src/test/java/au/com/integradev/delphi/symbol/resolve/ArrayElementTypeResolverTest.java
@@ -1,0 +1,269 @@
+/*
+ * Sonar Delphi Plugin
+ * Copyright (C) 2026 Integrated Application Development
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02
+ */
+package au.com.integradev.delphi.symbol.resolve;
+
+import static au.com.integradev.delphi.utils.types.TypeMocker.struct;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.sonar.plugins.communitydelphi.api.type.StructKind.CLASS;
+import static org.sonar.plugins.communitydelphi.api.type.StructKind.INTERFACE;
+
+import au.com.integradev.delphi.type.factory.TypeFactoryImpl;
+import au.com.integradev.delphi.utils.types.TypeFactoryUtils;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.sonar.plugins.communitydelphi.api.symbol.scope.DelphiScope;
+import org.sonar.plugins.communitydelphi.api.type.IntrinsicType;
+import org.sonar.plugins.communitydelphi.api.type.Type;
+import org.sonar.plugins.communitydelphi.api.type.Type.StructType;
+
+class ArrayElementTypeResolverTest {
+  private static final TypeFactoryImpl FACTORY =
+      (TypeFactoryImpl) TypeFactoryUtils.defaultFactory();
+  private static final ArrayElementTypeResolver RESOLVER = new ArrayElementTypeResolver(FACTORY);
+
+  @ParameterizedTest
+  @CsvSource({
+    "BYTE, BYTE",
+    "SHORTINT, SHORTINT",
+    "SMALLINT, SMALLINT",
+    "WORD, WORD",
+    "UINT64, UINT64",
+    "ANSICHAR, ANSICHAR",
+    "WIDECHAR, WIDECHAR",
+    "VARIANT, VARIANT",
+  })
+  void testIdenticalElementsKeepTheirType(IntrinsicType element, IntrinsicType expected) {
+    assertThat(resolve(intrinsic(element), intrinsic(element))).isEqualTo(intrinsic(expected));
+  }
+
+  @ParameterizedTest
+  @CsvSource({
+    "BYTE, SHORTINT, INTEGER",
+    "SMALLINT, BYTE, INTEGER",
+    "WORD, SHORTINT, INTEGER",
+    "BYTE, INTEGER, INTEGER",
+    "CARDINAL, INTEGER, INT64",
+    "INTEGER, INT64, INT64",
+    "CARDINAL, INT64, INT64",
+    "CARDINAL, UINT64, UINT64",
+  })
+  void testMixedIntegerElementsPromoteToAtLeastInteger(
+      IntrinsicType then, IntrinsicType els, IntrinsicType expected) {
+    assertThat(resolve(intrinsic(then), intrinsic(els))).isEqualTo(intrinsic(expected));
+    assertThat(resolve(intrinsic(els), intrinsic(then))).isEqualTo(intrinsic(expected));
+  }
+
+  @Test
+  void testInt64AndUInt64ElementsResolveToUInt64() {
+    assertThat(resolve(intrinsic(IntrinsicType.INT64), intrinsic(IntrinsicType.UINT64)))
+        .isEqualTo(intrinsic(IntrinsicType.UINT64));
+    assertThat(resolve(intrinsic(IntrinsicType.UINT64), intrinsic(IntrinsicType.INT64)))
+        .isEqualTo(intrinsic(IntrinsicType.UINT64));
+  }
+
+  @ParameterizedTest
+  @CsvSource({"SINGLE", "DOUBLE", "EXTENDED", "CURRENCY", "COMP"})
+  void testRealElementsResolveToExtended(IntrinsicType real) {
+    assertThat(resolve(intrinsic(real))).isEqualTo(intrinsic(IntrinsicType.EXTENDED));
+    assertThat(resolve(intrinsic(real), intrinsic(real)))
+        .isEqualTo(intrinsic(IntrinsicType.EXTENDED));
+    assertThat(resolve(intrinsic(IntrinsicType.SINGLE), intrinsic(real)))
+        .isEqualTo(intrinsic(IntrinsicType.EXTENDED));
+  }
+
+  @Test
+  void testIntegerAndRealElementsResolveToUnknown() {
+    assertThat(resolve(intrinsic(IntrinsicType.INTEGER), intrinsic(IntrinsicType.DOUBLE)))
+        .matches(Type::isUnknown);
+    assertThat(resolve(intrinsic(IntrinsicType.SINGLE), intrinsic(IntrinsicType.INTEGER)))
+        .matches(Type::isUnknown);
+  }
+
+  @ParameterizedTest
+  @CsvSource({
+    "WIDECHAR, ANSICHAR, UNICODESTRING",
+    "WIDECHAR, UNICODESTRING, UNICODESTRING",
+    "UNICODESTRING, ANSISTRING, UNICODESTRING",
+    "ANSICHAR, UNICODESTRING, UNICODESTRING",
+  })
+  void testMixedTextualElementsResolveToUnicodeString(
+      IntrinsicType then, IntrinsicType els, IntrinsicType expected) {
+    assertThat(resolve(intrinsic(then), intrinsic(els))).isEqualTo(intrinsic(expected));
+    assertThat(resolve(intrinsic(els), intrinsic(then))).isEqualTo(intrinsic(expected));
+  }
+
+  @ParameterizedTest
+  @CsvSource({
+    "BOOLEAN, BYTEBOOL",
+    "BYTEBOOL, BOOLEAN",
+    "LONGBOOL, BOOLEAN",
+    "WORDBOOL, LONGBOOL",
+  })
+  void testMixedBooleanElementsResolveToBoolean(IntrinsicType then, IntrinsicType els) {
+    assertThat(resolve(intrinsic(then), intrinsic(els)))
+        .isEqualTo(intrinsic(IntrinsicType.BOOLEAN));
+  }
+
+  @Test
+  void testEnumAndItsSubrangeElementsResolveToTheEnum() {
+    Type enumeration = FACTORY.enumeration("TEnum", DelphiScope.unknownScope());
+    Type subrange = FACTORY.subrange("eOne..eTwo", enumeration);
+
+    assertThat(resolve(enumeration, subrange)).isEqualTo(enumeration);
+    assertThat(resolve(subrange, enumeration)).isEqualTo(enumeration);
+  }
+
+  @Test
+  void testDistinctEnumElementsResolveToUnknown() {
+    Type enumA = FACTORY.enumeration("TEnumA", DelphiScope.unknownScope());
+    Type enumB = FACTORY.enumeration("TEnumB", DelphiScope.unknownScope());
+
+    assertThat(resolve(enumA, enumB)).matches(Type::isUnknown);
+    assertThat(resolve(enumA, intrinsic(IntrinsicType.BYTE))).matches(Type::isUnknown);
+  }
+
+  @Test
+  void testClassElementsResolveToTheAssignableClassOrTheRoot() {
+    StructType object = struct("TObject", CLASS);
+    StructType base = struct("TBase", CLASS, object);
+    StructType dog = struct("TDog", CLASS, base);
+    StructType cat = struct("TCat", CLASS, base);
+
+    assertThat(resolve(dog, base)).isEqualTo(base);
+    assertThat(resolve(base, dog)).isEqualTo(base);
+    assertThat(resolve(dog, cat)).isEqualTo(object);
+    assertThat(resolve(cat, dog)).isEqualTo(object);
+  }
+
+  @Test
+  void testClassElementOrderDecidesTheResult() {
+    StructType object = struct("TObject", CLASS);
+    StructType base = struct("TBase", CLASS, object);
+    StructType dog = struct("TDog", CLASS, base);
+    StructType cat = struct("TCat", CLASS, base);
+
+    assertThat(RESOLVER.elementType(List.of(dog, base, cat))).isEqualTo(base);
+    assertThat(RESOLVER.elementType(List.of(dog, cat, base))).isEqualTo(object);
+  }
+
+  @Test
+  void testInterfaceElementsResolveToTheAssignableInterfaceOrTheRoot() {
+    StructType iinterface = struct("IInterface", INTERFACE);
+    StructType foo = struct("IFoo", INTERFACE, iinterface);
+    StructType bar = struct("IBar", INTERFACE, foo);
+    StructType baz = struct("IBaz", INTERFACE, foo);
+
+    assertThat(resolve(bar, foo)).isEqualTo(foo);
+    assertThat(resolve(bar, baz)).isEqualTo(iinterface);
+  }
+
+  @Test
+  void testClassAndInterfaceElementsResolveToUnknown() {
+    StructType object = struct("TObject", CLASS);
+    StructType clazz = struct("TFoo", CLASS, object);
+    StructType intf = struct("IFoo", INTERFACE, struct("IInterface", INTERFACE));
+
+    assertThat(resolve(clazz, intf)).matches(Type::isUnknown);
+    assertThat(resolve(intf, clazz)).matches(Type::isUnknown);
+  }
+
+  @Test
+  void testClassReferenceElementsResolveToTheAncestorReference() {
+    StructType object = struct("TObject", CLASS);
+    StructType base = struct("TBase", CLASS, object);
+    StructType dog = struct("TDog", CLASS, base);
+    Type baseReference = FACTORY.classOf("TBaseClass", base);
+    Type dogReference = FACTORY.classOf("TDogClass", dog);
+
+    assertThat(resolve(baseReference, dogReference)).isEqualTo(baseReference);
+    assertThat(resolve(dogReference, baseReference)).isEqualTo(baseReference);
+  }
+
+  @Test
+  void testUnrelatedClassReferenceElementsResolveToUnknown() {
+    Type left = FACTORY.classOf("TFooClass", struct("TFoo", CLASS));
+    Type right = FACTORY.classOf("TBarClass", struct("TBar", CLASS));
+
+    assertThat(resolve(left, right)).matches(Type::isUnknown);
+  }
+
+  @Test
+  void testPointerElementsResolveToPointer() {
+    Type pInteger = FACTORY.pointerTo("PInteger", intrinsic(IntrinsicType.INTEGER));
+    Type pByte = FACTORY.pointerTo("PByte", intrinsic(IntrinsicType.BYTE));
+    StructType clazz = struct("TFoo", CLASS, struct("TObject", CLASS));
+
+    assertThat(resolve(pInteger, pByte)).isEqualTo(intrinsic(IntrinsicType.POINTER));
+    assertThat(resolve(pInteger, FACTORY.nilPointer())).isEqualTo(intrinsic(IntrinsicType.POINTER));
+    assertThat(resolve(FACTORY.nilPointer())).isEqualTo(intrinsic(IntrinsicType.POINTER));
+    assertThat(resolve(clazz, FACTORY.nilPointer())).matches(Type::isUnknown);
+  }
+
+  @Test
+  void testVariantAndOtherElementsResolveToUnknown() {
+    assertThat(resolve(intrinsic(IntrinsicType.VARIANT), intrinsic(IntrinsicType.INTEGER)))
+        .matches(Type::isUnknown);
+    assertThat(resolve(intrinsic(IntrinsicType.VARIANT), intrinsic(IntrinsicType.UNICODESTRING)))
+        .matches(Type::isUnknown);
+  }
+
+  @Test
+  void testCrossFamilyElementsResolveToUnknown() {
+    assertThat(resolve(intrinsic(IntrinsicType.UNICODESTRING), intrinsic(IntrinsicType.INTEGER)))
+        .matches(Type::isUnknown);
+    assertThat(resolve(intrinsic(IntrinsicType.BOOLEAN), intrinsic(IntrinsicType.INTEGER)))
+        .matches(Type::isUnknown);
+    assertThat(
+            resolve(
+                FACTORY.pointerTo("PInteger", intrinsic(IntrinsicType.INTEGER)),
+                intrinsic(IntrinsicType.INTEGER)))
+        .matches(Type::isUnknown);
+    assertThat(
+            resolve(
+                FACTORY.classOf("TFooClass", struct("TFoo", CLASS)),
+                intrinsic(IntrinsicType.INTEGER)))
+        .matches(Type::isUnknown);
+  }
+
+  @Test
+  void testNoElementsResolveToUnknown() {
+    assertThat(RESOLVER.elementType(List.of())).matches(Type::isUnknown);
+  }
+
+  @Test
+  void testFailedUnificationIsAbsorbing() {
+    assertThat(
+            RESOLVER.elementType(
+                List.of(
+                    intrinsic(IntrinsicType.INTEGER),
+                    intrinsic(IntrinsicType.DOUBLE),
+                    intrinsic(IntrinsicType.INTEGER))))
+        .matches(Type::isUnknown);
+  }
+
+  private static Type resolve(Type... elements) {
+    return RESOLVER.elementType(List.of(elements));
+  }
+
+  private static Type intrinsic(IntrinsicType type) {
+    return FACTORY.getIntrinsic(type);
+  }
+}

--- a/delphi-frontend/src/test/java/au/com/integradev/delphi/symbol/resolve/CommonTypeResolverTest.java
+++ b/delphi-frontend/src/test/java/au/com/integradev/delphi/symbol/resolve/CommonTypeResolverTest.java
@@ -1,0 +1,1184 @@
+/*
+ * Sonar Delphi Plugin
+ * Copyright (C) 2026 Integrated Application Development
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02
+ */
+package au.com.integradev.delphi.symbol.resolve;
+
+import static au.com.integradev.delphi.utils.types.TypeMocker.struct;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.sonar.plugins.communitydelphi.api.type.StructKind.CLASS;
+import static org.sonar.plugins.communitydelphi.api.type.StructKind.INTERFACE;
+import static org.sonar.plugins.communitydelphi.api.type.TypeFactory.unknownType;
+
+import au.com.integradev.delphi.DelphiProperties;
+import au.com.integradev.delphi.compiler.Toolchain;
+import au.com.integradev.delphi.type.factory.ArrayOption;
+import au.com.integradev.delphi.type.factory.TypeFactoryImpl;
+import au.com.integradev.delphi.utils.types.TypeFactoryUtils;
+import au.com.integradev.delphi.utils.types.TypeMocker;
+import java.math.BigInteger;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.sonar.plugins.communitydelphi.api.symbol.scope.DelphiScope;
+import org.sonar.plugins.communitydelphi.api.type.IntrinsicType;
+import org.sonar.plugins.communitydelphi.api.type.StructKind;
+import org.sonar.plugins.communitydelphi.api.type.Type;
+import org.sonar.plugins.communitydelphi.api.type.Type.ClassReferenceType;
+import org.sonar.plugins.communitydelphi.api.type.Type.CollectionType;
+import org.sonar.plugins.communitydelphi.api.type.Type.IntegerType;
+import org.sonar.plugins.communitydelphi.api.type.Type.ProceduralType.ProceduralKind;
+import org.sonar.plugins.communitydelphi.api.type.Type.StructType;
+import org.sonar.plugins.communitydelphi.api.type.TypeFactory;
+
+class CommonTypeResolverTest {
+  private static final TypeFactoryImpl FACTORY =
+      (TypeFactoryImpl) TypeFactoryUtils.defaultFactory();
+  private static final CommonTypeResolver RESOLVER = new CommonTypeResolver(FACTORY);
+
+  private static final TypeFactoryImpl DCC64_FACTORY =
+      new TypeFactoryImpl(Toolchain.DCC64, DelphiProperties.COMPILER_VERSION_DEFAULT);
+  private static final CommonTypeResolver DCC64_RESOLVER = new CommonTypeResolver(DCC64_FACTORY);
+
+  @ParameterizedTest
+  @CsvSource({
+    "INTEGER, INTEGER, INTEGER",
+    "UNICODESTRING, UNICODESTRING, UNICODESTRING",
+    "ANSISTRING, ANSISTRING, ANSISTRING",
+    "WIDESTRING, WIDESTRING, WIDESTRING",
+    "BOOLEAN, BOOLEAN, BOOLEAN",
+    "SINGLE, SINGLE, SINGLE",
+    "DOUBLE, DOUBLE, DOUBLE",
+    "SHORTSTRING, SHORTSTRING, SHORTSTRING",
+    "ANSICHAR, ANSICHAR, ANSICHAR",
+    "WIDECHAR, WIDECHAR, WIDECHAR",
+    "OLEVARIANT, OLEVARIANT, OLEVARIANT",
+  })
+  void testIdenticalBranchTypesResolveToThatType(
+      IntrinsicType then, IntrinsicType els, IntrinsicType expected) {
+    assertResolvesBothWays(then, els, expected);
+  }
+
+  /** Char is a weak alias of WideChar. */
+  @Test
+  void testWeakAliasBranchesResolveToTheAliasedType() {
+    assertThat(resolve(intrinsic(IntrinsicType.CHAR), intrinsic(IntrinsicType.WIDECHAR)))
+        .matches(type -> type.is(IntrinsicType.WIDECHAR));
+    assertThat(resolve(intrinsic(IntrinsicType.WIDECHAR), intrinsic(IntrinsicType.CHAR)))
+        .matches(type -> type.is(IntrinsicType.WIDECHAR));
+  }
+
+  /**
+   * Unlike arithmetic, which widens every operand to at least {@code Integer}, an {@code if}
+   * expression resolves to the narrowest integer type holding both branches.
+   */
+  @ParameterizedTest
+  @CsvSource({
+    "SHORTINT, BYTE, SMALLINT",
+    "BYTE, WORD, WORD",
+    "BYTE, SMALLINT, SMALLINT",
+    "SHORTINT, SMALLINT, SMALLINT",
+    "SHORTINT, WORD, INTEGER",
+    "SMALLINT, WORD, INTEGER",
+    "BYTE, INTEGER, INTEGER",
+    "SHORTINT, INTEGER, INTEGER",
+    "BYTE, CARDINAL, CARDINAL",
+    "WORD, CARDINAL, CARDINAL",
+    "INTEGER, CARDINAL, INT64",
+    "SHORTINT, CARDINAL, INT64",
+    "INTEGER, INT64, INT64",
+    "CARDINAL, INT64, INT64",
+    "INTEGER, UINT64, UINT64",
+    "INT64, UINT64, UINT64",
+    "NATIVEINT, BYTE, INTEGER",
+    "NATIVEINT, INT64, INT64",
+  })
+  void testIntegerBranchesResolveToTheNarrowestIntegerHoldingBoth(
+      IntrinsicType then, IntrinsicType els, IntrinsicType expected) {
+    assertResolvesBothWays(then, els, expected);
+  }
+
+  /**
+   * Where a signed and an unsigned type of the same size both hold the combined range, the compiler
+   * uses an anonymous unsigned subrange, whatever the range actually is.
+   */
+  @ParameterizedTest
+  @CsvSource({
+    "0, 1000, 0, 500, 0, 32767",
+    "0, 32767, 0, 255, 0, 32767",
+    "0, 100000, 0, 99, 0, 2147483647",
+    "0, 2147483647, 0, 99, 0, 2147483647",
+  })
+  void testIntegerBranchesHeldByBothSignedAndUnsignedResolveToAnAnonymousSubrange(
+      int thenMin, int thenMax, int elseMin, int elseMax, int expectedMin, int expectedMax) {
+    Type result = resolve(subrange(thenMin, thenMax), subrange(elseMin, elseMax));
+
+    assertThat(result.isSubrange()).isTrue();
+    assertThat(((IntegerType) result).min()).isEqualTo(BigInteger.valueOf(expectedMin));
+    assertThat(((IntegerType) result).max()).isEqualTo(BigInteger.valueOf(expectedMax));
+  }
+
+  /** There is no anonymous subrange for one and eight byte results, so the signed type wins. */
+  @Test
+  void testIntegerBranchesWithNoAnonymousSubrangeResolveToTheSignedType() {
+    assertThat(resolve(subrange(0, 100), subrange(0, 50)))
+        .isEqualTo(intrinsic(IntrinsicType.SHORTINT));
+    assertThat(resolve(subrange(0, Long.MAX_VALUE), subrange(0, 99)))
+        .isEqualTo(intrinsic(IntrinsicType.INT64));
+  }
+
+  /** On DCC32, Extended is 10 bytes and can hold Comp and Currency without losing precision. */
+  @ParameterizedTest
+  @CsvSource({
+    "SINGLE, DOUBLE, EXTENDED",
+    "DOUBLE, EXTENDED, EXTENDED",
+    "SINGLE, EXTENDED, EXTENDED",
+    "INTEGER, SINGLE, EXTENDED",
+    "INTEGER, DOUBLE, EXTENDED",
+    "INTEGER, EXTENDED, EXTENDED",
+    "INT64, EXTENDED, EXTENDED",
+    "CURRENCY, EXTENDED, EXTENDED",
+    "CURRENCY, SINGLE, EXTENDED",
+    "COMP, SINGLE, EXTENDED",
+    "COMP, DOUBLE, EXTENDED",
+    "INTEGER, COMP, EXTENDED",
+    "INT64, COMP, EXTENDED",
+    "BYTE, COMP, EXTENDED",
+    "INTEGER, CURRENCY, EXTENDED",
+    "INT64, CURRENCY, EXTENDED",
+    "COMP, CURRENCY, EXTENDED",
+    "REAL48, DOUBLE, EXTENDED",
+    "INTEGER, REAL48, EXTENDED",
+  })
+  void testRealBranchesWidenToExtended(
+      IntrinsicType then, IntrinsicType els, IntrinsicType expected) {
+    assertResolvesBothWays(then, els, expected);
+  }
+
+  /** On DCC64, Extended is 8 bytes. This causes Comp and Currency to be preferred for some */
+  @ParameterizedTest
+  @CsvSource({
+    "INTEGER, COMP, COMP",
+    "INT64, COMP, COMP",
+    "BYTE, COMP, COMP",
+    "INTEGER, CURRENCY, CURRENCY",
+    "INT64, CURRENCY, CURRENCY",
+  })
+  void testFixedPointBranchesAbsorbIntegerBranchesWhereExtendedCannotHoldThem(
+      IntrinsicType then, IntrinsicType els, IntrinsicType expected) {
+    assertResolvesBothWays(DCC64_RESOLVER, DCC64_FACTORY, then, els, expected);
+  }
+
+  @ParameterizedTest
+  @CsvSource({
+    "SINGLE, DOUBLE",
+    "DOUBLE, CURRENCY",
+    "SINGLE, CURRENCY",
+    "EXTENDED, CURRENCY",
+    "DOUBLE, COMP",
+    "SINGLE, COMP",
+    "EXTENDED, COMP",
+  })
+  void testFloatingPointBranchesWidenToExtendedEvenWhereExtendedCannotHoldFixedPointTypes(
+      IntrinsicType then, IntrinsicType els) {
+    assertResolvesBothWays(DCC64_RESOLVER, DCC64_FACTORY, then, els, IntrinsicType.EXTENDED);
+  }
+
+  @Test
+  void testCurrencyBeatsCompWhereExtendedCannotHoldThem() {
+    assertResolvesBothWays(
+        DCC64_RESOLVER,
+        DCC64_FACTORY,
+        IntrinsicType.COMP,
+        IntrinsicType.CURRENCY,
+        IntrinsicType.CURRENCY);
+  }
+
+  @ParameterizedTest
+  @CsvSource({
+    "CHAR, UNICODESTRING, UNICODESTRING",
+    "ANSICHAR, ANSISTRING, ANSISTRING",
+    "ANSICHAR, WIDESTRING, WIDESTRING",
+    "ANSICHAR, WIDECHAR, UNICODESTRING",
+    "ANSICHAR, UNICODESTRING, UNICODESTRING",
+    "ANSICHAR, SHORTSTRING, SHORTSTRING",
+    "WIDECHAR, ANSISTRING, UNICODESTRING",
+    "WIDECHAR, WIDESTRING, WIDESTRING",
+    "ANSISTRING, UNICODESTRING, UNICODESTRING",
+    "ANSISTRING, WIDESTRING, WIDESTRING",
+    "WIDESTRING, UNICODESTRING, UNICODESTRING",
+    "SHORTSTRING, UNICODESTRING, UNICODESTRING",
+  })
+  void testTextualBranchesWidenToACommonTextualType(
+      IntrinsicType then, IntrinsicType els, IntrinsicType expected) {
+    assertResolvesBothWays(then, els, expected);
+  }
+
+  /**
+   * Where neither branch type is wider than the other, the compiler keeps the type of the {@code
+   * then} branch rather than picking a common type.
+   */
+  @ParameterizedTest
+  @CsvSource({
+    "BOOLEAN, BYTEBOOL",
+    "BOOLEAN, WORDBOOL",
+    "BOOLEAN, LONGBOOL",
+    "BYTEBOOL, WORDBOOL",
+    "WORDBOOL, LONGBOOL",
+  })
+  void testMixedBooleanBranchesResolveToTheThenBranch(IntrinsicType then, IntrinsicType els) {
+    assertThat(resolve(intrinsic(then), intrinsic(els))).isEqualTo(intrinsic(then));
+    assertThat(resolve(intrinsic(els), intrinsic(then))).isEqualTo(intrinsic(els));
+  }
+
+  @Test
+  void testMixedAnsiStringBranchesResolveToTheThenBranch() {
+    Type ansiString = intrinsic(IntrinsicType.ANSISTRING);
+    Type utf8String = FACTORY.ansiString(65001);
+
+    assertThat(resolve(ansiString, utf8String)).isEqualTo(ansiString);
+    assertThat(resolve(utf8String, ansiString)).isEqualTo(utf8String);
+  }
+
+  @Test
+  void testAnsiCharBranchIsAbsorbedByAnAnsiStringOfAnyCodePage() {
+    Type ansiChar = intrinsic(IntrinsicType.ANSICHAR);
+    Type utf8String = FACTORY.ansiString(65001);
+
+    assertThat(resolve(ansiChar, utf8String)).isEqualTo(utf8String);
+    assertThat(resolve(utf8String, ansiChar)).isEqualTo(utf8String);
+  }
+
+  @Test
+  void testMixedVariantBranchesResolveToVariant() {
+    assertResolvesBothWays(IntrinsicType.VARIANT, IntrinsicType.OLEVARIANT, IntrinsicType.VARIANT);
+  }
+
+  @ParameterizedTest
+  @CsvSource({
+    "INTEGER, UNICODESTRING",
+    "INTEGER, BOOLEAN",
+    "UNICODESTRING, BOOLEAN",
+    "DOUBLE, UNICODESTRING",
+    "INTEGER, VARIANT",
+    "UNICODESTRING, VARIANT",
+    "BOOLEAN, VARIANT",
+    "DOUBLE, VARIANT",
+    "ANSICHAR, VARIANT",
+    "INTEGER, ANSICHAR",
+    "BOOLEAN, ANSICHAR",
+    "SHORTSTRING, ANSISTRING",
+    "SHORTSTRING, WIDESTRING",
+    "SHORTSTRING, WIDECHAR",
+  })
+  void testUnrelatedBranchesResolveToUnknown(IntrinsicType then, IntrinsicType els) {
+    assertThat(resolve(intrinsic(then), intrinsic(els))).matches(Type::isUnknown);
+    assertThat(resolve(intrinsic(els), intrinsic(then))).matches(Type::isUnknown);
+  }
+
+  @Test
+  void testIntrinsicAndStructuralBranchesResolveToUnknown() {
+    assertThat(resolve(intrinsic(IntrinsicType.INTEGER), intrinsic(IntrinsicType.POINTER)))
+        .matches(Type::isUnknown);
+    assertThat(resolve(intrinsic(IntrinsicType.POINTER), intrinsic(IntrinsicType.INTEGER)))
+        .matches(Type::isUnknown);
+  }
+
+  @Test
+  void testClassReferenceOrProceduralAgainstAnUnrelatedTypeResolvesToUnknown() {
+    Type reference = FACTORY.classOf("TFooClass", struct("TFoo", CLASS));
+    Type procedural = procedure(List.of(), TypeFactory.voidType());
+
+    assertThat(resolve(reference, intrinsic(IntrinsicType.INTEGER))).matches(Type::isUnknown);
+    assertThat(resolve(intrinsic(IntrinsicType.INTEGER), reference)).matches(Type::isUnknown);
+    assertThat(resolve(procedural, intrinsic(IntrinsicType.INTEGER))).matches(Type::isUnknown);
+    assertThat(resolve(intrinsic(IntrinsicType.INTEGER), procedural)).matches(Type::isUnknown);
+  }
+
+  @Test
+  void testUnknownBranchResolvesToUnknown() {
+    assertThat(resolve(unknownType(), intrinsic(IntrinsicType.INTEGER))).matches(Type::isUnknown);
+    assertThat(resolve(intrinsic(IntrinsicType.INTEGER), unknownType())).matches(Type::isUnknown);
+  }
+
+  @Test
+  void testDescendantAndAncestorResolveToTheAncestor() {
+    StructType object = struct("TObject", CLASS);
+    StructType ancestor = struct("TAncestor", CLASS, object);
+    StructType descendant = struct("TDescendant", CLASS, ancestor);
+
+    assertThat(resolve(descendant, ancestor)).isEqualTo(ancestor);
+    assertThat(resolve(ancestor, descendant)).isEqualTo(ancestor);
+  }
+
+  @Test
+  void testClassesWithNoCommonAncestorResolveToUnknown() {
+    assertThat(resolve(struct("TFoo", CLASS), struct("TBar", CLASS))).matches(Type::isUnknown);
+  }
+
+  @Test
+  void testSiblingsResolveToTheirCommonAncestor() {
+    StructType object = struct("TObject", CLASS);
+    StructType ancestor = struct("TAncestor", CLASS, object);
+    StructType left = struct("TLeft", CLASS, ancestor);
+    StructType right = struct("TRight", CLASS, ancestor);
+
+    assertThat(resolve(left, right)).isEqualTo(ancestor);
+    assertThat(resolve(right, left)).isEqualTo(ancestor);
+  }
+
+  @Test
+  void testDistantSiblingsResolveToTheirNearestCommonAncestor() {
+    StructType object = struct("TObject", CLASS);
+    StructType ancestor = struct("TAncestor", CLASS, object);
+    StructType middle = struct("TMiddle", CLASS, ancestor);
+    StructType left = struct("TLeft", CLASS, middle);
+    StructType right = struct("TRight", CLASS, ancestor);
+
+    assertThat(resolve(left, right)).isEqualTo(ancestor);
+    assertThat(resolve(right, left)).isEqualTo(ancestor);
+    assertThat(resolve(left, middle)).isEqualTo(middle);
+    assertThat(resolve(middle, left)).isEqualTo(middle);
+  }
+
+  @Test
+  void testInterfacesResolveToTheirCommonAncestor() {
+    StructType iinterface = struct("IInterface", INTERFACE);
+    StructType ancestor = struct("IAncestor", INTERFACE, iinterface);
+    StructType left = struct("ILeft", INTERFACE, ancestor);
+    StructType right = struct("IRight", INTERFACE, ancestor);
+
+    assertThat(resolve(left, right)).isEqualTo(ancestor);
+    assertThat(resolve(right, left)).isEqualTo(ancestor);
+  }
+
+  @Test
+  void testNilBranchResolvesToTheOtherReferenceType() {
+    StructType object = struct("TObject", CLASS);
+    StructType foo = struct("TFoo", CLASS, object);
+    StructType intf = struct("IFoo", INTERFACE, struct("IInterface", INTERFACE));
+    Type classReference = FACTORY.classOf("TFooClass", foo);
+    Type procedural = procedure(List.of(), TypeFactory.voidType());
+    Type dynamicArray =
+        FACTORY.array(null, intrinsic(IntrinsicType.INTEGER), Set.of(ArrayOption.DYNAMIC));
+
+    assertThat(resolve(foo, nilPointer())).isEqualTo(foo);
+    assertThat(resolve(nilPointer(), foo)).isEqualTo(foo);
+    assertThat(resolve(intf, nilPointer())).isEqualTo(intf);
+    assertThat(resolve(nilPointer(), intf)).isEqualTo(intf);
+    assertThat(resolve(classReference, nilPointer())).isEqualTo(classReference);
+    assertThat(resolve(nilPointer(), classReference)).isEqualTo(classReference);
+    assertThat(resolve(procedural, nilPointer())).isEqualTo(procedural);
+    assertThat(resolve(nilPointer(), procedural)).isEqualTo(procedural);
+    assertThat(resolve(dynamicArray, nilPointer())).isEqualTo(dynamicArray);
+    assertThat(resolve(nilPointer(), dynamicArray)).isEqualTo(dynamicArray);
+  }
+
+  @Test
+  void testDistinctObjectBranchesResolveToUnknown() {
+    StructType ancestor = struct("TObjAncestor", StructKind.OBJECT);
+    StructType left = struct("TObjLeft", StructKind.OBJECT, ancestor);
+    StructType right = struct("TObjRight", StructKind.OBJECT, ancestor);
+    assertThat(resolve(left, right)).matches(Type::isUnknown);
+  }
+
+  @Test
+  void testDistinctRecordBranchesResolveToUnknown() {
+    StructType left = struct("TRecLeft", StructKind.RECORD);
+    StructType right = struct("TRecRight", StructKind.RECORD);
+    assertThat(resolve(left, right)).matches(Type::isUnknown);
+  }
+
+  @Test
+  void testArrayBranchesResolveOnlyAsTheSameType() {
+    Type element = intrinsic(IntrinsicType.INTEGER);
+    Type fixedArray = FACTORY.array("TArrA", element, Set.of(ArrayOption.FIXED));
+
+    assertThat(resolve(fixedArray, fixedArray)).isEqualTo(fixedArray);
+    assertThat(resolve(fixedArray, FACTORY.array("TArrB", element, Set.of(ArrayOption.FIXED))))
+        .matches(Type::isUnknown);
+    assertThat(
+            resolve(
+                FACTORY.array("TDynA", element, Set.of(ArrayOption.DYNAMIC)),
+                FACTORY.array("TDynB", element, Set.of(ArrayOption.DYNAMIC))))
+        .matches(Type::isUnknown);
+  }
+
+  @Test
+  void testDistinctEnumBranchesResolveToUnknown() {
+    Type enumA = FACTORY.enumeration("TEnumA", DelphiScope.unknownScope());
+    Type enumB = FACTORY.enumeration("TEnumB", DelphiScope.unknownScope());
+
+    assertThat(resolve(enumA, enumB)).matches(Type::isUnknown);
+    assertThat(resolve(enumB, enumA)).matches(Type::isUnknown);
+  }
+
+  @Test
+  void testSetWithContainingElementRangeWins() {
+    Type small = FACTORY.set(subrange(0, 7));
+    Type wide = FACTORY.set(subrange(0, 100));
+    Type byteSet = FACTORY.set(intrinsic(IntrinsicType.BYTE));
+
+    assertThat(resolve(small, wide)).isSameAs(wide);
+    assertThat(resolve(wide, small)).isSameAs(wide);
+    assertThat(resolve(small, byteSet)).isSameAs(byteSet);
+    assertThat(resolve(byteSet, small)).isSameAs(byteSet);
+  }
+
+  @Test
+  void testCharSubrangeSetsResolveToTheFirstOperand() {
+    Type lower = FACTORY.set(FACTORY.subrange("'a'..'z'", intrinsic(IntrinsicType.ANSICHAR)));
+    Type digits = FACTORY.set(FACTORY.subrange("'0'..'9'", intrinsic(IntrinsicType.ANSICHAR)));
+
+    assertThat(resolve(lower, digits)).isSameAs(lower);
+    assertThat(resolve(digits, lower)).isSameAs(digits);
+  }
+
+  @Test
+  void testArrayConstructorTakesTheOtherSetOperandsType() {
+    Type enumeration = FACTORY.enumeration("TEnum", DelphiScope.unknownScope());
+    Type set = FACTORY.set(enumeration);
+    Type constructor = FACTORY.arrayConstructor(List.of(enumeration));
+    Type empty = FACTORY.arrayConstructor(List.of());
+
+    assertThat(resolve(set, constructor)).isEqualTo(set);
+    assertThat(resolve(constructor, set)).isEqualTo(set);
+    assertThat(resolve(set, empty)).isEqualTo(set);
+    assertThat(resolve(empty, set)).isEqualTo(set);
+  }
+
+  @Test
+  void testDynamicArrayAndSetConstructorResolveToUnknown() {
+    Type dynamicArray =
+        FACTORY.array(null, intrinsic(IntrinsicType.INTEGER), Set.of(ArrayOption.DYNAMIC));
+    Type constructor = FACTORY.arrayConstructor(List.of(intrinsic(IntrinsicType.INTEGER)));
+    Type empty = FACTORY.arrayConstructor(List.of());
+
+    assertThat(resolve(dynamicArray, constructor)).matches(Type::isUnknown);
+    assertThat(resolve(constructor, dynamicArray)).matches(Type::isUnknown);
+    assertThat(resolve(dynamicArray, empty)).matches(Type::isUnknown);
+    assertThat(resolve(empty, dynamicArray)).matches(Type::isUnknown);
+  }
+
+  @Test
+  void testDynamicArrayAndSetResolveToUnknown() {
+    Type dynamicArray =
+        FACTORY.array(null, intrinsic(IntrinsicType.BYTE), Set.of(ArrayOption.DYNAMIC));
+    Type set = FACTORY.set(intrinsic(IntrinsicType.BYTE));
+
+    assertThat(resolve(dynamicArray, set)).matches(Type::isUnknown);
+    assertThat(resolve(set, dynamicArray)).matches(Type::isUnknown);
+  }
+
+  private static Stream<Arguments> ordinalConstructorElements() {
+    Type enumeration = FACTORY.enumeration("TEnum", DelphiScope.unknownScope());
+    return Stream.of(
+        Arguments.of(intrinsic(IntrinsicType.SHORTINT), intrinsic(IntrinsicType.BYTE)),
+        Arguments.of(enumeration, FACTORY.subrange("eOne..eTwo", enumeration)),
+        Arguments.of(intrinsic(IntrinsicType.ANSICHAR), intrinsic(IntrinsicType.WIDECHAR)),
+        Arguments.of(intrinsic(IntrinsicType.BOOLEAN), intrinsic(IntrinsicType.BYTEBOOL)),
+        Arguments.of(subrange(0, 9), subrange(0, 5)));
+  }
+
+  @ParameterizedTest
+  @MethodSource("ordinalConstructorElements")
+  void testOrdinalSetConstructorsResolveToTheFirstConstructor(Type thenElement, Type elseElement) {
+    Type left = FACTORY.arrayConstructor(List.of(thenElement));
+    Type right = FACTORY.arrayConstructor(List.of(elseElement));
+
+    assertThat(resolve(left, right)).isSameAs(left);
+    assertThat(resolve(right, left)).isSameAs(right);
+  }
+
+  @Test
+  void testSetConstructorsOfNonOrdinalElementsResolveToUnknown() {
+    Type strings = FACTORY.arrayConstructor(List.of(intrinsic(IntrinsicType.UNICODESTRING)));
+    Type integers = FACTORY.arrayConstructor(List.of(intrinsic(IntrinsicType.INTEGER)));
+
+    assertThat(resolve(strings, integers)).matches(Type::isUnknown);
+    assertThat(resolve(integers, strings)).matches(Type::isUnknown);
+  }
+
+  /** `nil` combined with any array constructor yields an anonymous dynamic array. */
+  @Test
+  void testNilBranchGivesAConstructorItsDynamicArrayReading() {
+    Type ordinal = FACTORY.arrayConstructor(List.of(intrinsic(IntrinsicType.INTEGER)));
+    Type strings = FACTORY.arrayConstructor(List.of(intrinsic(IntrinsicType.UNICODESTRING)));
+
+    Type result = resolve(nilPointer(), ordinal);
+    assertThat(result.isDynamicArray()).isTrue();
+    assertThat(((CollectionType) result).elementType()).isEqualTo(intrinsic(IntrinsicType.INTEGER));
+
+    result = resolve(strings, nilPointer());
+    assertThat(result.isDynamicArray()).isTrue();
+    assertThat(((CollectionType) result).elementType())
+        .isEqualTo(intrinsic(IntrinsicType.UNICODESTRING));
+
+    Type integers =
+        FACTORY.arrayConstructor(
+            List.of(intrinsic(IntrinsicType.BYTE), intrinsic(IntrinsicType.INTEGER)));
+    result = resolve(nilPointer(), integers);
+    assertThat(result.isDynamicArray()).isTrue();
+    assertThat(((CollectionType) result).elementType()).isEqualTo(intrinsic(IntrinsicType.INTEGER));
+
+    Type single = FACTORY.arrayConstructor(List.of(intrinsic(IntrinsicType.SINGLE)));
+    result = resolve(nilPointer(), single);
+    assertThat(result.isDynamicArray()).isTrue();
+    assertThat(((CollectionType) result).elementType())
+        .isEqualTo(intrinsic(IntrinsicType.EXTENDED));
+  }
+
+  @Test
+  void testNilBranchWithConstructorOfMixedElementFamiliesResolvesToUnknown() {
+    Type integerAndString =
+        FACTORY.arrayConstructor(
+            List.of(intrinsic(IntrinsicType.INTEGER), intrinsic(IntrinsicType.UNICODESTRING)));
+    Type integerAndReal =
+        FACTORY.arrayConstructor(
+            List.of(intrinsic(IntrinsicType.INTEGER), intrinsic(IntrinsicType.DOUBLE)));
+    Type realAndInteger =
+        FACTORY.arrayConstructor(
+            List.of(intrinsic(IntrinsicType.DOUBLE), intrinsic(IntrinsicType.INTEGER)));
+    Type realAndString =
+        FACTORY.arrayConstructor(
+            List.of(intrinsic(IntrinsicType.DOUBLE), intrinsic(IntrinsicType.UNICODESTRING)));
+
+    assertThat(resolve(nilPointer(), integerAndString)).matches(Type::isUnknown);
+    assertThat(resolve(integerAndString, nilPointer())).matches(Type::isUnknown);
+    assertThat(resolve(nilPointer(), integerAndReal)).matches(Type::isUnknown);
+    assertThat(resolve(integerAndReal, nilPointer())).matches(Type::isUnknown);
+    assertThat(resolve(nilPointer(), realAndInteger)).matches(Type::isUnknown);
+    assertThat(resolve(nilPointer(), realAndString)).matches(Type::isUnknown);
+  }
+
+  @Test
+  void testNilBranchWithEmptyConstructorResolvesToUnknown() {
+    Type empty = FACTORY.arrayConstructor(List.of());
+
+    assertThat(resolve(nilPointer(), empty)).matches(Type::isUnknown);
+    assertThat(resolve(empty, nilPointer())).matches(Type::isUnknown);
+  }
+
+  @Test
+  void testSetConstructorOfIncompatibleElementsResolvesToUnknown() {
+    Type set = FACTORY.set(FACTORY.enumeration("TEnumA", DelphiScope.unknownScope()));
+    Type constructor =
+        FACTORY.arrayConstructor(
+            List.of(FACTORY.enumeration("TEnumB", DelphiScope.unknownScope())));
+
+    assertThat(resolve(set, constructor)).matches(Type::isUnknown);
+    assertThat(resolve(constructor, set)).matches(Type::isUnknown);
+  }
+
+  @Test
+  void testSetBranchesResolveOnlyByMatchingElementType() {
+    Type enumA = FACTORY.enumeration("TEnumA", DelphiScope.unknownScope());
+    Type enumB = FACTORY.enumeration("TEnumB", DelphiScope.unknownScope());
+    Type setA = FACTORY.set(enumA);
+
+    assertThat(resolve(setA, FACTORY.set(enumA))).isEqualTo(setA);
+    assertThat(resolve(setA, FACTORY.set(enumB))).matches(Type::isUnknown);
+  }
+
+  @Test
+  void testOverlappingIntegerSetsResolveToTheLargeSetOfByte() {
+    Type left = FACTORY.set(subrange(0, 10));
+    Type right = FACTORY.set(subrange(5, 20));
+
+    Type result = resolve(left, right);
+    assertThat(result.isSet()).isTrue();
+    assertThat(((CollectionType) result).elementType()).isEqualTo(intrinsic(IntrinsicType.BYTE));
+
+    result = resolve(right, left);
+    assertThat(result.isSet()).isTrue();
+    assertThat(((CollectionType) result).elementType()).isEqualTo(intrinsic(IntrinsicType.BYTE));
+  }
+
+  @Test
+  void testDistinctCharSetsResolveToTheLargeSetOfAnsiChar() {
+    Type ansi = FACTORY.set(intrinsic(IntrinsicType.ANSICHAR));
+    Type wide = FACTORY.set(intrinsic(IntrinsicType.WIDECHAR));
+
+    Type result = resolve(ansi, wide);
+    assertThat(result.isSet()).isTrue();
+    assertThat(((CollectionType) result).elementType())
+        .isEqualTo(intrinsic(IntrinsicType.ANSICHAR));
+
+    result = resolve(wide, ansi);
+    assertThat(result.isSet()).isTrue();
+    assertThat(((CollectionType) result).elementType())
+        .isEqualTo(intrinsic(IntrinsicType.ANSICHAR));
+  }
+
+  @Test
+  void testIntegerAndCharSetsResolveToUnknown() {
+    Type integers = FACTORY.set(subrange(0, 10));
+    Type chars = FACTORY.set(intrinsic(IntrinsicType.ANSICHAR));
+
+    assertThat(resolve(integers, chars)).matches(Type::isUnknown);
+    assertThat(resolve(chars, integers)).matches(Type::isUnknown);
+  }
+
+  @Test
+  void testProceduralBranchesWithDifferentSignaturesResolveToUnknown() {
+    Type noArguments = procedure(List.of(), TypeFactory.voidType());
+    Type oneArgument = procedure(List.of(intrinsic(IntrinsicType.INTEGER)), TypeFactory.voidType());
+    Type stringArgument =
+        procedure(List.of(intrinsic(IntrinsicType.UNICODESTRING)), TypeFactory.voidType());
+    Type integerFunction = procedure(List.of(), intrinsic(IntrinsicType.INTEGER));
+    Type booleanFunction = procedure(List.of(), intrinsic(IntrinsicType.BOOLEAN));
+
+    assertThat(resolve(noArguments, oneArgument)).matches(Type::isUnknown);
+    assertThat(resolve(oneArgument, noArguments)).matches(Type::isUnknown);
+    assertThat(resolve(oneArgument, stringArgument)).matches(Type::isUnknown);
+    assertThat(resolve(stringArgument, oneArgument)).matches(Type::isUnknown);
+    assertThat(resolve(noArguments, integerFunction)).matches(Type::isUnknown);
+    assertThat(resolve(integerFunction, noArguments)).matches(Type::isUnknown);
+    assertThat(resolve(integerFunction, booleanFunction)).matches(Type::isUnknown);
+    assertThat(resolve(booleanFunction, integerFunction)).matches(Type::isUnknown);
+  }
+
+  @ParameterizedTest
+  @CsvSource({"PROCEDURE", "PROCEDURE_OF_OBJECT", "REFERENCE", "ANONYMOUS"})
+  void testSameSignatureProceduralBranchesResolveToTheFirstOperand(ProceduralKind kind) {
+    List<Type> parameters = List.of(intrinsic(IntrinsicType.INTEGER));
+    Type left = procedural(kind, parameters, TypeFactory.voidType());
+    Type right = procedural(kind, parameters, TypeFactory.voidType());
+
+    assertThat(resolve(left, right)).isSameAs(left);
+    assertThat(resolve(right, left)).isSameAs(right);
+  }
+
+  /** A named method reference absorbs an anonymous method with the same signature. */
+  @Test
+  void testMethodReferenceAbsorbsAnonymousMethodOfTheSameSignature() {
+    List<Type> parameters = List.of(intrinsic(IntrinsicType.INTEGER));
+    Type reference = procedural(ProceduralKind.REFERENCE, parameters, TypeFactory.voidType());
+    Type anonymous = procedural(ProceduralKind.ANONYMOUS, parameters, TypeFactory.voidType());
+
+    assertThat(resolve(reference, anonymous)).isSameAs(reference);
+    assertThat(resolve(anonymous, reference)).isSameAs(reference);
+  }
+
+  @Test
+  void testMethodReferenceAndAnonymousMethodOfDifferentSignaturesResolveToUnknown() {
+    Type reference =
+        procedural(
+            ProceduralKind.REFERENCE,
+            List.of(intrinsic(IntrinsicType.INTEGER)),
+            TypeFactory.voidType());
+    Type anonymous = procedural(ProceduralKind.ANONYMOUS, List.of(), TypeFactory.voidType());
+
+    assertThat(resolve(reference, anonymous)).matches(Type::isUnknown);
+    assertThat(resolve(anonymous, reference)).matches(Type::isUnknown);
+  }
+
+  /** Mixed procedural kinds are a compile error even with matching signatures. */
+  @Test
+  void testMixedProceduralKindBranchesResolveToUnknown() {
+    List<Type> parameters = List.of(intrinsic(IntrinsicType.INTEGER));
+    Type plain = procedural(ProceduralKind.PROCEDURE, parameters, TypeFactory.voidType());
+    Type method =
+        procedural(ProceduralKind.PROCEDURE_OF_OBJECT, parameters, TypeFactory.voidType());
+    Type reference = procedural(ProceduralKind.REFERENCE, parameters, TypeFactory.voidType());
+    Type anonymous = procedural(ProceduralKind.ANONYMOUS, parameters, TypeFactory.voidType());
+
+    assertThat(resolve(plain, method)).matches(Type::isUnknown);
+    assertThat(resolve(method, plain)).matches(Type::isUnknown);
+    assertThat(resolve(reference, plain)).matches(Type::isUnknown);
+    assertThat(resolve(plain, reference)).matches(Type::isUnknown);
+    assertThat(resolve(anonymous, plain)).matches(Type::isUnknown);
+    assertThat(resolve(plain, anonymous)).matches(Type::isUnknown);
+  }
+
+  @Test
+  void testNilBranchResolvesToTheOtherMethodReference() {
+    Type reference = procedural(ProceduralKind.REFERENCE, List.of(), TypeFactory.voidType());
+
+    assertThat(resolve(reference, nilPointer())).isEqualTo(reference);
+    assertThat(resolve(nilPointer(), reference)).isEqualTo(reference);
+  }
+
+  @Test
+  void testDistinctFileBranchesResolveToUnknown() {
+    assertThat(
+            resolve(
+                FACTORY.fileOf(intrinsic(IntrinsicType.INTEGER)),
+                FACTORY.fileOf(intrinsic(IntrinsicType.UNICODESTRING))))
+        .matches(Type::isUnknown);
+  }
+
+  /** `nil` is only assignable to reference types; a value type alongside it is a compile error. */
+  @ParameterizedTest
+  @CsvSource({
+    "INTEGER",
+    "ANSICHAR",
+    "WIDECHAR",
+    "UNICODESTRING",
+    "ANSISTRING",
+    "WIDESTRING",
+    "SHORTSTRING",
+    "BOOLEAN",
+    "DOUBLE",
+    "VARIANT"
+  })
+  void testNilAndValueTypeBranchesResolveToUnknown(IntrinsicType value) {
+    assertThat(resolve(nilPointer(), intrinsic(value))).matches(Type::isUnknown);
+    assertThat(resolve(intrinsic(value), nilPointer())).matches(Type::isUnknown);
+  }
+
+  @Test
+  void testNilAndNonReferenceStructuralBranchesResolveToUnknown() {
+    Type enumeration = FACTORY.enumeration("TEnum", DelphiScope.unknownScope());
+    Type set = FACTORY.set(enumeration);
+    Type fixedArray =
+        FACTORY.array(null, intrinsic(IntrinsicType.INTEGER), Set.of(ArrayOption.FIXED));
+
+    assertThat(resolve(nilPointer(), enumeration)).matches(Type::isUnknown);
+    assertThat(resolve(enumeration, nilPointer())).matches(Type::isUnknown);
+    assertThat(resolve(nilPointer(), set)).matches(Type::isUnknown);
+    assertThat(resolve(nilPointer(), fixedArray)).matches(Type::isUnknown);
+  }
+
+  /**
+   * The common ancestor of two classes is a class: an interface both happen to implement never
+   * wins, however near it is.
+   */
+  @Test
+  void testClassesSharingAnInterfaceResolveToTheirCommonClassAncestor() {
+    StructType object = struct("TObject", CLASS);
+    StructType iinterface = struct("IInterface", INTERFACE);
+    StructType shared = struct("IShared", INTERFACE, iinterface);
+    StructType base = struct("TBase", CLASS, object);
+    StructType foo = struct("TFoo", CLASS, shared, base);
+    StructType bar = struct("TBar", CLASS, shared, base);
+
+    assertThat(resolve(foo, bar)).isEqualTo(base);
+    assertThat(resolve(bar, foo)).isEqualTo(base);
+  }
+
+  @Test
+  void testClassAndInterfaceBranchesResolveToUnknown() {
+    StructType object = struct("TObject", CLASS);
+    StructType iinterface = struct("IInterface", INTERFACE);
+    StructType intf = struct("IFoo", INTERFACE, iinterface);
+    StructType clazz = struct("TFoo", CLASS, intf, object);
+
+    assertThat(resolve(clazz, intf)).matches(Type::isUnknown);
+    assertThat(resolve(intf, clazz)).matches(Type::isUnknown);
+  }
+
+  @Test
+  void testPointerBranchesCollapseToPointerUnlessTheSecondOperandIsUntypedOrNil() {
+    Type pointer = intrinsic(IntrinsicType.POINTER);
+    Type pAnsiChar = intrinsic(IntrinsicType.PANSICHAR);
+    Type pWideChar = intrinsic(IntrinsicType.PWIDECHAR);
+
+    assertThat(resolve(pAnsiChar, pWideChar)).isEqualTo(pointer);
+    assertThat(resolve(pWideChar, pAnsiChar)).isEqualTo(pointer);
+    assertThat(resolve(pAnsiChar, pointer)).isEqualTo(pAnsiChar);
+    assertThat(resolve(pointer, pAnsiChar)).isEqualTo(pointer);
+    assertThat(resolve(pAnsiChar, nilPointer())).isEqualTo(pAnsiChar);
+    assertThat(resolve(nilPointer(), pAnsiChar)).isEqualTo(pointer);
+  }
+
+  @ParameterizedTest
+  @CsvSource({"ANSICHAR", "WIDECHAR", "SHORTSTRING", "ANSISTRING", "WIDESTRING", "UNICODESTRING"})
+  void testPWideCharAndTextualBranchesResolveToUnicodeString(IntrinsicType textual) {
+    Type expected = intrinsic(IntrinsicType.UNICODESTRING);
+
+    assertThat(resolve(intrinsic(IntrinsicType.PWIDECHAR), intrinsic(textual))).isEqualTo(expected);
+    assertThat(resolve(intrinsic(textual), intrinsic(IntrinsicType.PWIDECHAR))).isEqualTo(expected);
+    assertThat(resolve(intrinsic(IntrinsicType.PANSICHAR), intrinsic(textual)))
+        .matches(Type::isUnknown);
+    assertThat(resolve(intrinsic(textual), intrinsic(IntrinsicType.PANSICHAR)))
+        .matches(Type::isUnknown);
+  }
+
+  @Test
+  void testClassReferenceBranchesResolveToAReferenceToTheCommonAncestor() {
+    StructType object = struct("TObject", CLASS);
+    StructType ancestor = struct("TAncestor", CLASS, object);
+    StructType middle = struct("TMiddle", CLASS, ancestor);
+
+    Type ancestorRef = FACTORY.classOf("TClassRef", ancestor);
+    Type middleRef = FACTORY.classOf("TClassRefMid", middle);
+
+    assertThat(resolve(middleRef, ancestorRef)).isEqualTo(ancestorRef);
+    assertThat(resolve(ancestorRef, middleRef)).isEqualTo(ancestorRef);
+  }
+
+  @Test
+  void testSiblingClassReferenceBranchesResolveToAReferenceToTheCommonAncestor() {
+    StructType object = struct("TObject", CLASS);
+    StructType ancestor = struct("TAncestor", CLASS, object);
+    StructType left = struct("TLeft", CLASS, ancestor);
+    StructType right = struct("TRight", CLASS, ancestor);
+
+    Type leftRef = FACTORY.classOf("TLeftClass", left);
+    Type rightRef = FACTORY.classOf("TRightClass", right);
+
+    Type result = resolve(leftRef, rightRef);
+    assertThat(result).isInstanceOf(ClassReferenceType.class);
+    assertThat(((ClassReferenceType) result).classType()).isEqualTo(ancestor);
+  }
+
+  @Test
+  void testClassReferencesWithNoCommonAncestorResolveToUnknown() {
+    Type left = FACTORY.classOf("TFooClass", struct("TFoo", CLASS));
+    Type right = FACTORY.classOf("TBarClass", struct("TBar", CLASS));
+
+    assertThat(resolve(left, right)).matches(Type::isUnknown);
+    assertThat(resolve(right, left)).matches(Type::isUnknown);
+  }
+
+  @Test
+  void testEnumAndSubrangeOfThatEnumResolveToTheEnum() {
+    Type enumeration = FACTORY.enumeration("TEnum", DelphiScope.unknownScope());
+    Type subrange = FACTORY.subrange("eOne..eTwo", enumeration);
+
+    assertThat(resolve(enumeration, subrange)).isEqualTo(enumeration);
+    assertThat(resolve(subrange, enumeration)).isEqualTo(enumeration);
+  }
+
+  @Test
+  void testStrongAliasOfStringKeepsItsDeclaredTypeOnTies() {
+    Type myString = strongAlias("MyString", intrinsic(IntrinsicType.UNICODESTRING));
+    Type myString2 = strongAlias("MyString2", intrinsic(IntrinsicType.UNICODESTRING));
+
+    assertThat(resolve(myString, intrinsic(IntrinsicType.UNICODESTRING))).isEqualTo(myString);
+    assertThat(resolve(intrinsic(IntrinsicType.UNICODESTRING), myString))
+        .isEqualTo(intrinsic(IntrinsicType.UNICODESTRING));
+    assertThat(resolve(myString, myString2)).isEqualTo(myString);
+    assertThat(resolve(myString2, myString)).isEqualTo(myString2);
+  }
+
+  @Test
+  void testWinningStringOperandKeepsItsStrongAliasType() {
+    Type myString = strongAlias("MyString", intrinsic(IntrinsicType.UNICODESTRING));
+
+    assertThat(resolve(myString, intrinsic(IntrinsicType.ANSISTRING))).isEqualTo(myString);
+    assertThat(resolve(intrinsic(IntrinsicType.ANSISTRING), myString)).isEqualTo(myString);
+    assertThat(resolve(myString, intrinsic(IntrinsicType.WIDESTRING))).isEqualTo(myString);
+  }
+
+  @Test
+  void testStrongAliasOfBooleanKeepsItsDeclaredTypeOnTies() {
+    Type myBool = strongAlias("MyBool", intrinsic(IntrinsicType.BOOLEAN));
+
+    assertThat(resolve(myBool, intrinsic(IntrinsicType.BOOLEAN))).isEqualTo(myBool);
+    assertThat(resolve(intrinsic(IntrinsicType.BOOLEAN), myBool))
+        .isEqualTo(intrinsic(IntrinsicType.BOOLEAN));
+    assertThat(resolve(myBool, intrinsic(IntrinsicType.BYTEBOOL))).isEqualTo(myBool);
+  }
+
+  @Test
+  void testStrongAliasOfIntegerCollapsesToTheCommonIntegerType() {
+    Type myInt = strongAlias("MyInt", intrinsic(IntrinsicType.INTEGER));
+    Type myInt2 = strongAlias("MyInt2", intrinsic(IntrinsicType.INTEGER));
+
+    assertThat(resolve(myInt, intrinsic(IntrinsicType.INTEGER)))
+        .isEqualTo(intrinsic(IntrinsicType.INTEGER));
+    assertThat(resolve(myInt, myInt2)).isEqualTo(intrinsic(IntrinsicType.INTEGER));
+    assertThat(resolve(myInt, intrinsic(IntrinsicType.BYTE)))
+        .isEqualTo(intrinsic(IntrinsicType.INTEGER));
+    assertThat(resolve(myInt, intrinsic(IntrinsicType.INT64)))
+        .isEqualTo(intrinsic(IntrinsicType.INT64));
+  }
+
+  @Test
+  void testStrongAliasOfPointerCollapsesToTheUntypedPointer() {
+    Type pInt = FACTORY.pointerTo("PInt", intrinsic(IntrinsicType.INTEGER));
+    Type myPInt = strongAlias("MyPInt", pInt);
+    Type myPInt2 = strongAlias("MyPInt2", pInt);
+
+    assertThat(resolve(myPInt, pInt)).isEqualTo(intrinsic(IntrinsicType.POINTER));
+    assertThat(resolve(pInt, myPInt)).isEqualTo(intrinsic(IntrinsicType.POINTER));
+    assertThat(resolve(myPInt, myPInt2)).isEqualTo(intrinsic(IntrinsicType.POINTER));
+  }
+
+  @Test
+  void testStrongAliasOfTheUntypedPointerKeepsItsDeclaredTypeAsFirstOperand() {
+    Type myPointer = strongAlias("MyPointer", intrinsic(IntrinsicType.POINTER));
+
+    assertThat(resolve(myPointer, intrinsic(IntrinsicType.POINTER))).isEqualTo(myPointer);
+    assertThat(resolve(intrinsic(IntrinsicType.POINTER), myPointer))
+        .isEqualTo(intrinsic(IntrinsicType.POINTER));
+  }
+
+  @Test
+  void testStrongAliasOfSetKeepsItsDeclaredTypeOnTies() {
+    Type enumeration = FACTORY.enumeration("TEnum", DelphiScope.unknownScope());
+    Type set = FACTORY.set(enumeration);
+    Type mySet = strongAlias("MySet", set);
+    Type mySet2 = strongAlias("MySet2", set);
+
+    assertThat(resolve(mySet, set)).isEqualTo(mySet);
+    assertThat(resolve(set, mySet)).isEqualTo(set);
+    assertThat(resolve(mySet, mySet2)).isEqualTo(mySet);
+  }
+
+  @Test
+  void testStrongAliasOfEnumCollapsesToTheEnum() {
+    Type enumeration = FACTORY.enumeration("TEnum", DelphiScope.unknownScope());
+    Type myEnum = strongAlias("MyEnum", enumeration);
+
+    assertThat(resolve(myEnum, enumeration)).isEqualTo(enumeration);
+    assertThat(resolve(enumeration, myEnum)).isEqualTo(enumeration);
+  }
+
+  @Test
+  void testStrongAliasOfShortStringKeepsItsDeclaredTypeOnlyWhenItWins() {
+    Type myShort = strongAlias("MyShort", intrinsic(IntrinsicType.SHORTSTRING));
+
+    assertThat(resolve(myShort, intrinsic(IntrinsicType.SHORTSTRING))).isEqualTo(myShort);
+    assertThat(resolve(intrinsic(IntrinsicType.SHORTSTRING), myShort))
+        .isEqualTo(intrinsic(IntrinsicType.SHORTSTRING));
+    assertThat(resolve(myShort, intrinsic(IntrinsicType.ANSICHAR))).isEqualTo(myShort);
+    assertThat(resolve(myShort, intrinsic(IntrinsicType.UNICODESTRING)))
+        .isEqualTo(intrinsic(IntrinsicType.UNICODESTRING));
+  }
+
+  @Test
+  void testStrongAliasOfAnsiAndWideStringKeepsItsDeclaredTypeOnlyWhenItWins() {
+    Type myAnsi = strongAlias("MyAnsi", intrinsic(IntrinsicType.ANSISTRING));
+    Type myWide = strongAlias("MyWide", intrinsic(IntrinsicType.WIDESTRING));
+
+    assertThat(resolve(myAnsi, intrinsic(IntrinsicType.ANSISTRING))).isEqualTo(myAnsi);
+    assertThat(resolve(myAnsi, intrinsic(IntrinsicType.WIDESTRING)))
+        .isEqualTo(intrinsic(IntrinsicType.WIDESTRING));
+    assertThat(resolve(myWide, intrinsic(IntrinsicType.WIDESTRING))).isEqualTo(myWide);
+    assertThat(resolve(myWide, intrinsic(IntrinsicType.UNICODESTRING)))
+        .isEqualTo(intrinsic(IntrinsicType.UNICODESTRING));
+  }
+
+  @Test
+  void testStrongAliasOfCurrencyAbsorbsIntegerWhereExtendedCannotHoldIt() {
+    Type currency = DCC64_FACTORY.getIntrinsic(IntrinsicType.CURRENCY);
+    Type myCurrency = DCC64_FACTORY.strongAlias("MyCurrency", currency);
+
+    assertThat(DCC64_RESOLVER.commonType(myCurrency, currency)).isEqualTo(currency);
+    assertThat(
+            DCC64_RESOLVER.commonType(
+                myCurrency, DCC64_FACTORY.getIntrinsic(IntrinsicType.INTEGER)))
+        .isEqualTo(currency);
+  }
+
+  @Test
+  void testStrongAliasOfPWideCharCombinesWithText() {
+    Type myPWideChar = strongAlias("MyPWideChar", intrinsic(IntrinsicType.PWIDECHAR));
+
+    assertThat(resolve(myPWideChar, intrinsic(IntrinsicType.UNICODESTRING)))
+        .isEqualTo(intrinsic(IntrinsicType.UNICODESTRING));
+    assertThat(resolve(myPWideChar, intrinsic(IntrinsicType.PWIDECHAR)))
+        .isEqualTo(intrinsic(IntrinsicType.POINTER));
+  }
+
+  @Test
+  void testStrongAliasOfCharCollapsesToTheChar() {
+    Type myChar = strongAlias("MyChar", intrinsic(IntrinsicType.WIDECHAR));
+
+    assertThat(resolve(myChar, intrinsic(IntrinsicType.WIDECHAR)))
+        .isEqualTo(intrinsic(IntrinsicType.WIDECHAR));
+    assertThat(resolve(intrinsic(IntrinsicType.WIDECHAR), myChar))
+        .isEqualTo(intrinsic(IntrinsicType.WIDECHAR));
+  }
+
+  @Test
+  void testStrongAliasOfRealWidensToExtended() {
+    Type myDouble = strongAlias("MyDouble", intrinsic(IntrinsicType.DOUBLE));
+
+    assertThat(resolve(myDouble, intrinsic(IntrinsicType.DOUBLE)))
+        .isEqualTo(intrinsic(IntrinsicType.EXTENDED));
+    assertThat(resolve(myDouble, intrinsic(IntrinsicType.SINGLE)))
+        .isEqualTo(intrinsic(IntrinsicType.EXTENDED));
+  }
+
+  @Test
+  void testCharAndSubrangeOfThatCharResolveToTheChar() {
+    Type wideChar = intrinsic(IntrinsicType.WIDECHAR);
+    Type subrange = FACTORY.subrange("'0'..'9'", wideChar);
+
+    assertThat(resolve(wideChar, subrange)).isEqualTo(wideChar);
+    assertThat(resolve(subrange, wideChar)).isEqualTo(wideChar);
+  }
+
+  @Test
+  void testCharSubrangeCombinesWithTextualTypesThroughItsHost() {
+    Type digit = FACTORY.subrange("'0'..'9'", intrinsic(IntrinsicType.WIDECHAR));
+    Type unicodeString = intrinsic(IntrinsicType.UNICODESTRING);
+    Type wideString = intrinsic(IntrinsicType.WIDESTRING);
+
+    assertThat(resolve(intrinsic(IntrinsicType.ANSICHAR), digit)).isEqualTo(unicodeString);
+    assertThat(resolve(digit, intrinsic(IntrinsicType.ANSICHAR))).isEqualTo(unicodeString);
+    assertThat(resolve(digit, unicodeString)).isEqualTo(unicodeString);
+    assertThat(resolve(digit, intrinsic(IntrinsicType.ANSISTRING))).isEqualTo(unicodeString);
+    assertThat(resolve(digit, wideString)).isEqualTo(wideString);
+    assertThat(resolve(digit, intrinsic(IntrinsicType.PWIDECHAR))).isEqualTo(unicodeString);
+    assertThat(resolve(digit, intrinsic(IntrinsicType.SHORTSTRING))).matches(Type::isUnknown);
+  }
+
+  @Test
+  void testBooleanSubrangeBranchesResolveToTheFirstOperand() {
+    Type boolSubrange = FACTORY.subrange("False..True", intrinsic(IntrinsicType.BOOLEAN));
+
+    assertThat(resolve(intrinsic(IntrinsicType.BOOLEAN), boolSubrange))
+        .isEqualTo(intrinsic(IntrinsicType.BOOLEAN));
+    assertThat(resolve(boolSubrange, intrinsic(IntrinsicType.BOOLEAN))).isEqualTo(boolSubrange);
+    assertThat(resolve(intrinsic(IntrinsicType.BYTEBOOL), boolSubrange))
+        .isEqualTo(intrinsic(IntrinsicType.BYTEBOOL));
+    assertThat(resolve(boolSubrange, intrinsic(IntrinsicType.BYTEBOOL))).isEqualTo(boolSubrange);
+  }
+
+  @Test
+  void testStrongAliasOfVariantResolvesToVariant() {
+    Type myVariant = strongAlias("MyVariant", intrinsic(IntrinsicType.VARIANT));
+
+    assertThat(resolve(myVariant, intrinsic(IntrinsicType.VARIANT)))
+        .isEqualTo(intrinsic(IntrinsicType.VARIANT));
+    assertThat(resolve(intrinsic(IntrinsicType.VARIANT), myVariant))
+        .isEqualTo(intrinsic(IntrinsicType.VARIANT));
+    assertThat(resolve(myVariant, intrinsic(IntrinsicType.OLEVARIANT)))
+        .isEqualTo(intrinsic(IntrinsicType.VARIANT));
+  }
+
+  @Test
+  void testDisjointSubrangesOfOneEnumResolveToTheEnum() {
+    Type enumeration = FACTORY.enumeration("TEnum", DelphiScope.unknownScope());
+    Type low = FACTORY.subrange("eaOne..eaTwo", enumeration);
+    Type high = FACTORY.subrange("eaThree..eaFour", enumeration);
+
+    assertThat(resolve(low, high)).isEqualTo(enumeration);
+    assertThat(resolve(high, low)).isEqualTo(enumeration);
+  }
+
+  /** A strong alias of a class is a sibling of its base: they unify at the base's parent. */
+  @Test
+  void testStrongAliasOfClassResolvesToTheBaseClassParent() {
+    StructType object = struct("TObject", CLASS);
+    StructType base = struct("TBase", CLASS, object);
+    StructType derived = struct("TDerived", CLASS, base);
+    Type alias = strongAlias("TMyBase", base);
+
+    assertThat(resolve(alias, base)).isEqualTo(object);
+    assertThat(resolve(base, alias)).isEqualTo(object);
+    assertThat(resolve(alias, derived)).isEqualTo(object);
+    assertThat(resolve(derived, alias)).isEqualTo(object);
+    assertThat(resolve(alias, strongAlias("TMyBase2", base))).isEqualTo(object);
+  }
+
+  @Test
+  void testStrongAliasOfInterfaceResolvesToTheBaseInterfaceParent() {
+    StructType iinterface = struct("IInterface", INTERFACE);
+    StructType base = struct("IFoo", INTERFACE, iinterface);
+    Type alias = strongAlias("IMyFoo", base);
+
+    assertThat(resolve(alias, base)).isEqualTo(iinterface);
+    assertThat(resolve(base, alias)).isEqualTo(iinterface);
+  }
+
+  /**
+   * Class references over one class with distinct identities resolve to the second (!!!) operand.
+   * This is the only case where the second operand breaks the tie.
+   */
+  @Test
+  void testReferencesToOneClassResolveToTheSecondOperand() {
+    StructType object = struct("TObject", CLASS);
+    StructType base = struct("TBase", CLASS, object);
+    Type reference = FACTORY.classOf("TBaseClass", base);
+    Type alias = strongAlias("TMyBaseClass", reference);
+
+    assertThat(resolve(alias, reference)).isSameAs(reference);
+    assertThat(resolve(reference, alias)).isSameAs(alias);
+  }
+
+  @Test
+  void testPointersWithoutDeclaredNamesCollapseToTheFirstOperand() {
+    Type left = FACTORY.pointerTo(null, intrinsic(IntrinsicType.INTEGER));
+    Type right = FACTORY.pointerTo(null, intrinsic(IntrinsicType.INTEGER));
+
+    assertThat(resolve(left, right)).isSameAs(left);
+  }
+
+  @Test
+  void testSetKeepsItsTypeAgainstConstructorOfCompatibleElements() {
+    Type set = FACTORY.set(subrange(0, 200));
+    Type constructor = FACTORY.arrayConstructor(List.of(intrinsic(IntrinsicType.SHORTINT)));
+
+    assertThat(resolve(set, constructor)).isSameAs(set);
+    assertThat(resolve(constructor, set)).isSameAs(set);
+  }
+
+  private static void assertResolvesBothWays(
+      IntrinsicType then, IntrinsicType els, IntrinsicType expected) {
+    assertResolvesBothWays(RESOLVER, FACTORY, then, els, expected);
+  }
+
+  private static void assertResolvesBothWays(
+      CommonTypeResolver resolver,
+      TypeFactory factory,
+      IntrinsicType then,
+      IntrinsicType els,
+      IntrinsicType expected) {
+    assertThat(resolver.commonType(factory.getIntrinsic(then), factory.getIntrinsic(els)))
+        .as("%s | %s", then, els)
+        .isEqualTo(factory.getIntrinsic(expected));
+    assertThat(resolver.commonType(factory.getIntrinsic(els), factory.getIntrinsic(then)))
+        .as("%s | %s", els, then)
+        .isEqualTo(factory.getIntrinsic(expected));
+  }
+
+  private static Type intrinsic(IntrinsicType type) {
+    return FACTORY.getIntrinsic(type);
+  }
+
+  private static Type nilPointer() {
+    return FACTORY.nilPointer();
+  }
+
+  private static Type strongAlias(String image, Type aliased) {
+    return FACTORY.strongAlias(image, aliased);
+  }
+
+  private static Type procedure(List<Type> parameterTypes, Type returnType) {
+    return procedural(ProceduralKind.PROCEDURE, parameterTypes, returnType);
+  }
+
+  private static Type procedural(ProceduralKind kind, List<Type> parameterTypes, Type returnType) {
+    return FACTORY.createProcedural(
+        kind,
+        parameterTypes.stream().map(TypeMocker::parameter).collect(Collectors.toUnmodifiableList()),
+        returnType,
+        Collections.emptySet());
+  }
+
+  private static Type subrange(long min, long max) {
+    return FACTORY.subrange(
+        String.format("%d..%d", min, max), BigInteger.valueOf(min), BigInteger.valueOf(max));
+  }
+
+  private static Type resolve(Type first, Type second) {
+    return RESOLVER.commonType(first, second);
+  }
+}

--- a/delphi-frontend/src/test/java/au/com/integradev/delphi/symbol/resolve/IfExpressionTypeResolverTest.java
+++ b/delphi-frontend/src/test/java/au/com/integradev/delphi/symbol/resolve/IfExpressionTypeResolverTest.java
@@ -1,0 +1,57 @@
+/*
+ * Sonar Delphi Plugin
+ * Copyright (C) 2026 Integrated Application Development
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02
+ */
+package au.com.integradev.delphi.symbol.resolve;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import au.com.integradev.delphi.utils.types.TypeFactoryUtils;
+import org.junit.jupiter.api.Test;
+import org.sonar.plugins.communitydelphi.api.ast.ExpressionNode;
+import org.sonar.plugins.communitydelphi.api.ast.IfExpressionNode;
+import org.sonar.plugins.communitydelphi.api.type.IntrinsicType;
+import org.sonar.plugins.communitydelphi.api.type.Type;
+import org.sonar.plugins.communitydelphi.api.type.TypeFactory;
+
+class IfExpressionTypeResolverTest {
+  private static final TypeFactory FACTORY = TypeFactoryUtils.defaultFactory();
+  private static final ExpressionTypeResolver RESOLVER = new ExpressionTypeResolver(FACTORY);
+
+  @Test
+  void testBranchTypesAreResolvedInOrder() {
+    assertThat(resolve(IntrinsicType.BYTEBOOL, IntrinsicType.BOOLEAN))
+        .isEqualTo(FACTORY.getIntrinsic(IntrinsicType.BYTEBOOL));
+    assertThat(resolve(IntrinsicType.BOOLEAN, IntrinsicType.BYTEBOOL))
+        .isEqualTo(FACTORY.getIntrinsic(IntrinsicType.BOOLEAN));
+  }
+
+  private static Type resolve(IntrinsicType then, IntrinsicType els) {
+    ExpressionNode thenExpression = mock(ExpressionNode.class);
+    ExpressionNode elseExpression = mock(ExpressionNode.class);
+    when(thenExpression.getType()).thenReturn(FACTORY.getIntrinsic(then));
+    when(elseExpression.getType()).thenReturn(FACTORY.getIntrinsic(els));
+
+    IfExpressionNode node = mock(IfExpressionNode.class);
+    when(node.getThenExpression()).thenReturn(thenExpression);
+    when(node.getElseExpression()).thenReturn(elseExpression);
+
+    return RESOLVER.resolve(node);
+  }
+}

--- a/delphi-frontend/src/test/java/au/com/integradev/delphi/symbol/resolve/TypeInferrerTest.java
+++ b/delphi-frontend/src/test/java/au/com/integradev/delphi/symbol/resolve/TypeInferrerTest.java
@@ -58,7 +58,7 @@ class TypeInferrerTest {
     @Override
     public Stream<Arguments> provideArguments(ExtensionContext context) {
       return Stream.of(
-          Arguments.of(arrayConstructor(), dynamicArrayType(TypeFactory.voidType())),
+          Arguments.of(arrayConstructor(), TypeFactory.unknownType()),
           Arguments.of(
               arrayConstructor(integerLiteral("127")), dynamicArrayType(IntrinsicType.INTEGER)),
           Arguments.of(
@@ -111,7 +111,7 @@ class TypeInferrerTest {
                   integerLiteral("32768"),
                   integerLiteral("2147483647"),
                   integerLiteral("2147483648")),
-              dynamicArrayType(IntrinsicType.CARDINAL)),
+              dynamicArrayType(IntrinsicType.INT64)),
           Arguments.of(
               arrayConstructor(
                   integerLiteral("127"),
@@ -123,7 +123,7 @@ class TypeInferrerTest {
                   integerLiteral("2147483647"),
                   integerLiteral("2147483648"),
                   integerLiteral("4294967295")),
-              dynamicArrayType(IntrinsicType.CARDINAL)),
+              dynamicArrayType(IntrinsicType.INT64)),
           Arguments.of(
               arrayConstructor(
                   integerLiteral("127"),

--- a/delphi-frontend/src/test/java/au/com/integradev/delphi/utils/types/TypeMocker.java
+++ b/delphi-frontend/src/test/java/au/com/integradev/delphi/utils/types/TypeMocker.java
@@ -27,6 +27,10 @@ import static org.sonar.plugins.communitydelphi.api.type.TypeFactory.unknownType
 import au.com.integradev.delphi.symbol.scope.TypeScopeImpl;
 import au.com.integradev.delphi.type.factory.HelperTypeImpl;
 import au.com.integradev.delphi.type.factory.StructTypeImpl;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.function.Predicate;
 import org.sonar.plugins.communitydelphi.api.type.Parameter;
 import org.sonar.plugins.communitydelphi.api.type.StructKind;
 import org.sonar.plugins.communitydelphi.api.type.Type;
@@ -37,11 +41,7 @@ public final class TypeMocker {
     // Utility class
   }
 
-  public static StructType struct(String image, StructKind kind) {
-    return struct(image, kind, unknownType());
-  }
-
-  public static StructType struct(String image, StructKind kind, Type parent) {
+  public static StructType struct(String image, StructKind kind, Type... ancestors) {
     StructType type;
 
     switch (kind) {
@@ -56,12 +56,18 @@ public final class TypeMocker {
     var typeScope = new TypeScopeImpl();
     typeScope.setType(type);
 
+    Set<Type> ancestorList = new LinkedHashSet<>(List.of(ancestors));
+    Type parent =
+        ancestorList.stream()
+            .filter(ancestor -> kind == StructKind.INTERFACE || !ancestor.isInterface())
+            .findFirst()
+            .orElse(unknownType());
+
     when(type.typeScope()).thenReturn(typeScope);
     when(type.isStruct()).thenReturn(true);
     when(type.isClass()).thenReturn(kind == StructKind.CLASS);
     when(type.isInterface()).thenReturn(kind == StructKind.INTERFACE);
     when(type.isRecord()).thenReturn(kind == StructKind.RECORD);
-    when(type.isClass()).thenReturn(kind == StructKind.CLASS);
     when(type.isHelper())
         .thenReturn(kind == StructKind.RECORD_HELPER || kind == StructKind.CLASS_HELPER);
     when(type.getImage()).thenReturn(image);
@@ -71,13 +77,18 @@ public final class TypeMocker {
         .thenAnswer(
             arguments -> image.equalsIgnoreCase(((Type) arguments.getArgument(0)).getImage()));
     when(type.kind()).thenReturn(kind);
-    when(type.isDescendantOf(anyString()))
-        .thenAnswer(invocation -> isImageOrParentType(invocation.getArgument(0), image, parent));
-    when(type.isDescendantOf(any(Type.class)))
-        .thenAnswer(
-            invocation ->
-                isImageOrParentType(((Type) invocation.getArgument(0)).getImage(), image, parent));
+    when(type.ancestorList()).thenReturn(ancestorList);
     when(type.parent()).thenReturn(parent);
+    Predicate<String> descendsFrom =
+        ancestorImage ->
+            ancestorList.stream()
+                .anyMatch(
+                    ancestor ->
+                        ancestor.is(ancestorImage) || ancestor.isDescendantOf(ancestorImage));
+    when(type.isDescendantOf(anyString()))
+        .thenAnswer(invocation -> descendsFrom.test(invocation.getArgument(0)));
+    when(type.isDescendantOf(any(Type.class)))
+        .thenAnswer(invocation -> descendsFrom.test(((Type) invocation.getArgument(0)).getImage()));
 
     return type;
   }
@@ -87,9 +98,5 @@ public final class TypeMocker {
     when(parameter.getImage()).thenReturn("_");
     when(parameter.getType()).thenReturn(type);
     return parameter;
-  }
-
-  private static boolean isImageOrParentType(String typeToCheck, String image, Type parent) {
-    return image.equalsIgnoreCase(typeToCheck) || parent.is(typeToCheck);
   }
 }

--- a/delphi-frontend/src/test/resources/au/com/integradev/delphi/grammar/IfExpressions.pas
+++ b/delphi-frontend/src/test/resources/au/com/integradev/delphi/grammar/IfExpressions.pas
@@ -1,0 +1,12 @@
+unit IfExpressions;
+
+interface
+
+implementation
+
+function Simple(Flag: Boolean): Integer;
+begin
+  Result := if Flag then 1 else 2;
+end;
+
+end.


### PR DESCRIPTION
This PR implements `if` expressions.

## Embarcadero Documentation

The language feature is documented by Embarcadero [here](https://docwiki.embarcadero.com/RADStudio/Florence/en/Conditional_Operators_(Delphi)).

They even kindly provided a table of operand type combinations with the corresponding result type.

| Type 1 | Type 2 | Result type |
| --- | --- | --- |
| AnsiChar | AnsiChar | AnsiChar |
| AnsiString | AnsiString, AnsiChar | AnsiString |
| Array | Array | Array of the same element type. |
| Boolean types | Boolean types | Common Boolean type or Boolean type. |
| Class reference | Class reference, nil | Common type, Base type, or TClass. |
| Dynamic array | Dynamic array | Common dynamic array type. |
| Enum type | Enum type | Common enum type. |
| File | File | Error (use pointer to File type). |
| Instance | Instance, nil | Common type, Base type, or TObject. |
| Integral types | Integral types | Common integral type, or the type that covers both ranges. |
| Integral types | Real types | Real type. |
| Interface | Interface, nil | Common type, Base type, or IInterface. |
| nil | AnsiChar, ShortString, AnsiString, WideChar, WideString | Pointer to WideChar |
| Object | Object | Object type. |
| Pointer to AnsiChar | AnsiChar, ShortString, AnsiString literal | Pointer to AnsiChar |
| Pointer to AnsiChar | Pointer to WideChar literal | Pointer to WideChar |
| Pointer to WideChar | AnsiChar, ShortString, AnsiString, WideChar, WideString, UnicodeString | UnicodeString |
| Pointer types | Pointer types | Common pointer type, or Pointer type. |
| Procedure | Procedure | Procedure type, if they have the same signature. |
| Procedure of object | Procedure of object | Procedure for object type if they have the same signature. |
| Real types | Real types | The real type with the greater precision. |
| Record | Record | Record type. |
| Reference to procedure Anonymous Method | Reference to procedure Anonymous Method | Reference to the procedure type, if they have the same signature. |
| Set | Set | Common set type, or large set type if list literals. |
| Short string | Short string, AnsiChar | Longer short string |
| Text | Text | Error (use pointer to Text type). |
| UnicodeString | UnicodeString, WideString, AnsiString, Short string, WideChar, AnsiChar | UnicodeString |
| Variant | Variant | Variant type. |
| WideChar | WideChar | WideChar |
| WideChar | AnsiChar, AnsiString | UnicodeString |
| WideString | WideString, AnsiString, WideChar, AnsiChar | WideString |

## Reality

Unfortunately, the documented operand/result type combinations are inaccurate or incomplete in various ways.
Below is what Delphi 13 actually does.

| Type 1 | Type 2 | Result type |
| --- | --- | --- |
| AnsiChar | AnsiChar | AnsiChar |
| AnsiString | AnsiString, AnsiChar | Left operand (code pages don't unify) |
| Array | Array | Identical type only; else error |
| Boolean types | Boolean types | Left operand, never widened |
| Class reference | Class reference, nil | Reference to nearest common ancestor; same class -> **right** operand; nil -> the reference |
| Dynamic array | Dynamic array, nil | Identical type only (nil -> the array); else error |
| Dynamic array | `[...]` constructor | Error |
| Enum type | Enum type | The enum (subranges unify to it); distinct enums error |
| File | File | Error (use pointer to File type). |
| Instance | Instance, nil | Nearest common ancestor class, never an interface; strong aliases are siblings of their base; nil -> the class |
| Instance | Interface | Error |
| Integral types | Integral types | Narrowest type covering both ranges; signed/unsigned tie -> anonymous unsigned subrange, or UInt64 |
| Integral types | Real types | Extended; Comp/Currency where Extended is 8 bytes |
| Interface | Interface, nil | Nearest common ancestor; nil -> the interface |
| nil | AnsiChar, ShortString, AnsiString, WideChar, WideString | Error |
| nil | Procedure, procedure of object, reference to | The procedural type |
| nil | `[...]` constructor | Anonymous `array of T` |
| nil | Variant, any value type | Error |
| Object | Object | Identical type only; else error |
| Pointer to AnsiChar | AnsiChar, ShortString, AnsiString literal | Error |
| Pointer to AnsiChar | Pointer to WideChar literal | Error |
| Pointer to WideChar | AnsiChar, ShortString, AnsiString, WideChar, WideString, UnicodeString | UnicodeString |
| Pointer types | Pointer types | Left operand if either is untyped or the right is nil; nil on the left, or unrelated pointers -> Pointer |
| Procedure | Procedure | Left operand, if they have the same signature |
| Procedure of object | Procedure of object | Left operand, if they have the same signature |
| Mixed procedural kinds | Mixed procedural kinds | Error |
| Real types | Real types | Extended; Comp/Currency where Extended is 8 bytes |
| Record | Record | Identical type only; else error |
| Reference to procedure Anonymous Method | Reference to procedure Anonymous Method | The `reference to` type, if they have the same signature |
| Set | Set | The containing set (left on ties); else `set of Byte` or `set of AnsiChar` |
| Set | `[...]` constructor | The set, if the elements are compatible |
| `[...]` constructor | `[...]` constructor | Left operand's set reading, if all elements are ordinal; else error |
| ShortString | ShortString, AnsiChar | Longer ShortString |
| Text | Text | Error (use pointer to Text type). |
| UnicodeString | UnicodeString, WideString, AnsiString, Short string, WideChar, AnsiChar | Left operand |
| Variant | Variant | Variant (even for OleVariant mixes) |
| WideChar | WideChar | WideChar |
| WideChar | AnsiChar, AnsiString | UnicodeString |
| WideString | WideString, AnsiString, WideChar, AnsiChar | Left operand |

Working out the actual rules required a lot of painful testing against the Delphi 13 compiler, but I think this is pretty accurate now.

It definitely isn't a "least upper bound" as commonly understood, or as documented:
  - operand types can end up stuffed into ill-fitting result types
    - signed integers going into `UInt64`
    - large booleans going into smaller booleans (whichever the left operand happened to be)
  - ties typically go to the left operand, so ordering of the expression is significant

## Fun Facts

- `if b then [] else DynArray` crashes the 64-bit compiler with an internal error (F2084).
