### PR TITLE
Migrate to JDK 25 and upgrade various dependencies

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Setup Java
         uses: actions/setup-java@v4
         with:
-          java-version: '21'
+          java-version: '25'
           distribution: 'temurin'
           cache: maven
       - name: Maven Install

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -1,7 +1,6 @@
 name: Format
 
 on:
-  push:
     branches:
       - 'master'
     paths:
@@ -18,6 +17,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - name: Setup Java
+        uses: actions/setup-java@v4
+        with:
+          java-version: '25'
+          distribution: 'temurin'
       - uses: axel-op/googlejavaformat-action@c1134ebd196c4cbffb077f9476585b0be8b6afcd # v4.0.0
         with:
           release-name: v1.26.0

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -24,5 +24,5 @@ jobs:
           distribution: 'temurin'
       - uses: axel-op/googlejavaformat-action@c1134ebd196c4cbffb077f9476585b0be8b6afcd # v4.0.0
         with:
-          release-name: v1.26.0
+          release-name: v1.36.1
           args: "--set-exit-if-changed --dry-run"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ jobs:
         uses: actions/setup-java@v3
         with:
           distribution: 'temurin'
-          java-version: '21'
+          java-version: '25'
           server-id: central
           server-username: MAVEN_CENTRAL_PORTAL_USERNAME
           server-password: MAVEN_CENTRAL_PORTAL_PASSWORD

--- a/.github/workflows/scan-dependencies.yml
+++ b/.github/workflows/scan-dependencies.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Setup Java
         uses: actions/setup-java@v4
         with:
-          java-version: '21'
+          java-version: '25'
           distribution: 'temurin'
           cache: maven
       - name: Maven Install

--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Setup Java
         uses: actions/setup-java@v4
         with:
-          java-version: '21'
+          java-version: '25'
           distribution: 'temurin'
           cache: maven
       - name: Cache SonarCloud packages

--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ read the [contributing guide](docs/CONTRIBUTING.md).
 
 ## Development
 
-SonarDelphi can be built with JDK 17+ using [Maven](https://maven.apache.org/).
+SonarDelphi can be built with JDK 25+ using [Maven](https://maven.apache.org/).
 
 To build the project and run unit tests, execute the following command from the project's root directory:
 

--- a/delphi-frontend/src/test/java/au/com/integradev/delphi/antlr/ast/node/InterfaceTypeNodeImplTest.java
+++ b/delphi-frontend/src/test/java/au/com/integradev/delphi/antlr/ast/node/InterfaceTypeNodeImplTest.java
@@ -29,6 +29,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.ArgumentsProvider;
 import org.junit.jupiter.params.provider.ArgumentsSource;
+import org.junit.jupiter.params.support.ParameterDeclarations;
 import org.sonar.plugins.communitydelphi.api.ast.ExpressionNode;
 import org.sonar.plugins.communitydelphi.api.ast.InterfaceTypeNode;
 
@@ -37,7 +38,8 @@ class InterfaceTypeNodeImplTest {
 
   private static class GuidArgumentsProvider implements ArgumentsProvider {
     @Override
-    public Stream<Arguments> provideArguments(ExtensionContext context) {
+    public Stream<Arguments> provideArguments(
+        ParameterDeclarations parameters, ExtensionContext context) {
       return Stream.of(
           Arguments.of(
               Named.of(
@@ -75,7 +77,8 @@ class InterfaceTypeNodeImplTest {
 
   private static class NoGuidArgumentsProvider implements ArgumentsProvider {
     @Override
-    public Stream<Arguments> provideArguments(ExtensionContext context) {
+    public Stream<Arguments> provideArguments(
+        ParameterDeclarations parameters, ExtensionContext context) {
       return Stream.of(
           Arguments.of(
               Named.of(

--- a/delphi-frontend/src/test/java/au/com/integradev/delphi/check/FilePositionTest.java
+++ b/delphi-frontend/src/test/java/au/com/integradev/delphi/check/FilePositionTest.java
@@ -26,12 +26,14 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.ArgumentsProvider;
 import org.junit.jupiter.params.provider.ArgumentsSource;
+import org.junit.jupiter.params.support.ParameterDeclarations;
 import org.sonar.plugins.communitydelphi.api.check.FilePosition;
 
 class FilePositionTest {
   static class InvalidPrecisePositionArgumentsProvider implements ArgumentsProvider {
     @Override
-    public Stream<Arguments> provideArguments(ExtensionContext context) {
+    public Stream<Arguments> provideArguments(
+        ParameterDeclarations parameters, ExtensionContext context) {
       return Stream.of(
           Arguments.of(FilePosition.UNDEFINED_LINE, 2, 3, 4),
           Arguments.of(1, FilePosition.UNDEFINED_COLUMN, 3, 4),
@@ -42,7 +44,8 @@ class FilePositionTest {
 
   static class InvalidLineLevelPositionArgumentsProvider implements ArgumentsProvider {
     @Override
-    public Stream<Arguments> provideArguments(ExtensionContext context) {
+    public Stream<Arguments> provideArguments(
+        ParameterDeclarations parameters, ExtensionContext context) {
       return Stream.of(
           Arguments.of(FilePosition.UNDEFINED_LINE, 2),
           Arguments.of(1, FilePosition.UNDEFINED_LINE));

--- a/delphi-frontend/src/test/java/au/com/integradev/delphi/msbuild/MSBuildItemTest.java
+++ b/delphi-frontend/src/test/java/au/com/integradev/delphi/msbuild/MSBuildItemTest.java
@@ -31,13 +31,15 @@ import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.ArgumentsProvider;
 import org.junit.jupiter.params.provider.ArgumentsSource;
 import org.junit.jupiter.params.provider.ValueSource;
+import org.junit.jupiter.params.support.ParameterDeclarations;
 
 class MSBuildItemTest {
   private static final String PROJECT_DIR = "C:\\project";
 
   static class SupportedWellKnownMetadataArgumentsProvider implements ArgumentsProvider {
     @Override
-    public Stream<Arguments> provideArguments(ExtensionContext context) {
+    public Stream<Arguments> provideArguments(
+        ParameterDeclarations parameters, ExtensionContext context) {
       return Stream.of(
           Arguments.of("FullPath", "C:\\foo\\bar\\baz.qux", "C:\\foo\\bar\\baz.qux"),
           Arguments.of("FullPath", "foo", "C:\\project\\foo"),
@@ -61,7 +63,8 @@ class MSBuildItemTest {
 
   static class CustomMetadataArgumentsProvider implements ArgumentsProvider {
     @Override
-    public Stream<Arguments> provideArguments(ExtensionContext context) {
+    public Stream<Arguments> provideArguments(
+        ParameterDeclarations parameters, ExtensionContext context) {
       return Stream.of(
           Arguments.of("FooMetadata", "foometadata", "foo value"),
           Arguments.of("FooMetadata", "FooMetadata", "foo value"),

--- a/delphi-frontend/src/test/java/au/com/integradev/delphi/msbuild/condition/ConditionLexerTest.java
+++ b/delphi-frontend/src/test/java/au/com/integradev/delphi/msbuild/condition/ConditionLexerTest.java
@@ -31,11 +31,13 @@ import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.ArgumentsProvider;
 import org.junit.jupiter.params.provider.ArgumentsSource;
 import org.junit.jupiter.params.provider.ValueSource;
+import org.junit.jupiter.params.support.ParameterDeclarations;
 
 class ConditionLexerTest {
   static class NumberTokensArgumentsProvider implements ArgumentsProvider {
     @Override
-    public Stream<Arguments> provideArguments(ExtensionContext context) {
+    public Stream<Arguments> provideArguments(
+        ParameterDeclarations parameters, ExtensionContext context) {
       return Stream.of(
           Arguments.of("123", TokenType.NUMERIC),
           Arguments.of("+123", TokenType.NUMERIC),
@@ -52,7 +54,8 @@ class ConditionLexerTest {
 
   static class SyntaxTokensArgumentsProvider implements ArgumentsProvider {
     @Override
-    public Stream<Arguments> provideArguments(ExtensionContext context) {
+    public Stream<Arguments> provideArguments(
+        ParameterDeclarations parameters, ExtensionContext context) {
       return Stream.of(
           Arguments.of(",", TokenType.COMMA),
           Arguments.of("(", TokenType.LPAREN),
@@ -62,7 +65,8 @@ class ConditionLexerTest {
 
   static class OperatorTokensArgumentsProvider implements ArgumentsProvider {
     @Override
-    public Stream<Arguments> provideArguments(ExtensionContext context) {
+    public Stream<Arguments> provideArguments(
+        ParameterDeclarations parameters, ExtensionContext context) {
       return Stream.of(
           Arguments.of("<", TokenType.LESS_THAN),
           Arguments.of(">", TokenType.GREATER_THAN),
@@ -78,7 +82,8 @@ class ConditionLexerTest {
 
   static class StringTokensArgumentsProvider implements ArgumentsProvider {
     @Override
-    public Stream<Arguments> provideArguments(ExtensionContext context) {
+    public Stream<Arguments> provideArguments(
+        ParameterDeclarations parameters, ExtensionContext context) {
       return Stream.of(
           Arguments.of("'My quoted string'", TokenType.STRING),
           Arguments.of("'$1.00'", TokenType.STRING),
@@ -92,7 +97,8 @@ class ConditionLexerTest {
 
   static class PropertyTokensArgumentsProvider implements ArgumentsProvider {
     @Override
-    public Stream<Arguments> provideArguments(ExtensionContext context) {
+    public Stream<Arguments> provideArguments(
+        ParameterDeclarations parameters, ExtensionContext context) {
       return Stream.of(
           Arguments.of("$(FOO)", TokenType.PROPERTY), Arguments.of("'$(FOO)'", TokenType.STRING));
     }

--- a/delphi-frontend/src/test/java/au/com/integradev/delphi/msbuild/condition/ExpressionEvaluationTest.java
+++ b/delphi-frontend/src/test/java/au/com/integradev/delphi/msbuild/condition/ExpressionEvaluationTest.java
@@ -39,13 +39,15 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.ArgumentsProvider;
 import org.junit.jupiter.params.provider.ArgumentsSource;
+import org.junit.jupiter.params.support.ParameterDeclarations;
 
 class ExpressionEvaluationTest {
   private @TempDir Path tempDir;
 
   static class BooleanArgumentsProvider implements ArgumentsProvider {
     @Override
-    public Stream<Arguments> provideArguments(ExtensionContext context) {
+    public Stream<Arguments> provideArguments(
+        ParameterDeclarations parameters, ExtensionContext context) {
       return Stream.of(
           Arguments.of("true", true),
           Arguments.of("on", true),
@@ -151,7 +153,8 @@ class ExpressionEvaluationTest {
 
   static class NumericArgumentsProvider implements ArgumentsProvider {
     @Override
-    public Stream<Arguments> provideArguments(ExtensionContext context) {
+    public Stream<Arguments> provideArguments(
+        ParameterDeclarations parameters, ExtensionContext context) {
       return Stream.of(
           Arguments.of("0", 0.0),
           Arguments.of("12.34", 12.34),
@@ -168,7 +171,8 @@ class ExpressionEvaluationTest {
 
   static class VersionArgumentsProvider implements ArgumentsProvider {
     @Override
-    public Stream<Arguments> provideArguments(ExtensionContext context) {
+    public Stream<Arguments> provideArguments(
+        ParameterDeclarations parameters, ExtensionContext context) {
       return Stream.of(
           Arguments.of("1", null),
           Arguments.of("1.2", new Version(1, 2)),
@@ -183,7 +187,8 @@ class ExpressionEvaluationTest {
 
   static class UnexpandedStringProvider implements ArgumentsProvider {
     @Override
-    public Stream<Arguments> provideArguments(ExtensionContext context) {
+    public Stream<Arguments> provideArguments(
+        ParameterDeclarations parameters, ExtensionContext context) {
       return Stream.of(
           Arguments.of("foo", "foo"),
           Arguments.of("'foo'", "foo"),
@@ -199,7 +204,8 @@ class ExpressionEvaluationTest {
 
   static class InvalidExpressionProvider implements ArgumentsProvider {
     @Override
-    public Stream<Arguments> provideArguments(ExtensionContext context) {
+    public Stream<Arguments> provideArguments(
+        ParameterDeclarations parameters, ExtensionContext context) {
       return Stream.of(
           Arguments.of("!'foo'", InvalidExpressionException.class),
           Arguments.of("'foo' and 'bar'", InvalidExpressionException.class),
@@ -222,7 +228,8 @@ class ExpressionEvaluationTest {
 
   static class ExpandedStringProvider implements ArgumentsProvider {
     @Override
-    public Stream<Arguments> provideArguments(ExtensionContext context) {
+    public Stream<Arguments> provideArguments(
+        ParameterDeclarations parameters, ExtensionContext context) {
       return Stream.of(
           Arguments.of("foo", "foo"),
           Arguments.of("'foo'", "foo"),

--- a/delphi-frontend/src/test/java/au/com/integradev/delphi/msbuild/condition/utils/NumericUtilsTest.java
+++ b/delphi-frontend/src/test/java/au/com/integradev/delphi/msbuild/condition/utils/NumericUtilsTest.java
@@ -28,11 +28,13 @@ import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.ArgumentsProvider;
 import org.junit.jupiter.params.provider.ArgumentsSource;
 import org.junit.jupiter.params.provider.ValueSource;
+import org.junit.jupiter.params.support.ParameterDeclarations;
 
 class NumericUtilsTest {
   static class ValidNumericArgumentsProvider implements ArgumentsProvider {
     @Override
-    public Stream<Arguments> provideArguments(ExtensionContext context) {
+    public Stream<Arguments> provideArguments(
+        ParameterDeclarations parameters, ExtensionContext context) {
       return Stream.of(
           Arguments.of("1", 1.0),
           Arguments.of("2.3", 2.3),

--- a/delphi-frontend/src/test/java/au/com/integradev/delphi/msbuild/condition/utils/VersionUtilsTest.java
+++ b/delphi-frontend/src/test/java/au/com/integradev/delphi/msbuild/condition/utils/VersionUtilsTest.java
@@ -29,11 +29,13 @@ import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.ArgumentsProvider;
 import org.junit.jupiter.params.provider.ArgumentsSource;
 import org.junit.jupiter.params.provider.ValueSource;
+import org.junit.jupiter.params.support.ParameterDeclarations;
 
 class VersionUtilsTest {
   static class ValidVersionArgumentsProvider implements ArgumentsProvider {
     @Override
-    public Stream<Arguments> provideArguments(ExtensionContext context) {
+    public Stream<Arguments> provideArguments(
+        ParameterDeclarations parameters, ExtensionContext context) {
       return Stream.of(
           Arguments.of("1.2", new Version(1, 2)),
           Arguments.of("1.2.3", new Version(1, 2, 3)),

--- a/delphi-frontend/src/test/java/au/com/integradev/delphi/msbuild/expression/MSBuildWellKnownPropertyHelperTest.java
+++ b/delphi-frontend/src/test/java/au/com/integradev/delphi/msbuild/expression/MSBuildWellKnownPropertyHelperTest.java
@@ -27,12 +27,14 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.ArgumentsProvider;
 import org.junit.jupiter.params.provider.ArgumentsSource;
+import org.junit.jupiter.params.support.ParameterDeclarations;
 
 class MSBuildWellKnownPropertyHelperTest {
 
   private static class WellKnownPropertyArgumentsProvider implements ArgumentsProvider {
     @Override
-    public Stream<Arguments> provideArguments(ExtensionContext context) {
+    public Stream<Arguments> provideArguments(
+        ParameterDeclarations parameters, ExtensionContext context) {
       return Stream.of(
           Arguments.of("MSBuildProjectFullPath", "C:\\Source\\Repos\\ConsoleApp1.dproj"),
           Arguments.of("MSBuildProjectFile", "ConsoleApp1.dproj"),

--- a/delphi-frontend/src/test/java/au/com/integradev/delphi/preprocessor/directive/expression/ExpressionLexerTest.java
+++ b/delphi-frontend/src/test/java/au/com/integradev/delphi/preprocessor/directive/expression/ExpressionLexerTest.java
@@ -31,11 +31,13 @@ import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.ArgumentsProvider;
 import org.junit.jupiter.params.provider.ArgumentsSource;
 import org.junit.jupiter.params.provider.ValueSource;
+import org.junit.jupiter.params.support.ParameterDeclarations;
 
 class ExpressionLexerTest {
   static class NumberTokensArgumentsProvider implements ArgumentsProvider {
     @Override
-    public Stream<Arguments> provideArguments(ExtensionContext context) {
+    public Stream<Arguments> provideArguments(
+        ParameterDeclarations parameters, ExtensionContext context) {
       return Stream.of(
           Arguments.of("12345", TokenType.INTEGER),
           Arguments.of("123_456_789", TokenType.INTEGER),
@@ -53,7 +55,8 @@ class ExpressionLexerTest {
 
   static class IdentifierTokensArgumentsProvider implements ArgumentsProvider {
     @Override
-    public Stream<Arguments> provideArguments(ExtensionContext context) {
+    public Stream<Arguments> provideArguments(
+        ParameterDeclarations parameters, ExtensionContext context) {
       return Stream.of(
           Arguments.of("MyIdentifier", TokenType.IDENTIFIER),
           Arguments.of("_MyIdentifier", TokenType.IDENTIFIER),
@@ -64,7 +67,8 @@ class ExpressionLexerTest {
 
   static class SyntaxTokensArgumentsProvider implements ArgumentsProvider {
     @Override
-    public Stream<Arguments> provideArguments(ExtensionContext context) {
+    public Stream<Arguments> provideArguments(
+        ParameterDeclarations parameters, ExtensionContext context) {
       return Stream.of(
           Arguments.of(".", TokenType.DOT),
           Arguments.of(",", TokenType.COMMA),
@@ -79,7 +83,8 @@ class ExpressionLexerTest {
 
   static class OperatorTokensArgumentsProvider implements ArgumentsProvider {
     @Override
-    public Stream<Arguments> provideArguments(ExtensionContext context) {
+    public Stream<Arguments> provideArguments(
+        ParameterDeclarations parameters, ExtensionContext context) {
       return Stream.of(
           Arguments.of("<>", TokenType.NOT_EQUALS),
           Arguments.of("<=", TokenType.LESS_THAN_EQUAL),
@@ -90,7 +95,8 @@ class ExpressionLexerTest {
 
   static class StringTokensArgumentsProvider implements ArgumentsProvider {
     @Override
-    public Stream<Arguments> provideArguments(ExtensionContext context) {
+    public Stream<Arguments> provideArguments(
+        ParameterDeclarations parameters, ExtensionContext context) {
       return Stream.of(
           Arguments.of("'My string'", TokenType.STRING),
           Arguments.of("'Escaped '' single-quotes'", TokenType.STRING),
@@ -101,7 +107,8 @@ class ExpressionLexerTest {
 
   static class CommentTokensArgumentsProvider implements ArgumentsProvider {
     @Override
-    public Stream<Arguments> provideArguments(ExtensionContext context) {
+    public Stream<Arguments> provideArguments(
+        ParameterDeclarations parameters, ExtensionContext context) {
       return Stream.of(
           Arguments.of("// foo", TokenType.COMMENT),
           Arguments.of("{bar}", TokenType.COMMENT),
@@ -111,7 +118,8 @@ class ExpressionLexerTest {
 
   static class DirectiveTokensArgumentsProvider implements ArgumentsProvider {
     @Override
-    public Stream<Arguments> provideArguments(ExtensionContext context) {
+    public Stream<Arguments> provideArguments(
+        ParameterDeclarations parameters, ExtensionContext context) {
       return Stream.of(
           Arguments.of("{$i foo.inc}", TokenType.DIRECTIVE),
           Arguments.of("(*$i bar.inc*)", TokenType.DIRECTIVE),

--- a/delphi-frontend/src/test/java/au/com/integradev/delphi/preprocessor/directive/expression/ExpressionsTest.java
+++ b/delphi-frontend/src/test/java/au/com/integradev/delphi/preprocessor/directive/expression/ExpressionsTest.java
@@ -43,6 +43,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.ArgumentsProvider;
 import org.junit.jupiter.params.provider.ArgumentsSource;
+import org.junit.jupiter.params.support.ParameterDeclarations;
 import org.sonar.plugins.communitydelphi.api.type.IntrinsicType;
 import org.sonar.plugins.communitydelphi.api.type.TypeFactory;
 
@@ -50,7 +51,8 @@ class ExpressionsTest {
 
   static class NumericExpressionArgumentsProvider implements ArgumentsProvider {
     @Override
-    public Stream<Arguments> provideArguments(ExtensionContext context) {
+    public Stream<Arguments> provideArguments(
+        ParameterDeclarations parameters, ExtensionContext context) {
       return Stream.of(
           Arguments.of("$26E", 622),
           Arguments.of("%10011_01110", 622),
@@ -64,7 +66,8 @@ class ExpressionsTest {
 
   static class IntegerMathArgumentsProvider implements ArgumentsProvider {
     @Override
-    public Stream<Arguments> provideArguments(ExtensionContext context) {
+    public Stream<Arguments> provideArguments(
+        ParameterDeclarations parameters, ExtensionContext context) {
       return Stream.of(
           Arguments.of("1 + 2", 3),
           Arguments.of("1 - 2", -1),
@@ -81,7 +84,8 @@ class ExpressionsTest {
 
   static class RealMathArgumentsProvider implements ArgumentsProvider {
     @Override
-    public Stream<Arguments> provideArguments(ExtensionContext context) {
+    public Stream<Arguments> provideArguments(
+        ParameterDeclarations parameters, ExtensionContext context) {
       return Stream.of(
           Arguments.of("1 + 2", 3.0),
           Arguments.of("5 / 2", 2.5),
@@ -95,7 +99,8 @@ class ExpressionsTest {
 
   static class StringArgumentsProvider implements ArgumentsProvider {
     @Override
-    public Stream<Arguments> provideArguments(ExtensionContext context) {
+    public Stream<Arguments> provideArguments(
+        ParameterDeclarations parameters, ExtensionContext context) {
       return Stream.of(
           Arguments.of("'My string'", "My string"),
           Arguments.of("'Escaped '' single-quotes'", "Escaped ' single-quotes"),
@@ -106,7 +111,8 @@ class ExpressionsTest {
 
   static class StringConcatenationArgumentsProvider implements ArgumentsProvider {
     @Override
-    public Stream<Arguments> provideArguments(ExtensionContext context) {
+    public Stream<Arguments> provideArguments(
+        ParameterDeclarations parameters, ExtensionContext context) {
       return Stream.of(
           Arguments.of("'abc' + '123'", "abc123"),
           Arguments.of("'abc' + ''", "abc"),
@@ -116,7 +122,8 @@ class ExpressionsTest {
 
   static class EqualityArgumentsProvider implements ArgumentsProvider {
     @Override
-    public Stream<Arguments> provideArguments(ExtensionContext context) {
+    public Stream<Arguments> provideArguments(
+        ParameterDeclarations parameters, ExtensionContext context) {
       return Stream.of(
           Arguments.of("1 = 1", true),
           Arguments.of("1 = 2", false),
@@ -160,7 +167,8 @@ class ExpressionsTest {
 
   static class ComparisonArgumentsProvider implements ArgumentsProvider {
     @Override
-    public Stream<Arguments> provideArguments(ExtensionContext context) {
+    public Stream<Arguments> provideArguments(
+        ParameterDeclarations parameters, ExtensionContext context) {
       return Stream.of(
           Arguments.of("1 > 1", false),
           Arguments.of("2 > 1", true),
@@ -209,7 +217,8 @@ class ExpressionsTest {
 
   static class LogicalOperatorsArgumentsProvider implements ArgumentsProvider {
     @Override
-    public Stream<Arguments> provideArguments(ExtensionContext context) {
+    public Stream<Arguments> provideArguments(
+        ParameterDeclarations parameters, ExtensionContext context) {
       return Stream.of(
           Arguments.of("1 in [1, 2, 3]", true),
           Arguments.of("1 in [2, 3]", false),
@@ -237,7 +246,8 @@ class ExpressionsTest {
 
   static class UnaryEvaluationArgumentsProvider implements ArgumentsProvider {
     @Override
-    public Stream<Arguments> provideArguments(ExtensionContext context) {
+    public Stream<Arguments> provideArguments(
+        ParameterDeclarations parameters, ExtensionContext context) {
       return Stream.of(
           Arguments.of("+1", 1),
           Arguments.of("-1", -1),
@@ -255,7 +265,8 @@ class ExpressionsTest {
 
   static class DefinedArgumentsProvider implements ArgumentsProvider {
     @Override
-    public Stream<Arguments> provideArguments(ExtensionContext context) {
+    public Stream<Arguments> provideArguments(
+        ParameterDeclarations parameters, ExtensionContext context) {
       return addSystemQualifier(
           Stream.of(
               Arguments.of("Defined(TEST_DEFINE)", true),
@@ -267,7 +278,8 @@ class ExpressionsTest {
 
   static class SizeOfArgumentsProvider implements ArgumentsProvider {
     @Override
-    public Stream<Arguments> provideArguments(ExtensionContext context) {
+    public Stream<Arguments> provideArguments(
+        ParameterDeclarations parameters, ExtensionContext context) {
       return addSystemQualifier(
           Stream.of(
               Arguments.of("SizeOf(Byte)", size(IntrinsicType.BYTE)),
@@ -290,7 +302,8 @@ class ExpressionsTest {
 
   static class CompilerVersionArgumentsProvider implements ArgumentsProvider {
     @Override
-    public Stream<Arguments> provideArguments(ExtensionContext context) {
+    public Stream<Arguments> provideArguments(
+        ParameterDeclarations parameters, ExtensionContext context) {
       return addSystemQualifier(Stream.of(Arguments.of("CompilerVersion", 30.0)));
     }
   }

--- a/delphi-frontend/src/test/java/au/com/integradev/delphi/symbol/resolve/TypeInferrerTest.java
+++ b/delphi-frontend/src/test/java/au/com/integradev/delphi/symbol/resolve/TypeInferrerTest.java
@@ -43,6 +43,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.ArgumentsProvider;
 import org.junit.jupiter.params.provider.ArgumentsSource;
+import org.junit.jupiter.params.support.ParameterDeclarations;
 import org.sonar.plugins.communitydelphi.api.ast.CommonDelphiNode;
 import org.sonar.plugins.communitydelphi.api.ast.ExpressionNode;
 import org.sonar.plugins.communitydelphi.api.type.IntrinsicType;
@@ -56,7 +57,8 @@ class TypeInferrerTest {
 
   static class ArrayConstructorArgumentsProvider implements ArgumentsProvider {
     @Override
-    public Stream<Arguments> provideArguments(ExtensionContext context) {
+    public Stream<Arguments> provideArguments(
+        ParameterDeclarations parameters, ExtensionContext context) {
       return Stream.of(
           Arguments.of(arrayConstructor(), dynamicArrayType(TypeFactory.voidType())),
           Arguments.of(
@@ -171,7 +173,8 @@ class TypeInferrerTest {
 
   static class IntegerArgumentsProvider implements ArgumentsProvider {
     @Override
-    public Stream<Arguments> provideArguments(ExtensionContext context) {
+    public Stream<Arguments> provideArguments(
+        ParameterDeclarations parameters, ExtensionContext context) {
       return Stream.of(
           Arguments.of(integerLiteral("-2147483649"), intrinsicType(IntrinsicType.INT64)),
           Arguments.of(integerLiteral("-2147483648"), intrinsicType(IntrinsicType.INTEGER)),
@@ -198,7 +201,8 @@ class TypeInferrerTest {
 
   static class ProceduralArgumentsProvider implements ArgumentsProvider {
     @Override
-    public Stream<Arguments> provideArguments(ExtensionContext context) {
+    public Stream<Arguments> provideArguments(
+        ParameterDeclarations parameters, ExtensionContext context) {
       Type integer = intrinsicType(IntrinsicType.INTEGER);
       ExpressionNode voidProcedural = procedural(TypeFactory.voidType());
 
@@ -210,7 +214,8 @@ class TypeInferrerTest {
 
   static class RealArgumentsProvider implements ArgumentsProvider {
     @Override
-    public Stream<Arguments> provideArguments(ExtensionContext context) {
+    public Stream<Arguments> provideArguments(
+        ParameterDeclarations parameters, ExtensionContext context) {
       Type extended = intrinsicType(IntrinsicType.EXTENDED);
       Type comp = intrinsicType(IntrinsicType.COMP);
       Type currency = intrinsicType(IntrinsicType.CURRENCY);

--- a/delphi-frontend/src/test/java/au/com/integradev/delphi/type/TypeFactoryTest.java
+++ b/delphi-frontend/src/test/java/au/com/integradev/delphi/type/TypeFactoryTest.java
@@ -31,6 +31,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.ArgumentsProvider;
 import org.junit.jupiter.params.provider.ArgumentsSource;
+import org.junit.jupiter.params.support.ParameterDeclarations;
 import org.sonar.plugins.communitydelphi.api.type.IntrinsicType;
 import org.sonar.plugins.communitydelphi.api.type.Type;
 import org.sonar.plugins.communitydelphi.api.type.TypeFactory;
@@ -47,14 +48,16 @@ class TypeFactoryTest {
 
   static class RealSizeArgumentsProvider implements ArgumentsProvider {
     @Override
-    public Stream<Arguments> provideArguments(ExtensionContext context) {
+    public Stream<Arguments> provideArguments(
+        ParameterDeclarations parameters, ExtensionContext context) {
       return Stream.of(Arguments.of(VERSION_3, 6), Arguments.of(VERSION_4, 8));
     }
   }
 
   static class ExtendedSizeArgumentsProvider implements ArgumentsProvider {
     @Override
-    public Stream<Arguments> provideArguments(ExtensionContext context) {
+    public Stream<Arguments> provideArguments(
+        ParameterDeclarations parameters, ExtensionContext context) {
       return Stream.of(
           Arguments.of(Toolchain.DCCOSX, 16),
           Arguments.of(Toolchain.DCCIOS32, 16),
@@ -70,7 +73,8 @@ class TypeFactoryTest {
 
   static class LongSizeArgumentsProvider implements ArgumentsProvider {
     @Override
-    public Stream<Arguments> provideArguments(ExtensionContext context) {
+    public Stream<Arguments> provideArguments(
+        ParameterDeclarations parameters, ExtensionContext context) {
       return Stream.of(
           Arguments.of(Toolchain.DCC32, VERSION_XE7, 4),
           Arguments.of(Toolchain.DCC64, VERSION_XE7, 4),
@@ -85,7 +89,8 @@ class TypeFactoryTest {
 
   static class NativeSizeArgumentsProvider implements ArgumentsProvider {
     @Override
-    public Stream<Arguments> provideArguments(ExtensionContext context) {
+    public Stream<Arguments> provideArguments(
+        ParameterDeclarations parameters, ExtensionContext context) {
       return Stream.of(
           Arguments.of(Toolchain.DCC32, VERSION_2007, 8),
           Arguments.of(Toolchain.DCC64, VERSION_2007, 8),
@@ -96,14 +101,16 @@ class TypeFactoryTest {
 
   static class PointerSizeArgumentsProvider implements ArgumentsProvider {
     @Override
-    public Stream<Arguments> provideArguments(ExtensionContext context) {
+    public Stream<Arguments> provideArguments(
+        ParameterDeclarations parameters, ExtensionContext context) {
       return Stream.of(Arguments.of(Toolchain.DCC32, 4), Arguments.of(Toolchain.DCC64, 8));
     }
   }
 
   static class StringTypeArgumentsProvider implements ArgumentsProvider {
     @Override
-    public Stream<Arguments> provideArguments(ExtensionContext context) {
+    public Stream<Arguments> provideArguments(
+        ParameterDeclarations parameters, ExtensionContext context) {
       return Stream.of(
           Arguments.of(VERSION_2007, "System.AnsiString"),
           Arguments.of(VERSION_2009, "System.UnicodeString"));
@@ -112,7 +119,8 @@ class TypeFactoryTest {
 
   static class CharTypeArgumentsProvider implements ArgumentsProvider {
     @Override
-    public Stream<Arguments> provideArguments(ExtensionContext context) {
+    public Stream<Arguments> provideArguments(
+        ParameterDeclarations parameters, ExtensionContext context) {
       return Stream.of(
           Arguments.of(VERSION_2007, "System.AnsiChar"),
           Arguments.of(VERSION_2009, "System.WideChar"));

--- a/delphi-frontend/src/test/java/au/com/integradev/delphi/type/factory/TypeAliasGeneratorTest.java
+++ b/delphi-frontend/src/test/java/au/com/integradev/delphi/type/factory/TypeAliasGeneratorTest.java
@@ -39,6 +39,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.ArgumentsProvider;
 import org.junit.jupiter.params.provider.ArgumentsSource;
+import org.junit.jupiter.params.support.ParameterDeclarations;
 import org.sonar.plugins.communitydelphi.api.symbol.scope.DelphiScope;
 import org.sonar.plugins.communitydelphi.api.type.IntrinsicType;
 import org.sonar.plugins.communitydelphi.api.type.StructKind;
@@ -77,7 +78,8 @@ class TypeAliasGeneratorTest {
 
   static class AliasedTypeProvider implements ArgumentsProvider {
     @Override
-    public Stream<Arguments> provideArguments(ExtensionContext context) {
+    public Stream<Arguments> provideArguments(
+        ParameterDeclarations parameters, ExtensionContext context) {
       return Stream.of(
           Arguments.of(FACTORY.set(BYTE), CollectionType.class),
           Arguments.of(TypeMocker.struct(ALIASED_NAME, StructKind.CLASS), StructType.class),

--- a/delphi-frontend/src/test/java/au/com/integradev/delphi/type/generic/constraint/ClassConstraintTest.java
+++ b/delphi-frontend/src/test/java/au/com/integradev/delphi/type/generic/constraint/ClassConstraintTest.java
@@ -33,6 +33,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.ArgumentsProvider;
 import org.junit.jupiter.params.provider.ArgumentsSource;
+import org.junit.jupiter.params.support.ParameterDeclarations;
 import org.sonar.plugins.communitydelphi.api.type.Constraint;
 import org.sonar.plugins.communitydelphi.api.type.IntrinsicType;
 import org.sonar.plugins.communitydelphi.api.type.Type;
@@ -43,7 +44,8 @@ class ClassConstraintTest {
 
   private static class SatisfiedArgumentsProvider implements ArgumentsProvider {
     @Override
-    public Stream<Arguments> provideArguments(ExtensionContext context) {
+    public Stream<Arguments> provideArguments(
+        ParameterDeclarations parameters, ExtensionContext context) {
       return Stream.of(
           Arguments.of(TypeMocker.struct("TBar", CLASS)),
           Arguments.of(TypeParameterTypeImpl.create("T", List.of(ClassConstraintImpl.instance()))),
@@ -63,7 +65,8 @@ class ClassConstraintTest {
 
   private static class ViolatedArgumentsProvider implements ArgumentsProvider {
     @Override
-    public Stream<Arguments> provideArguments(ExtensionContext context) {
+    public Stream<Arguments> provideArguments(
+        ParameterDeclarations parameters, ExtensionContext context) {
       return Stream.of(
           Arguments.of(FACTORY.getIntrinsic(IntrinsicType.BYTE)),
           Arguments.of(FACTORY.getIntrinsic(IntrinsicType.STRING)),

--- a/delphi-frontend/src/test/java/au/com/integradev/delphi/type/generic/constraint/ConstructorConstraintTest.java
+++ b/delphi-frontend/src/test/java/au/com/integradev/delphi/type/generic/constraint/ConstructorConstraintTest.java
@@ -39,6 +39,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.ArgumentsProvider;
 import org.junit.jupiter.params.provider.ArgumentsSource;
+import org.junit.jupiter.params.support.ParameterDeclarations;
 import org.sonar.plugins.communitydelphi.api.ast.Visibility.VisibilityType;
 import org.sonar.plugins.communitydelphi.api.symbol.declaration.NameDeclaration;
 import org.sonar.plugins.communitydelphi.api.symbol.declaration.RoutineKind;
@@ -57,7 +58,8 @@ class ConstructorConstraintTest {
 
   private static class SatisfiedArgumentsProvider implements ArgumentsProvider {
     @Override
-    public Stream<Arguments> provideArguments(ExtensionContext context) {
+    public Stream<Arguments> provideArguments(
+        ParameterDeclarations parameters, ExtensionContext context) {
       var defaultConstructor = constructor("Create", VisibilityType.PUBLIC);
       var lowercaseDefaultConstructor = constructor("create", VisibilityType.PUBLIC);
       return Stream.of(
@@ -82,7 +84,8 @@ class ConstructorConstraintTest {
 
   private static class ViolatedArgumentsProvider implements ArgumentsProvider {
     @Override
-    public Stream<Arguments> provideArguments(ExtensionContext context) {
+    public Stream<Arguments> provideArguments(
+        ParameterDeclarations parameters, ExtensionContext context) {
       var defaultConstructor = constructor("Create", VisibilityType.PUBLIC);
       var classWithDefaultConstructor = addDeclaration(mockClass(), defaultConstructor);
 

--- a/delphi-frontend/src/test/java/au/com/integradev/delphi/type/generic/constraint/InterfaceConstraintTest.java
+++ b/delphi-frontend/src/test/java/au/com/integradev/delphi/type/generic/constraint/InterfaceConstraintTest.java
@@ -34,6 +34,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.ArgumentsProvider;
 import org.junit.jupiter.params.provider.ArgumentsSource;
+import org.junit.jupiter.params.support.ParameterDeclarations;
 import org.sonar.plugins.communitydelphi.api.type.Constraint;
 import org.sonar.plugins.communitydelphi.api.type.IntrinsicType;
 import org.sonar.plugins.communitydelphi.api.type.Type;
@@ -44,7 +45,8 @@ class InterfaceConstraintTest {
 
   private static class SatisfiedArgumentsProvider implements ArgumentsProvider {
     @Override
-    public Stream<Arguments> provideArguments(ExtensionContext context) {
+    public Stream<Arguments> provideArguments(
+        ParameterDeclarations parameters, ExtensionContext context) {
       return Stream.of(
           Arguments.of(TypeMocker.struct("IFoo", INTERFACE)),
           Arguments.of(
@@ -54,7 +56,8 @@ class InterfaceConstraintTest {
 
   private static class ViolatedArgumentsProvider implements ArgumentsProvider {
     @Override
-    public Stream<Arguments> provideArguments(ExtensionContext context) {
+    public Stream<Arguments> provideArguments(
+        ParameterDeclarations parameters, ExtensionContext context) {
       return Stream.of(
           Arguments.of(FACTORY.getIntrinsic(IntrinsicType.BYTE)),
           Arguments.of(FACTORY.getIntrinsic(IntrinsicType.STRING)),

--- a/delphi-frontend/src/test/java/au/com/integradev/delphi/type/generic/constraint/RecordConstraintTest.java
+++ b/delphi-frontend/src/test/java/au/com/integradev/delphi/type/generic/constraint/RecordConstraintTest.java
@@ -34,6 +34,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.ArgumentsProvider;
 import org.junit.jupiter.params.provider.ArgumentsSource;
+import org.junit.jupiter.params.support.ParameterDeclarations;
 import org.sonar.plugins.communitydelphi.api.symbol.scope.DelphiScope;
 import org.sonar.plugins.communitydelphi.api.type.Constraint;
 import org.sonar.plugins.communitydelphi.api.type.IntrinsicType;
@@ -45,7 +46,8 @@ class RecordConstraintTest {
 
   private static class SatisfiedArgumentsProvider implements ArgumentsProvider {
     @Override
-    public Stream<Arguments> provideArguments(ExtensionContext context) {
+    public Stream<Arguments> provideArguments(
+        ParameterDeclarations parameters, ExtensionContext context) {
       Type integer = FACTORY.getIntrinsic(IntrinsicType.INTEGER);
       Type enumeration = ((TypeFactoryImpl) FACTORY).enumeration("", DelphiScope.unknownScope());
       return Stream.of(
@@ -65,7 +67,8 @@ class RecordConstraintTest {
 
   private static class ViolatedArgumentsProvider implements ArgumentsProvider {
     @Override
-    public Stream<Arguments> provideArguments(ExtensionContext context) {
+    public Stream<Arguments> provideArguments(
+        ParameterDeclarations parameters, ExtensionContext context) {
       return Stream.of(
           Arguments.of(FACTORY.getIntrinsic(IntrinsicType.STRING)),
           Arguments.of(TypeMocker.struct("TBar", CLASS)),

--- a/delphi-frontend/src/test/java/au/com/integradev/delphi/type/generic/constraint/TypeConstraintTest.java
+++ b/delphi-frontend/src/test/java/au/com/integradev/delphi/type/generic/constraint/TypeConstraintTest.java
@@ -33,6 +33,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.ArgumentsProvider;
 import org.junit.jupiter.params.provider.ArgumentsSource;
+import org.junit.jupiter.params.support.ParameterDeclarations;
 import org.sonar.plugins.communitydelphi.api.type.Constraint;
 import org.sonar.plugins.communitydelphi.api.type.Constraint.TypeConstraint;
 import org.sonar.plugins.communitydelphi.api.type.IntrinsicType;
@@ -49,7 +50,8 @@ class TypeConstraintTest {
 
   private static class SatisfiedArgumentsProvider implements ArgumentsProvider {
     @Override
-    public Stream<Arguments> provideArguments(ExtensionContext context) {
+    public Stream<Arguments> provideArguments(
+        ParameterDeclarations parameters, ExtensionContext context) {
       return Stream.of(
           Arguments.of(TBAR),
           Arguments.of(TBAZ),
@@ -68,7 +70,8 @@ class TypeConstraintTest {
 
   private static class ViolatedArgumentsProvider implements ArgumentsProvider {
     @Override
-    public Stream<Arguments> provideArguments(ExtensionContext context) {
+    public Stream<Arguments> provideArguments(
+        ParameterDeclarations parameters, ExtensionContext context) {
       return Stream.of(
           Arguments.of(FACTORY.getIntrinsic(IntrinsicType.BYTE)),
           Arguments.of(FACTORY.getIntrinsic(IntrinsicType.STRING)),

--- a/delphi-frontend/src/test/java/au/com/integradev/delphi/type/generic/constraint/UnmanagedConstraintTest.java
+++ b/delphi-frontend/src/test/java/au/com/integradev/delphi/type/generic/constraint/UnmanagedConstraintTest.java
@@ -36,6 +36,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.ArgumentsProvider;
 import org.junit.jupiter.params.provider.ArgumentsSource;
+import org.junit.jupiter.params.support.ParameterDeclarations;
 import org.sonar.plugins.communitydelphi.api.symbol.declaration.VariableNameDeclaration;
 import org.sonar.plugins.communitydelphi.api.symbol.scope.DelphiScope;
 import org.sonar.plugins.communitydelphi.api.type.Constraint;
@@ -49,7 +50,8 @@ class UnmanagedConstraintTest {
 
   private static class SatisfiedArgumentsProvider implements ArgumentsProvider {
     @Override
-    public Stream<Arguments> provideArguments(ExtensionContext context) {
+    public Stream<Arguments> provideArguments(
+        ParameterDeclarations parameters, ExtensionContext context) {
       Type integer = FACTORY.getIntrinsic(IntrinsicType.INTEGER);
       Type enumeration = ((TypeFactoryImpl) FACTORY).enumeration("", DelphiScope.unknownScope());
       return Stream.of(
@@ -76,7 +78,8 @@ class UnmanagedConstraintTest {
 
   private static class ViolatedArgumentsProvider implements ArgumentsProvider {
     @Override
-    public Stream<Arguments> provideArguments(ExtensionContext context) {
+    public Stream<Arguments> provideArguments(
+        ParameterDeclarations parameters, ExtensionContext context) {
       return Stream.of(
           Arguments.of(FACTORY.getIntrinsic(IntrinsicType.STRING)),
           Arguments.of(TypeMocker.struct("TBar", CLASS)),

--- a/delphi-frontend/src/test/java/org/sonar/plugins/communitydelphi/api/check/ScopeMetadataLoaderTest.java
+++ b/delphi-frontend/src/test/java/org/sonar/plugins/communitydelphi/api/check/ScopeMetadataLoaderTest.java
@@ -27,13 +27,15 @@ import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.ArgumentsProvider;
 import org.junit.jupiter.params.provider.ArgumentsSource;
 import org.junit.jupiter.params.provider.ValueSource;
+import org.junit.jupiter.params.support.ParameterDeclarations;
 import org.sonar.api.rule.RuleKey;
 import org.sonar.api.rule.RuleScope;
 
 class ScopeMetadataLoaderTest {
   static class ValidMetadataArgumentsProvider implements ArgumentsProvider {
     @Override
-    public Stream<Arguments> provideArguments(ExtensionContext context) {
+    public Stream<Arguments> provideArguments(
+        ParameterDeclarations parameters, ExtensionContext context) {
       return Stream.of(
           Arguments.of("AllScope", RuleScope.ALL),
           Arguments.of("DefaultScope", RuleScope.MAIN),

--- a/delphi-tokens-generator-maven-plugin/pom.xml
+++ b/delphi-tokens-generator-maven-plugin/pom.xml
@@ -16,7 +16,7 @@
   <name>SonarDelphi :: Delphi Tokens Generator Maven Plugin</name>
 
   <properties>
-    <maven.version>3.8.6</maven.version>
+    <maven.version>3.9.16</maven.version>
   </properties>
 
   <dependencies>
@@ -41,7 +41,7 @@
     <dependency>
       <groupId>org.apache.maven.plugin-tools</groupId>
       <artifactId>maven-plugin-annotations</artifactId>
-      <version>3.15.0</version>
+      <version>${maven-plugin-plugin.version}</version>
       <scope>provided</scope>
     </dependency>
     <dependency>
@@ -51,6 +51,11 @@
     <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-lang3</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>commons-io</groupId>
+      <artifactId>commons-io</artifactId>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.junit.jupiter</groupId>
@@ -69,7 +74,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-plugin-plugin</artifactId>
-        <version>3.6.0</version>
+        <version>${maven-plugin-plugin.version}</version>
         <executions>
           <execution>
             <id>mojo-descriptor</id>

--- a/docs/delphi-custom-rules-example/pom.xml
+++ b/docs/delphi-custom-rules-example/pom.xml
@@ -50,17 +50,17 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <sonar.delphi.version>1.19.0</sonar.delphi.version>
     <sonar.plugin.api.version>10.1.0.809</sonar.plugin.api.version>
-    <sonar.analyzer.commons.version>2.13.0.3004</sonar.analyzer.commons.version>
-    <slf4j.version>1.7.30</slf4j.version>
-    <junit.version>5.11.0</junit.version>
+    <sonar.analyzer.commons.version>2.29.0.5138</sonar.analyzer.commons.version>
+    <slf4j.version>1.7.36</slf4j.version>
+    <junit.version>5.14.4</junit.version>
     <assertj.version>3.27.7</assertj.version>
-    <mockito.version>5.13.0</mockito.version>
-    <compiler.plugin.version>3.13.0</compiler.plugin.version>
-    <jacoco.plugin.version>0.8.12</jacoco.plugin.version>
-    <fmt.plugin.version>2.24</fmt.plugin.version>
-    <license.plugin.version>4.5</license.plugin.version>
+    <mockito.version>5.23.0</mockito.version>
+    <compiler.plugin.version>3.15.0</compiler.plugin.version>
+    <jacoco.plugin.version>0.8.15</jacoco.plugin.version>
+    <fmt.plugin.version>2.29</fmt.plugin.version>
+    <license.plugin.version>5.1.1</license.plugin.version>
     <sonar.packaging.plugin.version>1.23.0.740</sonar.packaging.plugin.version>
-    <shade.plugin.version>3.5.1</shade.plugin.version>
+    <shade.plugin.version>3.6.2</shade.plugin.version>
   </properties>
 
   <dependencies>

--- a/license-maven-plugin/pom.xml
+++ b/license-maven-plugin/pom.xml
@@ -16,7 +16,7 @@
   <name>SonarDelphi :: License Maven Plugin</name>
 
   <properties>
-    <maven.version>3.8.6</maven.version>
+    <maven.version>3.9.16</maven.version>
   </properties>
 
   <dependencies>
@@ -41,7 +41,7 @@
     <dependency>
       <groupId>org.apache.maven.plugin-tools</groupId>
       <artifactId>maven-plugin-annotations</artifactId>
-      <version>3.15.0</version>
+      <version>${maven-plugin-plugin.version}</version>
       <scope>provided</scope>
     </dependency>
   </dependencies>
@@ -51,7 +51,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-plugin-plugin</artifactId>
-        <version>3.6.0</version>
+        <version>${maven-plugin-plugin.version}</version>
         <executions>
           <execution>
             <id>mojo-descriptor</id>

--- a/pom.xml
+++ b/pom.xml
@@ -102,7 +102,7 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <maven.min.version>3.3.9</maven.min.version>
+    <maven.min.version>3.6.3</maven.min.version>
     <jdk.min.version>25</jdk.min.version>
     <skipITs>true</skipITs>
     <!-- SonarCloud scan -->
@@ -114,41 +114,43 @@
     <!-- Dependency versions -->
     <sonarqube.version>10.7.0.96327</sonarqube.version>
     <sonar-plugin-api.version>10.1.0.809</sonar-plugin-api.version>
-    <sonar-analyzer-commons.version>2.13.0.3004</sonar-analyzer-commons.version>
-    <sonar-orchestrator.version>5.6.1.2597</sonar-orchestrator.version>
+    <sonar-analyzer-commons.version>2.29.0.5138</sonar-analyzer-commons.version>
+    <sonar-orchestrator.version>6.4.0.4580</sonar-orchestrator.version>
     <antlr-runtime.version>3.5.3</antlr-runtime.version>
-    <commons-text.version>1.12.0</commons-text.version>
+    <commons-text.version>1.15.0</commons-text.version>
     <jdom.version>2.0.6.1</jdom.version>
-    <gson.version>2.11.0</gson.version>
+    <gson.version>2.14.0</gson.version>
     <jsr305.version>3.0.2</jsr305.version>
-    <guava.version>33.3.0-jre</guava.version>
-    <commons-lang.version>3.18.0</commons-lang.version>
-    <commons-io.version>2.17.0</commons-io.version>
-    <byte-buddy.version>1.15.1</byte-buddy.version>
-    <junit.version>5.11.0</junit.version>
-    <junit-platform-suite-engine.version>1.11.0</junit-platform-suite-engine.version>
+    <guava.version>33.6.0-jre</guava.version>
+    <commons-lang.version>3.20.0</commons-lang.version>
+    <commons-io.version>2.22.0</commons-io.version>
+    <byte-buddy.version>1.18.11</byte-buddy.version>
+    <junit.version>5.14.4</junit.version>
+    <junit-platform-suite-engine.version>1.14.4</junit-platform-suite-engine.version>
     <assertj.version>3.27.7</assertj.version>
-    <mockito.version>5.13.0</mockito.version>
-    <archunit.version>1.3.0</archunit.version>
-    <errorprone.version>2.32.0</errorprone.version>
-    <slf4j.version>1.7.30</slf4j.version>
+    <mockito.version>5.23.0</mockito.version>
+    <archunit.version>1.5.0</archunit.version>
+    <errorprone.version>2.50.0</errorprone.version>
+    <slf4j.version>1.7.36</slf4j.version>
     <!-- Plugin versions -->
-    <compiler-plugin.version>3.13.0</compiler-plugin.version>
-    <jacoco-plugin.version>0.8.12</jacoco-plugin.version>
-    <surefire-plugin.version>3.5.0</surefire-plugin.version>
-    <enforcer-plugin.version>3.5.0</enforcer-plugin.version>
+    <compiler-plugin.version>3.15.0</compiler-plugin.version>
+    <jacoco-plugin.version>0.8.15</jacoco-plugin.version>
+    <surefire-plugin.version>3.5.6</surefire-plugin.version>
+    <enforcer-plugin.version>3.6.3</enforcer-plugin.version>
     <sonar-packaging-plugin.version>1.23.0.740</sonar-packaging-plugin.version>
-    <spotless-plugin.version>2.43.0</spotless-plugin.version>
+    <spotless-plugin.version>3.9.0</spotless-plugin.version>
+    <google-java-format.version>1.36.1</google-java-format.version>
     <antlr3-plugin.version>3.5.3</antlr3-plugin.version>
-    <build-helper-plugin.version>3.6.0</build-helper-plugin.version>
+    <build-helper-plugin.version>3.6.1</build-helper-plugin.version>
     <replacer-plugin.version>1.5.3</replacer-plugin.version>
-    <shade-plugin.version>3.5.1</shade-plugin.version>
-    <versions-plugin.version>2.17.1</versions-plugin.version>
+    <shade-plugin.version>3.6.2</shade-plugin.version>
+    <versions-plugin.version>2.21.0</versions-plugin.version>
     <keepachangelog-plugin.version>2.1.1</keepachangelog-plugin.version>
-    <source-plugin.version>3.3.0</source-plugin.version>
-    <javadoc-plugin.version>3.6.3</javadoc-plugin.version>
-    <gpg-plugin.version>3.1.0</gpg-plugin.version>
-    <central-publishing-plugin.version>0.8.0</central-publishing-plugin.version>
+    <maven-plugin-plugin.version>3.15.2</maven-plugin-plugin.version>
+    <source-plugin.version>3.4.0</source-plugin.version>
+    <javadoc-plugin.version>3.12.0</javadoc-plugin.version>
+    <gpg-plugin.version>3.2.8</gpg-plugin.version>
+    <central-publishing-plugin.version>0.11.0</central-publishing-plugin.version>
   </properties>
 
   <dependencyManagement>
@@ -372,9 +374,10 @@
           <fork>true</fork>
           <compilerArgs>
             <arg>-XDcompilePolicy=simple</arg>
+            <arg>--should-stop=ifError=FLOW</arg>
             <arg>-Werror</arg>
             <arg>-Xlint:all,-serial,-processing,-classfile,-path</arg>
-            <arg>-Xplugin:ErrorProne -XepExcludedPaths:.*/generated-sources/.* -Xep:UnicodeInCode:OFF -Xep:CanIgnoreReturnValueSuggester:OFF -Xep:StringCaseLocaleUsage:OFF -Xep:EnumOrdinal:OFF</arg>
+            <arg>-Xplugin:ErrorProne -XepExcludedPaths:.*/generated-sources/.* -Xep:UnicodeInCode:OFF -Xep:CanIgnoreReturnValueSuggester:OFF -Xep:StringCaseLocaleUsage:OFF -Xep:EnumOrdinal:OFF -Xep:ReferenceEquality:OFF -Xep:EffectivelyPrivate:OFF -Xep:FormatStringShouldUsePlaceholders:OFF -Xep:AssignmentExpression:OFF</arg>
             <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED</arg>
             <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED</arg>
             <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.main=ALL-UNNAMED</arg>
@@ -463,7 +466,7 @@
         <configuration>
           <java>
             <googleJavaFormat>
-              <version>1.26.0</version>
+              <version>${google-java-format.version}</version>
               <style>GOOGLE</style>
               <reflowLongStrings>true</reflowLongStrings>
             </googleJavaFormat>

--- a/pom.xml
+++ b/pom.xml
@@ -103,7 +103,7 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.min.version>3.3.9</maven.min.version>
-    <jdk.min.version>17</jdk.min.version>
+    <jdk.min.version>25</jdk.min.version>
     <skipITs>true</skipITs>
     <!-- SonarCloud scan -->
     <sonar.organization>integrated-application-development</sonar.organization>


### PR DESCRIPTION
This PR migrates the project from JDK 17 to JDK 25, upgrading most dependencies in the process.

Upgrades:
- Required JDK (17 -> 25)
- Required Maven (3.3.9 -> 3.6.3)
- Various maven libraries
- Various maven plugins

