### PR TITLE
Fix format workflow syntax

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -1,6 +1,7 @@
 name: Format
 
 on:
+  push:
     branches:
       - 'master'
     paths:


### PR DESCRIPTION
Fixes a syntax error in the format action's workflow file, inadvertently introduced in #451. 