### PR TITLE
Fix obscure symbol reassociation bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Incorrect token image on `>=` and `<=` operators.
 - Incorrect branch selection around `{$IF}` conditions that can't be evaluated at compile time.
+- Obscure bug where name resolution could occur in the wrong lexical scope.
 
 ## [1.20.0] - 2026-08-12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Support for the `is not` operator, introduced in Delphi 13.
 - Support for the `not in` operator, introduced in Delphi 13.
+- **API:** `Node::getNodeId` method.
 - **API:** `OperatorNode` node type.
 - **API:** `BinaryOperatorNode` node type.
 - **API:** `UnaryOperatorNode` node type.

--- a/delphi-frontend/src/main/java/au/com/integradev/delphi/antlr/ast/DelphiAstImpl.java
+++ b/delphi-frontend/src/main/java/au/com/integradev/delphi/antlr/ast/DelphiAstImpl.java
@@ -52,6 +52,7 @@ public class DelphiAstImpl extends DelphiNodeImpl implements DelphiAst {
     if (root != null) {
       root.getChildren().forEach(ast::addChild);
     }
+    ast.initializeNodeIds();
     return ast;
   }
 

--- a/delphi-frontend/src/main/java/au/com/integradev/delphi/antlr/ast/node/DelphiNodeImpl.java
+++ b/delphi-frontend/src/main/java/au/com/integradev/delphi/antlr/ast/node/DelphiNodeImpl.java
@@ -44,6 +44,7 @@ public abstract class DelphiNodeImpl implements MutableDelphiNode {
   protected DelphiNode parent;
   private List<DelphiNode> children;
   private int childIndex;
+  private int nodeId = -1;
   private DelphiToken firstToken;
   private DelphiToken lastToken;
   private DelphiScope scope;
@@ -143,6 +144,11 @@ public abstract class DelphiNodeImpl implements MutableDelphiNode {
   }
 
   @Override
+  public final int getNodeId() {
+    return nodeId;
+  }
+
+  @Override
   public DelphiToken getToken() {
     return token;
   }
@@ -192,6 +198,20 @@ public abstract class DelphiNodeImpl implements MutableDelphiNode {
       }
     }
     return result;
+  }
+
+  protected final void initializeNodeIds() {
+    assignNodeIds(0);
+  }
+
+  private int assignNodeIds(int nextNodeId) {
+    this.nodeId = nextNodeId++;
+
+    for (DelphiNode child : getChildren()) {
+      nextNodeId = ((DelphiNodeImpl) child).assignNodeIds(nextNodeId);
+    }
+
+    return nextNodeId;
   }
 
   @Override

--- a/delphi-frontend/src/main/java/au/com/integradev/delphi/symbol/SymbolicNode.java
+++ b/delphi-frontend/src/main/java/au/com/integradev/delphi/symbol/SymbolicNode.java
@@ -27,8 +27,9 @@ import org.sonar.plugins.communitydelphi.api.symbol.scope.FileScope;
 import org.sonar.plugins.communitydelphi.api.token.DelphiTokenType;
 
 public final class SymbolicNode implements Node {
-  private static final AtomicInteger IMAGINARY_TOKEN_INDEX = new AtomicInteger(Integer.MIN_VALUE);
+  private static final AtomicInteger IMAGINARY_NODE_ID = new AtomicInteger(Integer.MIN_VALUE);
   private final DelphiTokenType tokenType;
+  private final int nodeId;
   private final int tokenIndex;
   private final String image;
   private final int beginLine;
@@ -44,6 +45,7 @@ public final class SymbolicNode implements Node {
 
   public SymbolicNode(DelphiNode node, DelphiScope scope) {
     this(
+        node.getNodeId(),
         node.getTokenType(),
         node.getTokenIndex(),
         node.getImage(),
@@ -56,6 +58,7 @@ public final class SymbolicNode implements Node {
   }
 
   private SymbolicNode(
+      int nodeId,
       DelphiTokenType tokenType,
       int tokenIndex,
       String image,
@@ -65,6 +68,7 @@ public final class SymbolicNode implements Node {
       int endColumn,
       DelphiScope scope,
       boolean isIncludedNode) {
+    this.nodeId = nodeId;
     this.tokenType = tokenType;
     this.tokenIndex = tokenIndex;
     this.image = image;
@@ -78,8 +82,9 @@ public final class SymbolicNode implements Node {
 
   public static SymbolicNode imaginary(String image, DelphiScope scope) {
     return new SymbolicNode(
+        IMAGINARY_NODE_ID.incrementAndGet(),
         DelphiTokenType.INVALID,
-        IMAGINARY_TOKEN_INDEX.incrementAndGet(),
+        -1,
         image,
         0,
         0,
@@ -91,6 +96,7 @@ public final class SymbolicNode implements Node {
 
   public static SymbolicNode fromRange(String image, DelphiNode begin, DelphiNode end) {
     return new SymbolicNode(
+        begin.getNodeId(),
         begin.getTokenType(),
         begin.getTokenIndex(),
         image,
@@ -100,6 +106,11 @@ public final class SymbolicNode implements Node {
         end.getEndColumn(),
         begin.getScope(),
         begin.getFirstToken().isIncludedToken() || end.getFirstToken().isIncludedToken());
+  }
+
+  @Override
+  public int getNodeId() {
+    return nodeId;
   }
 
   @Override

--- a/delphi-frontend/src/main/java/au/com/integradev/delphi/symbol/resolve/NameResolver.java
+++ b/delphi-frontend/src/main/java/au/com/integradev/delphi/symbol/resolve/NameResolver.java
@@ -532,7 +532,7 @@ public class NameResolver {
     for (int i = 0; i < typeParameters.size(); ++i) {
       TypedDeclaration declaration = typeParameters.get(i);
       NameReferenceNode typeReference = typeReferences.get(i).getNameNode();
-      NameOccurrenceImpl occurrence = new NameOccurrenceImpl(typeReference);
+      NameOccurrenceImpl occurrence = new NameOccurrenceImpl(typeReference.getIdentifier());
 
       occurrence.setNameDeclaration(declaration);
       ((NameReferenceNodeImpl) typeReference).setNameOccurrence(occurrence);
@@ -552,7 +552,7 @@ public class NameResolver {
       NameDeclaration declaration = new TypeParameterNameDeclarationImpl(typeReference, type);
       ((DelphiScopeImpl) routineScope).addDeclaration(declaration);
 
-      NameOccurrenceImpl occurrence = new NameOccurrenceImpl(typeReference);
+      NameOccurrenceImpl occurrence = new NameOccurrenceImpl(typeReference.getIdentifier());
       occurrence.setNameDeclaration(declaration);
       ((NameReferenceNodeImpl) typeReference).setNameOccurrence(occurrence);
 
@@ -784,7 +784,7 @@ public class NameResolver {
     SymbolicNode symbolicNode =
         SymbolicNode.fromRange(
             referenceImage.toString(),
-            node,
+            node.getIdentifier(),
             references.get(declarationParts.size() - 1).getIdentifier());
 
     NameOccurrenceImpl occurrence = new NameOccurrenceImpl(symbolicNode);

--- a/delphi-frontend/src/main/java/au/com/integradev/delphi/symbol/scope/FileScopeImpl.java
+++ b/delphi-frontend/src/main/java/au/com/integradev/delphi/symbol/scope/FileScopeImpl.java
@@ -146,7 +146,7 @@ public abstract class FileScopeImpl extends DelphiScopeImpl implements FileScope
    * @param scope The scope we want to associate the node to
    */
   public void registerScope(Node node, DelphiScope scope) {
-    registeredScopes.put(node.getTokenIndex(), scope);
+    registeredScopes.put(node.getNodeId(), scope);
   }
 
   /**
@@ -156,7 +156,7 @@ public abstract class FileScopeImpl extends DelphiScopeImpl implements FileScope
    * @param declaration The declaration we are registering
    */
   public void registerDeclaration(Node node, NameDeclaration declaration) {
-    registeredDeclarations.put(node.getTokenIndex(), declaration);
+    registeredDeclarations.put(node.getNodeId(), declaration);
   }
 
   /**
@@ -166,7 +166,7 @@ public abstract class FileScopeImpl extends DelphiScopeImpl implements FileScope
    * @param occurrence The occurrence we are registering
    */
   public void registerOccurrence(Node node, NameOccurrence occurrence) {
-    registeredOccurrences.put(node.getTokenIndex(), occurrence);
+    registeredOccurrences.put(node.getNodeId(), occurrence);
   }
 
   /**
@@ -177,7 +177,7 @@ public abstract class FileScopeImpl extends DelphiScopeImpl implements FileScope
    * @param occurrence The occurrence we are registering
    */
   public void registerOccurrence(ForInStatementNode node, EnumeratorOccurrence occurrence) {
-    registeredEnumeratorOccurrences.put(node.getTokenIndex(), occurrence);
+    registeredEnumeratorOccurrences.put(node.getNodeId(), occurrence);
   }
 
   /**
@@ -186,7 +186,7 @@ public abstract class FileScopeImpl extends DelphiScopeImpl implements FileScope
    * @param node The node which we want to attach symbol information to
    */
   public void attach(MutableDelphiNode node) {
-    node.setScope(registeredScopes.get(node.getTokenIndex()));
+    node.setScope(registeredScopes.get(node.getNodeId()));
   }
 
   /**
@@ -196,7 +196,7 @@ public abstract class FileScopeImpl extends DelphiScopeImpl implements FileScope
    */
   public void attach(NameDeclarationNode node) {
     ((NameDeclarationNodeImpl) node)
-        .setNameDeclaration(registeredDeclarations.get(node.getTokenIndex()));
+        .setNameDeclaration(registeredDeclarations.get(node.getNodeId()));
   }
 
   /**
@@ -205,7 +205,9 @@ public abstract class FileScopeImpl extends DelphiScopeImpl implements FileScope
    * @param node The node which we want to attach symbol information to
    */
   public void attach(RoutineNameNode node) {
-    var declaration = (RoutineNameDeclaration) registeredDeclarations.get(node.getTokenIndex());
+    NameDeclarationNode nameNode = node.getNameDeclarationNode();
+    int nodeId = nameNode == null ? node.getNodeId() : nameNode.getNodeId();
+    var declaration = (RoutineNameDeclaration) registeredDeclarations.get(nodeId);
     ((RoutineNameNodeImpl) node).setRoutineNameDeclaration(declaration);
   }
 
@@ -232,7 +234,7 @@ public abstract class FileScopeImpl extends DelphiScopeImpl implements FileScope
    */
   public void attach(NameReferenceNode node) {
     ((NameReferenceNodeImpl) node)
-        .setNameOccurrence(registeredOccurrences.get(node.getTokenIndex()));
+        .setNameOccurrence(registeredOccurrences.get(node.getIdentifier().getNodeId()));
   }
 
   /**
@@ -242,7 +244,7 @@ public abstract class FileScopeImpl extends DelphiScopeImpl implements FileScope
    */
   public void attach(ArrayAccessorNode node) {
     ((ArrayAccessorNodeImpl) node)
-        .setImplicitNameOccurrence(registeredOccurrences.get(node.getTokenIndex()));
+        .setImplicitNameOccurrence(registeredOccurrences.get(node.getNodeId()));
   }
 
   /**
@@ -252,7 +254,7 @@ public abstract class FileScopeImpl extends DelphiScopeImpl implements FileScope
    */
   public void attach(ForInStatementNode node) {
     ((ForInStatementNodeImpl) node)
-        .setEnumeratorOccurrence(registeredEnumeratorOccurrences.get(node.getTokenIndex()));
+        .setEnumeratorOccurrence(registeredEnumeratorOccurrences.get(node.getNodeId()));
   }
 
   @Override

--- a/delphi-frontend/src/main/java/org/sonar/plugins/communitydelphi/api/ast/Node.java
+++ b/delphi-frontend/src/main/java/org/sonar/plugins/communitydelphi/api/ast/Node.java
@@ -22,10 +22,17 @@ import org.sonar.plugins.communitydelphi.api.symbol.scope.DelphiScope;
 import org.sonar.plugins.communitydelphi.api.token.DelphiTokenType;
 
 public interface Node {
+  /**
+   * Returns the node's unique id
+   *
+   * @return Node id
+   */
+  int getNodeId();
+
   DelphiTokenType getTokenType();
 
   /**
-   * Returns the node's unique token index
+   * Returns the token index of this node's first concrete token
    *
    * @return Token index
    */

--- a/delphi-frontend/src/test/java/au/com/integradev/delphi/antlr/ast/DelphiAstTest.java
+++ b/delphi-frontend/src/test/java/au/com/integradev/delphi/antlr/ast/DelphiAstTest.java
@@ -30,6 +30,9 @@ import au.com.integradev.delphi.antlr.ast.visitors.DelphiParserVisitor;
 import au.com.integradev.delphi.file.DelphiFile;
 import au.com.integradev.delphi.utils.DelphiUtils;
 import au.com.integradev.delphi.utils.files.DelphiFileUtils;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
 import org.junit.jupiter.api.Test;
 import org.sonar.plugins.communitydelphi.api.ast.DelphiAst;
 import org.sonar.plugins.communitydelphi.api.ast.DelphiNode;
@@ -51,10 +54,42 @@ class DelphiAstTest {
     checkTypes(ast);
   }
 
+  @Test
+  void testNodeIdsAreUniqueAndStableAcrossEquivalentBuilds() {
+    DelphiAst reparsed =
+        DelphiFile.from(DelphiUtils.getResource(TEST_FILE), DelphiFileUtils.mockConfig()).getAst();
+
+    List<DelphiNode> originalNodes = flatten(ast);
+    List<DelphiNode> reparsedNodes = flatten(reparsed);
+    List<Integer> tokenIndices =
+        originalNodes.stream().map(DelphiNode::getTokenIndex).collect(Collectors.toList());
+
+    assertThat(originalNodes).hasSameSizeAs(reparsedNodes);
+    assertThat(tokenIndices.stream().distinct().count()).isLessThan(tokenIndices.size());
+    assertThat(originalNodes).extracting(DelphiNode::getNodeId).doesNotHaveDuplicates();
+    assertThat(originalNodes.stream().map(DelphiNode::getNodeId).collect(Collectors.toList()))
+        .containsExactlyElementsOf(
+            reparsedNodes.stream().map(DelphiNode::getNodeId).collect(Collectors.toList()));
+  }
+
   private static void checkTypes(DelphiNode node) {
     assertThat(node).isInstanceOf(DelphiNode.class);
     for (DelphiNode child : node.getChildren()) {
       checkTypes(child);
+    }
+  }
+
+  private static List<DelphiNode> flatten(DelphiNode node) {
+    List<DelphiNode> nodes = new ArrayList<>();
+    flatten(node, nodes);
+    return nodes;
+  }
+
+  private static void flatten(DelphiNode node, List<DelphiNode> nodes) {
+    nodes.add(node);
+
+    for (DelphiNode child : node.getChildren()) {
+      flatten(child, nodes);
     }
   }
 }

--- a/delphi-frontend/src/test/java/au/com/integradev/delphi/antlr/ast/visitors/SymbolAssociationVisitorTest.java
+++ b/delphi-frontend/src/test/java/au/com/integradev/delphi/antlr/ast/visitors/SymbolAssociationVisitorTest.java
@@ -1,0 +1,351 @@
+/*
+ * Sonar Delphi Plugin
+ * Copyright (C) 2026 Integrated Application Development
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02
+ */
+package au.com.integradev.delphi.antlr.ast.visitors;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import au.com.integradev.delphi.DelphiProperties;
+import au.com.integradev.delphi.compiler.Platform;
+import au.com.integradev.delphi.file.DelphiFile;
+import au.com.integradev.delphi.preprocessor.DelphiPreprocessorFactory;
+import au.com.integradev.delphi.symbol.SymbolTable;
+import au.com.integradev.delphi.type.factory.TypeFactoryImpl;
+import au.com.integradev.delphi.utils.files.DelphiFileUtils;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.apache.commons.lang3.StringUtils;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.sonar.plugins.communitydelphi.api.ast.ArrayAccessorNode;
+import org.sonar.plugins.communitydelphi.api.ast.DelphiAst;
+import org.sonar.plugins.communitydelphi.api.ast.DelphiNode;
+import org.sonar.plugins.communitydelphi.api.ast.ForInStatementNode;
+import org.sonar.plugins.communitydelphi.api.ast.NameDeclarationNode;
+import org.sonar.plugins.communitydelphi.api.ast.NameReferenceNode;
+import org.sonar.plugins.communitydelphi.api.ast.RoutineImplementationNode;
+import org.sonar.plugins.communitydelphi.api.ast.RoutineNameNode;
+import org.sonar.plugins.communitydelphi.api.ast.StructTypeNode;
+import org.sonar.plugins.communitydelphi.api.ast.VarDeclarationNode;
+import org.sonar.plugins.communitydelphi.api.symbol.scope.RoutineScope;
+import org.sonar.plugins.communitydelphi.api.symbol.scope.TypeScope;
+
+class SymbolAssociationVisitorTest {
+  @TempDir private Path tempDir;
+
+  @Test
+  void testScopesAreAttached() {
+    DelphiAst ast =
+        associate(
+            "unit Test;",
+            "interface",
+            "type",
+            "  TFoo = class(TObject)",
+            "    procedure Bar;",
+            "  end;",
+            "implementation",
+            "procedure TFoo.Bar;",
+            "begin",
+            "end;",
+            "end.");
+
+    assertThat(descendant(ast, StructTypeNode.class).getScope()).isInstanceOf(TypeScope.class);
+    assertThat(descendant(ast, RoutineImplementationNode.class).getScope())
+        .isInstanceOf(RoutineScope.class);
+  }
+
+  @Test
+  void testNameDeclarationsAreAttached() {
+    DelphiAst ast =
+        associate(
+            "unit Test;", //
+            "interface",
+            "var",
+            "  GFoo: Integer;",
+            "implementation",
+            "end.");
+
+    NameDeclarationNode declaration =
+        descendant(ast, VarDeclarationNode.class).getNameDeclarationList().getDeclarations().get(0);
+
+    assertThat(declaration.getNameDeclaration()).isNotNull();
+  }
+
+  @Test
+  void testNameReferenceOccurrencesAreAttached() {
+    DelphiAst ast =
+        associate(
+            "unit Test;",
+            "interface",
+            "var",
+            "  GFoo: Integer;",
+            "implementation",
+            "procedure Bar;",
+            "begin",
+            "  GFoo := 0;",
+            "  Exit;",
+            "end;",
+            "end.");
+
+    assertThat(nameReference(ast, "GFoo").getNameOccurrence()).isNotNull();
+    assertThat(nameReference(ast, "Exit").getNameOccurrence()).isNotNull();
+  }
+
+  @Test
+  void testQualifiedNameReferenceOccurrencesAreAttached() {
+    DelphiAst ast =
+        associate(
+            "unit Test;",
+            "interface",
+            "type",
+            "  TFoo = class(TObject)",
+            "    Bar: Integer;",
+            "  end;",
+            "var",
+            "  GFoo: TFoo;",
+            "implementation",
+            "procedure Baz;",
+            "begin",
+            "  GFoo.Bar := 0;",
+            "end;",
+            "end.");
+
+    assertThat(nameReference(ast, "GFoo").getNameOccurrence()).isNotNull();
+    assertThat(nameReference(ast, "Bar").getNameOccurrence()).isNotNull();
+  }
+
+  @Test
+  void testUnitNameReferenceOccurrencesAreAttached() {
+    DelphiAst ast =
+        associate(
+            "unit Test;",
+            "interface",
+            "uses System.SysUtils;",
+            "implementation",
+            "procedure Foo;",
+            "begin",
+            "  System.SysUtils.Bar;",
+            "end;",
+            "end.");
+
+    assertThat(nameReference(ast, "System").getNameOccurrence()).isNotNull();
+  }
+
+  @Test
+  void testRoutineDeclarationNamesAreAttached() {
+    DelphiAst ast =
+        associate(
+            "unit Test;",
+            "interface",
+            "type",
+            "  TFoo = class(TObject)",
+            "  public",
+            "    function GetBar: Integer;",
+            "  private",
+            "    property Bar: Integer read GetBar;",
+            "  end;",
+            "implementation",
+            "end.");
+
+    RoutineNameNode nameNode = descendant(ast, RoutineNameNode.class);
+
+    assertThat(nameNode.getUsages()).isNotEmpty();
+    assertThat(nameNode.getRoutineNameDeclaration()).isNotNull();
+    assertThat(nameNode.getNameDeclarationNode().getNameDeclaration()).isNotNull();
+  }
+
+  @Test
+  void testRoutineImplementationNamesAreAttached() {
+    DelphiAst ast =
+        associate(
+            "unit Test;", //
+            "interface",
+            "implementation",
+            "procedure Foo;",
+            "begin",
+            "end;",
+            "end.");
+
+    assertThat(descendant(ast, RoutineNameNode.class).getRoutineNameDeclaration()).isNotNull();
+  }
+
+  @Test
+  void testTypeParameterReferencesAreAttached() {
+    DelphiAst ast =
+        associate(
+            "unit Test;",
+            "interface",
+            "type",
+            "  TFoo<T> = class(TObject)",
+            "    procedure Bar;",
+            "  end;",
+            "procedure Baz<T>(Arg: T);",
+            "implementation",
+            "procedure TFoo<T>.Bar;",
+            "begin",
+            "end;",
+            "procedure Baz<T>(Arg: T);",
+            "begin",
+            "end;",
+            "end.");
+
+    List<NameReferenceNode> typeParameterReferences =
+        ast.findDescendantsOfType(RoutineImplementationNode.class).stream()
+            .map(RoutineImplementationNode::getRoutineHeading)
+            .flatMap(heading -> heading.findDescendantsOfType(NameReferenceNode.class).stream())
+            .filter(reference -> reference.getImage().equals("T"))
+            .collect(Collectors.toList());
+
+    assertThat(typeParameterReferences)
+        .hasSize(3)
+        .allSatisfy(reference -> assertThat(reference.getNameOccurrence()).isNotNull());
+  }
+
+  @Test
+  void testArrayAccessorImplicitOccurrencesAreAttached() {
+    DelphiAst ast =
+        associate(
+            "unit Test;",
+            "interface",
+            "type",
+            "  TFoo = class(TObject)",
+            "    function GetBar(Index: Integer): Integer;",
+            "    property Bar[Index: Integer]: Integer read GetBar; default;",
+            "  end;",
+            "var",
+            "  GFoo: TFoo;",
+            "implementation",
+            "procedure Baz;",
+            "begin",
+            "  GFoo[0] := 0;",
+            "end;",
+            "end.");
+
+    assertThat(descendant(ast, ArrayAccessorNode.class).getImplicitNameOccurrence()).isNotNull();
+  }
+
+  @Test
+  void testEnumeratorOccurrencesAreAttached() {
+    DelphiAst ast =
+        associate(
+            "unit Test;",
+            "interface",
+            "type",
+            "  TEnumerator = class(TObject)",
+            "    FCurrent: Integer;",
+            "    function MoveNext: Boolean;",
+            "    property Current: Integer read FCurrent;",
+            "  end;",
+            "  TFoo = class(TObject)",
+            "    function GetEnumerator: TEnumerator;",
+            "  end;",
+            "var",
+            "  GFoo: TFoo;",
+            "implementation",
+            "procedure Bar;",
+            "var",
+            "  Item: Integer;",
+            "begin",
+            "  for Item in GFoo do;",
+            "end;",
+            "end.");
+
+    assertThat(descendant(ast, ForInStatementNode.class).getEnumeratorOccurrence()).isNotNull();
+  }
+
+  private static NameReferenceNode nameReference(DelphiAst ast, String image) {
+    return ast.findDescendantsOfType(NameReferenceNode.class).stream()
+        .filter(reference -> reference.getIdentifier().getImage().equalsIgnoreCase(image))
+        .findFirst()
+        .orElseThrow();
+  }
+
+  private static <T extends DelphiNode> T descendant(DelphiAst ast, Class<T> type) {
+    return ast.findDescendantsOfType(type).stream().findFirst().orElseThrow();
+  }
+
+  private DelphiAst associate(String... lines) {
+    try {
+      Path sourceFile = tempDir.resolve("Test.pas");
+      Files.writeString(sourceFile, StringUtils.join(lines, '\n'), StandardCharsets.UTF_8);
+
+      DelphiFile file = DelphiFile.from(sourceFile.toFile(), DelphiFileUtils.mockConfig());
+
+      SymbolTable symbolTable =
+          SymbolTable.builder()
+              .preprocessorFactory(
+                  new DelphiPreprocessorFactory(
+                      DelphiProperties.COMPILER_VERSION_DEFAULT, Platform.WINDOWS))
+              .typeFactory(
+                  new TypeFactoryImpl(
+                      DelphiProperties.COMPILER_TOOLCHAIN_DEFAULT,
+                      DelphiProperties.COMPILER_VERSION_DEFAULT))
+              .standardLibraryPath(createStandardLibrary())
+              .sourceFiles(List.of(sourceFile))
+              .build();
+
+      new SymbolAssociationVisitor()
+          .visit(file.getAst(), new SymbolAssociationVisitor.Data(symbolTable));
+
+      return file.getAst();
+    } catch (IOException e) {
+      throw new UncheckedIOException(e);
+    }
+  }
+
+  private Path createStandardLibrary() throws IOException {
+    Path bds = tempDir.resolve("bds");
+    Path standardLibraryPath = Files.createDirectories(bds.resolve("source"));
+
+    Files.writeString(
+        standardLibraryPath.resolve("SysInit.pas"),
+        "unit SysInit;\ninterface\nimplementation\nend.");
+
+    Files.writeString(
+        standardLibraryPath.resolve("System.pas"),
+        "unit System;\n"
+            + "interface\n"
+            + "type\n"
+            + "  TObject = class\n"
+            + "    constructor Create;\n"
+            + "  end;\n"
+            + "  IInterface = interface\n"
+            + "  end;\n"
+            + "  TClassHelperBase = class\n"
+            + "  end;\n"
+            + "  TVarRec = record\n"
+            + "  end;\n"
+            + "implementation\n"
+            + "end.");
+
+    Files.writeString(
+        standardLibraryPath.resolve("System.SysUtils.pas"),
+        "unit System.SysUtils;\n"
+            + "interface\n"
+            + "procedure Bar;\n"
+            + "implementation\n"
+            + "end.");
+
+    return bds;
+  }
+}


### PR DESCRIPTION
This PR fixes an obscure bug related to the 2-pass semantic analysis we're doing where we build the symbol table in one pass, throw away ASTs as we go, and re-parse source files (reassociating symbol information) in a second pass.

For symbol reassociation purposes, we were registering declarations, occurences, and scopes against token indices as if they were unique at the node level. They're not.

This led to some tricky situations where scopes in particular would be incorrectly attributed to the wrong nodes. This bug was masked very well because most name resolution occurs during symbol table construction.

The problem came about after symbol reassociation. In the analysis phase, on-demand name resolution occurs during expression type resolution. Any analysis rule calling `ExpressionNode::getType` was potentially impacted.